### PR TITLE
Add read_files tool (glob-based context attach)

### DIFF
--- a/src/electron/agent/tools/__tests__/read-files.test.ts
+++ b/src/electron/agent/tools/__tests__/read-files.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { Workspace } from '../../../../shared/types';
+import { FileTools } from '../file-tools';
+import { GlobTools } from '../glob-tools';
+import { readFilesByPatterns } from '../read-files';
+
+function writeFile(p: string, content: string): void {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, 'utf-8');
+}
+
+describe('readFilesByPatterns', () => {
+  let tmpDir: string;
+  let workspace: Workspace;
+  let fileTools: FileTools;
+  let globTools: GlobTools;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cowork-read-files-'));
+    workspace = {
+      id: 'w1',
+      name: 'Test',
+      path: tmpDir,
+      createdAt: Date.now(),
+      permissions: {
+        read: true,
+        write: true,
+        delete: true,
+        network: false,
+        shell: false,
+      },
+      isTemp: true,
+    };
+
+    const daemon = {
+      logEvent: vi.fn(),
+      requestApproval: vi.fn(),
+    } as any;
+
+    fileTools = new FileTools(workspace, daemon, 'task-1');
+    globTools = new GlobTools(workspace, daemon, 'task-1');
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('reads matched files and returns their content', async () => {
+    writeFile(path.join(tmpDir, 'src', 'a.ts'), 'export const a = 1;\n');
+    writeFile(path.join(tmpDir, 'src', 'b.ts'), 'export const b = 2;\n');
+
+    const res = await readFilesByPatterns(
+      { patterns: ['src/**/*.ts'] },
+      { globTools, fileTools }
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.totalMatched).toBe(2);
+    expect(res.files.map((f) => f.path)).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(res.files[0].content).toContain('export const a');
+    expect(res.files[1].content).toContain('export const b');
+  });
+
+  it('supports exclusion patterns with leading !', async () => {
+    writeFile(path.join(tmpDir, 'src', 'a.ts'), 'export const a = 1;\n');
+    writeFile(path.join(tmpDir, 'src', 'b.ts'), 'export const b = 2;\n');
+
+    const res = await readFilesByPatterns(
+      { patterns: ['src/**/*.ts', '!src/b.ts'] },
+      { globTools, fileTools }
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.totalMatched).toBe(1);
+    expect(res.files.map((f) => f.path)).toEqual(['src/a.ts']);
+  });
+
+  it('truncates by maxFiles', async () => {
+    writeFile(path.join(tmpDir, 'src', 'a.ts'), 'export const a = 1;\n');
+    writeFile(path.join(tmpDir, 'src', 'b.ts'), 'export const b = 2;\n');
+
+    const res = await readFilesByPatterns(
+      { patterns: ['src/**/*.ts'], maxFiles: 1 },
+      { globTools, fileTools }
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.files.length).toBe(1);
+    expect(res.truncated).toBe(true);
+  });
+
+  it('truncates by maxTotalChars', async () => {
+    const big = 'x'.repeat(1500);
+    writeFile(path.join(tmpDir, 'src', 'big.txt'), big);
+    writeFile(path.join(tmpDir, 'src', 'small.txt'), 'small\n');
+
+    const res = await readFilesByPatterns(
+      { patterns: ['src/*.txt'], maxTotalChars: 1000, maxFiles: 10 },
+      { globTools, fileTools }
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.truncated).toBe(true);
+    expect(res.files.length).toBeGreaterThan(0);
+    expect(res.files[0].content.length).toBeLessThanOrEqual(1000);
+  });
+});
+

--- a/src/electron/agent/tools/builtin-settings.ts
+++ b/src/electron/agent/tools/builtin-settings.ts
@@ -162,6 +162,7 @@ const TOOL_CATEGORIES: Record<string, keyof BuiltinToolsSettings['categories']> 
   run_applescript: 'system',
   // File tools
   read_file: 'file',
+  read_files: 'file',
   write_file: 'file',
   copy_file: 'file',
   list_directory: 'file',

