### PR TITLE
Child Task Control Tools

### DIFF
--- a/src/electron/agent/daemon.ts
+++ b/src/electron/agent/daemon.ts
@@ -602,7 +602,7 @@ export class AgentDaemon extends EventEmitter {
   /**
    * Resume a paused task
    */
-  async resumeTask(taskId: string): Promise<void> {
+  async resumeTask(taskId: string): Promise<boolean> {
     const cached = this.activeTasks.get(taskId);
     if (cached) {
       cached.lastAccessed = Date.now();
@@ -610,7 +610,9 @@ export class AgentDaemon extends EventEmitter {
       this.updateTaskStatus(taskId, 'executing');
       this.logEvent(taskId, 'task_resumed', { message: 'Task resumed' });
       await cached.executor.resume();
+      return true;
     }
+    return false;
   }
 
   /**


### PR DESCRIPTION
Adds safe, descendant-only control tools for sub-agents.

- New meta tools: send_agent_message, capture_agent_events, cancel_agent, pause_agent, resume_agent
- wait_for_agent/get_agent_status now reject non-descendant task IDs
- capture_agent_events returns compact summaries to avoid large tool payloads
- Adds unit tests for descendant enforcement