--- a/src/electron/agent/tools/read-files.ts
+++ b/src/electron/agent/tools/read-files.ts
@@ -1,0 +1,187 @@
+import { FileTools } from './file-tools';
+import { GlobTools } from './glob-tools';
+
+export type ReadFilesInput = {
+  patterns: string[];
+  path?: string;
+  maxFiles?: number;
+  maxResults?: number;
+  maxTotalChars?: number;
+};
+
+export type ReadFilesResult = {
+  success: boolean;
+  basePath: string;
+  includePatterns: string[];
+  excludePatterns: string[];
+  totalMatched: number;
+  included: number;
+  skipped: number;
+  truncated: boolean;
+  files: Array<{
+    path: string;
+    size: number;
+    truncated?: boolean;
+    format?: string;
+    content: string;
+  }>;
+  skippedFiles: Array<{
+    path: string;
+    reason: string;
+  }>;
+  warnings: string[];
+};
+
+function clampInt(value: unknown, fallback: number, min: number, max: number): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(n)));
+}
+
+function splitPatterns(patterns: string[]): { include: string[]; exclude: string[] } {
+  const include: string[] = [];
+  const exclude: string[] = [];
+
+  for (const raw of patterns) {
+    const p = typeof raw === 'string' ? raw.trim() : '';
+    if (!p) continue;
+    if (p.startsWith('!') && p.length > 1) {
+      exclude.push(p.slice(1).trim());
+    } else {
+      include.push(p);
+    }
+  }
+
+  return { include, exclude };
+}
+
+export async function readFilesByPatterns(
+  input: ReadFilesInput,
+  deps: { globTools: GlobTools; fileTools: FileTools }
+): Promise<ReadFilesResult> {
+  if (!input || !Array.isArray(input.patterns) || input.patterns.length === 0) {
+    throw new Error('read_files requires a non-empty patterns array');
+  }
+
+  const basePath = typeof input.path === 'string' && input.path.trim().length > 0 ? input.path.trim() : '.';
+  const maxFiles = clampInt(input.maxFiles, 12, 1, 100);
+  const maxResults = clampInt(input.maxResults, 500, 1, 5000);
+  const maxTotalChars = clampInt(input.maxTotalChars, 30000, 1000, 200000);
+
+  const { include, exclude } = splitPatterns(input.patterns);
+  if (include.length === 0) {
+    throw new Error('read_files requires at least one include pattern');
+  }
+
+  const warnings: string[] = [];
+  const matched = new Map<string, { size: number }>();
+
+  let anyPatternTruncated = false;
+  for (const pattern of include) {
+    const res = await deps.globTools.glob({ pattern, path: basePath, maxResults });
+    if (!res.success) {
+      warnings.push(`Glob failed for pattern "${pattern}": ${res.error || 'unknown error'}`);
+      continue;
+    }
+    if (res.truncated) {
+      anyPatternTruncated = true;
+      warnings.push(`Glob results truncated for pattern "${pattern}" (maxResults=${maxResults})`);
+    }
+    for (const m of res.matches) {
+      if (!matched.has(m.path)) {
+        matched.set(m.path, { size: m.size });
+      }
+    }
+  }
+
+  for (const pattern of exclude) {
+    const res = await deps.globTools.glob({ pattern, path: basePath, maxResults });
+    if (!res.success) {
+      warnings.push(`Exclude glob failed for pattern "!${pattern}": ${res.error || 'unknown error'}`);
+      continue;
+    }
+    if (res.truncated) {
+      anyPatternTruncated = true;
+      warnings.push(`Exclude glob results truncated for pattern "!${pattern}" (maxResults=${maxResults})`);
+    }
+    for (const m of res.matches) {
+      matched.delete(m.path);
+    }
+  }
+
+  const allMatchedPaths = Array.from(matched.keys()).sort();
+  const selectedPaths = allMatchedPaths.slice(0, maxFiles);
+
+  const skippedFiles: ReadFilesResult['skippedFiles'] = [];
+  const files: ReadFilesResult['files'] = [];
+
+  let truncated = false;
+  if (allMatchedPaths.length > maxFiles) {
+    truncated = true;
+    skippedFiles.push({
+      path: '(additional files)',
+      reason: `Matched ${allMatchedPaths.length} files; limited to maxFiles=${maxFiles}`,
+    });
+  }
+
+  let totalChars = 0;
+  for (const filePath of selectedPaths) {
+    try {
+      const read = await deps.fileTools.readFile(filePath);
+
+      let content = read.content;
+      const remaining = maxTotalChars - totalChars;
+      if (content.length > remaining) {
+        truncated = true;
+        if (remaining > 200) {
+          content = content.slice(0, Math.max(0, remaining - 120)) + '\n\n[... truncated by read_files ...]';
+        } else {
+          skippedFiles.push({
+            path: filePath,
+            reason: `Skipped: maxTotalChars=${maxTotalChars} reached`,
+          });
+          break;
+        }
+      }
+
+      totalChars += content.length;
+      files.push({
+        path: filePath,
+        size: read.size,
+        truncated: read.truncated,
+        format: read.format,
+        content,
+      });
+
+      if (totalChars >= maxTotalChars) {
+        truncated = true;
+        break;
+      }
+    } catch (error: any) {
+      skippedFiles.push({
+        path: filePath,
+        reason: error?.message ? String(error.message) : 'Failed to read file',
+      });
+    }
+  }
+
+  if (anyPatternTruncated && !truncated) {
+    // Truncation can happen even if we didn't hit our own caps. Surface it via "truncated" to be explicit.
+    truncated = true;
+  }
+
+  return {
+    success: true,
+    basePath,
+    includePatterns: include,
+    excludePatterns: exclude,
+    totalMatched: allMatchedPaths.length,
+    included: files.length,
+    skipped: skippedFiles.length,
+    truncated,
+    files,
+    skippedFiles,
+    warnings,
+  };
+}
+

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -192,6 +192,7 @@ export const TOOL_GROUPS = {
   // Read-only operations - lowest risk
   'group:read': [
     'read_file',
+    'read_files',
     'list_directory',
     'search_files',
     'system_info',


### PR DESCRIPTION
Adds a new file tool, read_files, to read multiple files matched by glob patterns in a single call (supports exclusion patterns with leading "!").

Also fixes GlobTools globstar handling so patterns like **/*.ts and src/**/*.ts match expected paths.

Tests:
- npm test -- --run src/electron/agent/tools/__tests__/read-files.test.ts
- npm run type-check