### PR TITLE
Add best-fit workflow lanes for Support Ops, IT Ops, and Sales Ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,18 @@ Unified plugin platform with 17 bundled role-specific packs (Engineering, DevOps
 
 Access from **Settings** > **Customize**. [Learn more](docs/plugin-packs.md)
 
+### Best-Fit Workflows
+
+CoWork OS ships purpose-built packs and Tier-1 connectors for three operational lanes where governed AI delivery has the clearest ROI:
+
+| Lane | Pack | Connectors |
+|------|------|------------|
+| **Support Ops** | Customer Support Pack | Zendesk, ServiceNow |
+| **IT Ops** | DevOps Pack | ServiceNow, Jira, Linear |
+| **Sales Ops** | Sales CRM Pack | HubSpot, Salesforce, Outreach |
+
+These are the workflows where approval gates, local data control, and measurable outcome delivery pay off most — and where CoWork OS is a vendor-swap-friendly alternative to point solutions or BPO tooling. [Learn more](docs/best-fit-workflows.md)
+
 ### Extensibility
 
 - **139 built-in skills** across developer, productivity, communication, documents, game development, mobile development, financial analysis, infrastructure-as-code, and more
@@ -359,6 +371,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full history of completed features.
 | [Context Compaction](docs/context-compaction.md) | Proactive session compaction with structured summaries |
 | [Mission Control](docs/mission-control.md) | Agent orchestration dashboard |
 | [Plugin Packs](docs/plugin-packs.md) | Plugin platform, Customize panel, and Plugin Store |
+| [Best-Fit Workflows](docs/best-fit-workflows.md) | Support Ops, IT Ops, and Sales Ops — where CoWork OS delivers the strongest ROI |
 | [Admin Policies](docs/admin-policies.md) | Enterprise admin policies and organization pack management |
 | [Digital Twins](docs/digital-twins.md) | Role-based AI twin personas and cognitive offload |
 | [Digital Twins Guide](docs/digital-twin-personas-guide.md) | Comprehensive guide with scenarios and expanded job areas |

--- a/docs/best-fit-workflows.md
+++ b/docs/best-fit-workflows.md
@@ -1,0 +1,99 @@
+# Best-Fit Operational Workflows
+
+> This page explains where CoWork OS delivers the strongest return for teams running governed, intelligence-heavy operational lanes. It is a secondary narrative layer — it does not reframe the category. CoWork OS remains a **security-hardened, local-first AI operating system**.
+
+---
+
+## Why Operational Workflows Are a Strong Fit
+
+CoWork OS is built for production use: approval gates, guardrail budgets, local-first data ownership, and a runtime that governance teams can audit. Those same properties make it well-suited for outsourced or contractor-delivered operational lanes where the buyer cares about:
+
+- **Outcome consistency** — the same quality of triage, escalation, or outreach regardless of who runs the shift.
+- **Vendor-swap flexibility** — workflows defined in CoWork OS are not locked to a specific BPO or staffing provider.
+- **Managed oversight** — approval workflows, policy enforcement, and usage insights are on by default, not bolted on later.
+- **Local data control** — BYOK and no-telemetry defaults satisfy typical enterprise data-handling requirements without custom contracts.
+
+These are the same reasons teams pick CoWork OS for daily governed operations. The outsourced-workflow fit is additive, not a repositioning.
+
+---
+
+## Three Best-Fit Workflow Lanes
+
+CoWork OS ships purpose-built packs for three operational lanes. Each lane maps to an existing bundled pack and a set of Tier-1 connectors.
+
+### Support Ops — Customer Support Pack
+
+**Who already buys this outcome:** BPOs, CX outsourcers, managed-services providers, in-house support teams that operate like a managed lane.
+
+**What CoWork OS contributes:**
+
+- Ticket triage with priority, category, and sentiment analysis
+- Empathetic, tone-matched response drafting
+- Escalation summaries engineering can act on immediately
+- One-step KB article generation from resolved cases
+- Zendesk connector for live ticket context
+
+**Why this is a strong fit:** Support volume is predictable, quality criteria are measurable, and the workflow is well-defined — exactly the conditions where governed AI delivery outperforms ad-hoc tooling.
+
+**Pack:** `customer-support-pack` · **Connectors:** Zendesk, ServiceNow
+
+---
+
+### IT Ops — DevOps Pack
+
+**Who already buys this outcome:** Managed infrastructure providers, IT outsourcers, SRE-as-a-service teams, and internal platform teams operating under SLAs.
+
+**What CoWork OS contributes:**
+
+- Incident response plans with triage steps, comms templates, and post-mortem outlines
+- Deployment checklists with pre/post-deploy verification and rollback procedures
+- Terraform and Kubernetes manifest generation from plain-language descriptions
+- Cloud migration assessments using the 6Rs framework
+- Blameless post-mortems with structured action items
+
+**Why this is a strong fit:** Incident and release workflows have clear triggers, measurable completion, and high cost of error — making approval gates and audit trails valuable, not optional.
+
+**Pack:** `devops-pack` · **Connectors:** ServiceNow, Jira, Linear
+
+---
+
+### Sales Ops — Sales CRM Pack
+
+**Who already buys this outcome:** Outsourced SDR/BDR providers, sales development agencies, in-house sales teams running a managed outbound lane.
+
+**What CoWork OS contributes:**
+
+- Prospect research briefings with company context, pain points, and talking points
+- Personalized follow-up email drafts referencing specific call details
+- Pipeline health reviews with at-risk deal flags and recommended actions
+- Objection-handling scripts tailored to the product and prospect
+
+**Why this is a strong fit:** Outbound sales workflows are high-volume and repetitive but require personalization at scale — the balance where governed AI delivery performs best.
+
+**Pack:** `sales-crm-pack` · **Connectors:** HubSpot, Salesforce, Outreach
+
+---
+
+## Copy Rules for This Narrative
+
+Use these phrases:
+
+- "governed outcome delivery"
+- "managed operational lane"
+- "vendor-swap-friendly workflow"
+- "best-fit workflow"
+
+Avoid:
+
+- "replace employees" or "reorg"
+- "AI firm replacing teams"
+- Framing Digital Twins as labor replacement (prefer "offload", "governance", "orchestration")
+
+---
+
+## Related Pages
+
+- [Plugin Packs & Customize](plugin-packs.md) — how packs work and how to enable them
+- [GTM Strategy](gtm-strategy.md) — primary positioning and best-initial-wedge guidance
+- [Enterprise Connectors](enterprise-connectors.md) — Tier-1 connector setup
+- [Use Case Showcase](showcase.md) — example workflows across all lanes

--- a/docs/gtm-strategy.md
+++ b/docs/gtm-strategy.md
@@ -82,6 +82,22 @@ Use these phrases naturally in docs and landing sections:
 
 Keep SEO copy factual and fit-based. Avoid negative or inflammatory wording.
 
+## Best Initial Wedges
+
+> This section describes GTM entry points within the existing category — not a repositioning. CoWork OS remains a security-hardened, local-first AI operating system.
+
+The three operational lanes where CoWork OS has the clearest initial ROI are governed, intelligence-heavy workflows that benefit most from approval gates, local data control, and measurable outcome delivery:
+
+| Lane | Pack | Primary Connectors | Why It Wins Early |
+|------|------|--------------------|-------------------|
+| **Support Ops** | Customer Support Pack | Zendesk, ServiceNow | High-volume, well-defined quality criteria; completion rate and response time are measurable on day one |
+| **IT Ops** | DevOps Pack | ServiceNow, Jira, Linear | Incident and release workflows have clear triggers, audit requirements, and high cost of error |
+| **Sales Ops** | Sales CRM Pack | HubSpot, Salesforce, Outreach | Outbound workflows are repetitive but require personalization — the balance where governed AI delivery performs best |
+
+These are best-fit entry points, not exclusions. CoWork OS works across many workflows; these three have the most predictable buyer, measurable outcome, and vendor-swap-friendly structure.
+
+For the full workflow narrative, see [Best-Fit Operational Workflows](best-fit-workflows.md).
+
 ## GTM Assets in This Repo
 
 - [OpenClaw Alternative Guide](openclaw-comparison.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,4 +36,6 @@ features:
     details: Salesforce, Jira, HubSpot, Zendesk, ServiceNow, Linear, Asana, Okta, and Resend MCP connectors.
   - title: Security First
     details: Local-first architecture, sandboxed execution, guardrails, approval workflows, encrypted storage, and 3200+ tests.
+  - title: Best-Fit Operational Workflows
+    details: Purpose-built packs for Support Ops, IT Ops, and Sales Ops — governed outcome delivery for the workflows where AI assistance has the clearest ROI. See the Best-Fit Workflows guide.
 ---

--- a/docs/plugin-packs.md
+++ b/docs/plugin-packs.md
@@ -20,6 +20,8 @@ A JSON manifest (`cowork.plugin.json`) that bundles related capabilities:
 | **Connectors** | Declarative tool definitions (HTTP, shell, script) for external services |
 | **Try Asking** | Natural language prompt suggestions for discoverability |
 | **Digital Twin Link** | Optional `personaTemplateId` connecting the pack to a proactive persona |
+| **Best-Fit Workflows** | Optional `bestFitWorkflows` array tagging the pack to one or more operational lanes (`support_ops`, `it_ops`, `sales_ops`) |
+| **Outcome Examples** | Optional `outcomeExamples` array of short strings describing what users achieve with the pack |
 
 ### Pack Scopes
 
@@ -107,6 +109,8 @@ When a pack is selected, the right panel shows:
 | **Commands** | Card grid of slash commands derived from skills. Each card shows the `/command-name` and description. |
 | **Skills** | List of all skills in the pack with icon, name, description, and **per-skill toggle switch**. Individual skills can be enabled or disabled independently without toggling the entire pack. |
 | **Agents** | Agent roles defined by the pack, plus a Digital Twin entry if `personaTemplateId` is set. |
+
+When `bestFitWorkflows` is set, the pack header shows colored **Best for** lane badges (Support Ops, IT Ops, Sales Ops). When `outcomeExamples` is set, a short bulleted list of outcomes appears below the badges.
 
 **Try Asking**
 
@@ -964,6 +968,11 @@ window.electronAPI.scaffoldPluginPack({
   "category": "Engineering",
   "personaTemplateId": "software-engineer",
   "recommendedConnectors": ["hubspot-mcp"],
+  "bestFitWorkflows": ["sales_ops"],
+  "outcomeExamples": [
+    "Draft personalized follow-up emails for 20 prospects in one session",
+    "Review pipeline health and flag at-risk deals automatically"
+  ],
   "tryAsking": [
     "Natural language prompt 1",
     "Natural language prompt 2"

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -138,6 +138,11 @@ packages that conflict with our MIT license.
 
 ## DevOps & Infrastructure
 
+> **Best-fit workflow: IT Ops**
+> **Why this is a strong fit:** Incident and release workflows have clear triggers, defined completion criteria, and high cost of error — conditions where approval gates, local audit trails, and governed execution outperform ad-hoc tooling.
+> **Who already buys this outcome:** Managed infrastructure providers, SRE-as-a-service teams, IT outsourcers operating under SLAs.
+> **What CoWork OS contributes:** Incident response with comms templates, deployment checklists with rollback procedures, IaC generation from plain language, and blameless post-mortems with structured action items. Enable the DevOps Pack and connect ServiceNow or Jira.
+
 ### Kubernetes Cluster Operations
 
 Manage Kubernetes clusters, generate manifests, debug pods, and configure networking — all from natural language.
@@ -424,6 +429,11 @@ optimization plan to hit 30fps stable.
 
 ### CRM & Sales Automation
 
+> **Best-fit workflow: Sales Ops**
+> **Why this is a strong fit:** Outbound sales workflows are high-volume and repetitive but require personalization at scale — the balance where governed AI delivery performs best.
+> **Who already buys this outcome:** Outsourced SDR/BDR providers, sales development agencies, in-house sales teams running a managed outbound lane.
+> **What CoWork OS contributes:** Prospect research briefings, personalized follow-up drafts, pipeline health reviews, and objection-handling scripts. Enable the Sales CRM Pack and connect HubSpot, Salesforce, or Outreach.
+
 Connect to Salesforce and HubSpot to automate pipeline management, prospect research, and follow-up sequences.
 
 **What it handles:**
@@ -497,6 +507,11 @@ Set up a Discord server structure for our open-source project:
 ---
 
 ### Customer Support Workflows
+
+> **Best-fit workflow: Support Ops**
+> **Why this is a strong fit:** Support volume is predictable, quality criteria are measurable, and the workflow is well-defined — exactly the conditions where governed AI delivery outperforms ad-hoc tooling.
+> **Who already buys this outcome:** BPOs, CX outsourcers, managed-services providers, in-house support teams that operate like a managed lane.
+> **What CoWork OS contributes:** Ticket triage with priority and sentiment analysis, tone-matched response drafting, one-step KB article generation, and escalation summaries engineering can act on immediately. Enable the Customer Support Pack and connect Zendesk or ServiceNow.
 
 Connect to Zendesk and ServiceNow to automate ticket triage, response drafting, and escalation management.
 

--- a/resources/plugin-packs/customer-support/cowork.plugin.json
+++ b/resources/plugin-packs/customer-support/cowork.plugin.json
@@ -9,6 +9,13 @@
   "icon": "🎧",
   "category": "Operations",
   "recommendedConnectors": ["zendesk-mcp"],
+  "bestFitWorkflows": ["support_ops"],
+  "outcomeExamples": [
+    "Triage and draft responses to 40+ tickets per day without queue buildup",
+    "Reduce average first-response time with templated, tone-matched replies",
+    "Turn resolved cases into knowledge base articles in one step",
+    "Produce structured escalation summaries that engineering can act on immediately"
+  ],
   "tryAsking": [
     "Triage this support ticket and suggest a response",
     "Draft a response for a frustrated customer about a billing issue",

--- a/resources/plugin-packs/devops/cowork.plugin.json
+++ b/resources/plugin-packs/devops/cowork.plugin.json
@@ -8,6 +8,13 @@
   "keywords": ["devops", "deployment", "monitoring", "incident-response", "infrastructure", "terraform", "kubernetes", "k8s", "docker", "migration", "iac"],
   "icon": "⚙️",
   "category": "Engineering",
+  "bestFitWorkflows": ["it_ops"],
+  "outcomeExamples": [
+    "Produce incident response plans and post-mortems in minutes, not hours",
+    "Generate deployment checklists and rollback procedures for every release",
+    "Draft Terraform modules and Kubernetes manifests from plain-language descriptions",
+    "Run cloud migration assessments across workloads with effort and risk breakdowns"
+  ],
   "personaTemplateId": "devops-sre-engineer",
   "tryAsking": [
     "Create an incident response plan for this production issue",

--- a/resources/plugin-packs/sales-crm/cowork.plugin.json
+++ b/resources/plugin-packs/sales-crm/cowork.plugin.json
@@ -8,7 +8,14 @@
   "keywords": ["sales", "crm", "prospecting", "pipeline"],
   "icon": "💼",
   "category": "Sales",
-  "recommendedConnectors": ["hubspot-mcp"],
+  "recommendedConnectors": ["hubspot-mcp", "salesforce-mcp"],
+  "bestFitWorkflows": ["sales_ops"],
+  "outcomeExamples": [
+    "Research prospects and compile outreach briefings with company context and pain points",
+    "Draft personalized follow-up emails referencing specific conversation details",
+    "Review pipeline health and flag at-risk deals with recommended actions",
+    "Prepare objection-handling scripts tailored to the product and prospect"
+  ],
   "tryAsking": [
     "Research this prospect and compile a briefing for outreach",
     "Draft a follow-up email after yesterday's demo call",

--- a/src/electron/agent/tools/registry.ts
+++ b/src/electron/agent/tools/registry.ts
@@ -1528,7 +1528,7 @@ Channel Message Log (Local Gateway):
 		- request_user_input: Ask the user a structured multiple-choice question set (propose mode only) and wait for selection.
 		- task_history: Query recent task history/messages (use for "what did we talk about yesterday?")
 		- switch_workspace: Switch to a different workspace/working directory. Use when you need to work in a different folder.
-		- integration_setup: List/inspect/configure Tier-1 integrations from chat (resend/slack/gmail/google-calendar/google-drive/jira/linear/hubspot), including plan_hash stale-plan safety and optional OAuth setup.
+		- integration_setup: List/inspect/configure Tier-1 integrations from chat (resend/slack/gmail/google-calendar/google-drive/google-workspace/jira/linear/hubspot/salesforce/zendesk/servicenow/outreach/docusign), including plan_hash stale-plan safety and optional OAuth setup.
 		- set_personality: Change the assistant's communication style (professional, friendly, concise, creative, technical, casual).
 	- set_persona: Change the assistant's character persona (jarvis, friday, hal, computer, alfred, intern, sensei, pirate, noir, companion, or none).
 	- set_response_style: Adjust response preferences (emoji_usage, response_length, code_comments, explanation_depth).
@@ -7280,7 +7280,7 @@ ${skillDescriptions}`;
         name: "integration_setup",
         description:
           "Inspect, list, or configure integrations directly from chat. " +
-          "Supports Tier-1 providers: resend, slack, gmail, google-calendar, google-drive, jira, linear, hubspot. " +
+          "Supports Tier-1 providers: resend, slack, gmail, google-calendar, google-drive, google-workspace, jira, linear, hubspot, salesforce, zendesk, servicenow, outreach, docusign. " +
           "Use inspect to get plan_hash + missing inputs, and configure with expected_plan_hash for safe apply.",
         input_schema: {
           type: "object",
@@ -7299,9 +7299,15 @@ ${skillDescriptions}`;
                 "gmail",
                 "google-calendar",
                 "google-drive",
+                "google-workspace",
                 "jira",
                 "linear",
                 "hubspot",
+                "salesforce",
+                "zendesk",
+                "servicenow",
+                "outreach",
+                "docusign",
               ],
               description: "Integration provider to inspect/configure",
             },

--- a/src/electron/extensions/types.ts
+++ b/src/electron/extensions/types.ts
@@ -96,6 +96,12 @@ export interface PluginManifest {
 
   /** Whether this is an organization-distributed pack (vs personal) */
   scope?: "personal" | "organization";
+
+  /** Best-fit operational workflow lanes for this pack (support_ops, it_ops, sales_ops) */
+  bestFitWorkflows?: ("support_ops" | "it_ops" | "sales_ops")[];
+
+  /** Short outcome examples that describe what users achieve with this pack */
+  outcomeExamples?: string[];
 }
 
 /**

--- a/src/electron/ipc/plugin-pack-handlers.ts
+++ b/src/electron/ipc/plugin-pack-handlers.ts
@@ -20,6 +20,8 @@ export interface PluginPackData {
   personaTemplateId?: string;
   recommendedConnectors?: string[];
   tryAsking?: string[];
+  bestFitWorkflows?: ("support_ops" | "it_ops" | "sales_ops")[];
+  outcomeExamples?: string[];
   skills: { id: string; name: string; description: string; icon?: string; enabled?: boolean }[];
   slashCommands: { name: string; description: string; skillId: string }[];
   agentRoles: {
@@ -128,6 +130,8 @@ export function setupPluginPackHandlers(): void {
         personaTemplateId: m.personaTemplateId,
         recommendedConnectors: m.recommendedConnectors,
         tryAsking: m.tryAsking,
+        bestFitWorkflows: m.bestFitWorkflows,
+        outcomeExamples: m.outcomeExamples,
         skills: (m.skills || []).map((s) => ({
           id: s.id,
           name: s.name,

--- a/src/electron/mcp/connectors/capabilities.ts
+++ b/src/electron/mcp/connectors/capabilities.ts
@@ -9,6 +9,8 @@ export type ConnectorCapabilityId =
   | "hubspot"
   | "zendesk"
   | "servicenow"
+  | "outreach"
+  | "docusign"
   | "linear"
   | "asana"
   | "okta"
@@ -28,7 +30,12 @@ export type Tier1IntegrationProvider =
   | "google-workspace"
   | "jira"
   | "linear"
-  | "hubspot";
+  | "hubspot"
+  | "salesforce"
+  | "zendesk"
+  | "servicenow"
+  | "outreach"
+  | "docusign";
 
 export interface IntegrationLinkSet {
   dashboard?: string;
@@ -90,6 +97,7 @@ const CAPABILITIES: Record<ConnectorCapabilityId, ConnectorCapability> = {
       dashboard: "https://login.salesforce.com",
       oauth_docs: "https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_web_server_flow.htm",
     },
+    tier1: true,
   },
   jira: {
     id: "jira",
@@ -160,6 +168,7 @@ const CAPABILITIES: Record<ConnectorCapabilityId, ConnectorCapability> = {
       api_keys_docs: "https://support.zendesk.com/hc/en-us/articles/4408831452954",
       oauth_docs: "https://developer.zendesk.com/documentation/integration-services/apps/oauth/",
     },
+    tier1: true,
   },
   servicenow: {
     id: "servicenow",
@@ -177,6 +186,46 @@ const CAPABILITIES: Record<ConnectorCapabilityId, ConnectorCapability> = {
       dashboard: "https://www.servicenow.com",
       api_keys_docs: "https://www.servicenow.com/docs/bundle/washingtondc-platform-security/page/integrate/authentication/task/t_CreateAnOAuthApiEndpointForExternalClients.html",
     },
+    tier1: true,
+  },
+  outreach: {
+    id: "outreach",
+    name: "Outreach",
+    registryEntryId: "outreach",
+    authMethods: ["oauth"],
+    oauthProvider: "outreach",
+    readinessAny: [["OUTREACH_ACCESS_TOKEN"]],
+    readinessByAuth: {
+      oauth: [["OUTREACH_ACCESS_TOKEN", "OUTREACH_REFRESH_TOKEN"]],
+    },
+    healthTool: "outreach.health",
+    links: {
+      dashboard: "https://app.outreach.io",
+      oauth_docs: "https://developers.outreach.io/api/oauth/",
+    },
+    tier1: true,
+  },
+  docusign: {
+    id: "docusign",
+    name: "DocuSign",
+    registryEntryId: "docusign",
+    authMethods: ["api_key", "oauth"],
+    oauthProvider: "docusign",
+    readinessAny: [
+      ["DOCUSIGN_ACCOUNT_ID", "DOCUSIGN_ACCESS_TOKEN"],
+      ["DOCUSIGN_ACCOUNT_ID", "DOCUSIGN_INTEGRATION_KEY", "DOCUSIGN_SECRET_KEY"],
+    ],
+    readinessByAuth: {
+      api_key: [["DOCUSIGN_ACCOUNT_ID", "DOCUSIGN_INTEGRATION_KEY", "DOCUSIGN_SECRET_KEY"]],
+      oauth: [["DOCUSIGN_ACCOUNT_ID", "DOCUSIGN_ACCESS_TOKEN", "DOCUSIGN_REFRESH_TOKEN"]],
+    },
+    healthTool: "docusign.health",
+    links: {
+      dashboard: "https://admindemo.docusign.com",
+      api_keys_docs: "https://developers.docusign.com/platform/auth/",
+      oauth_docs: "https://developers.docusign.com/platform/auth/authcode/",
+    },
+    tier1: true,
   },
   linear: {
     id: "linear",
@@ -339,6 +388,11 @@ export const TIER1_CONNECTOR_IDS: Tier1IntegrationProvider[] = [
   "jira",
   "linear",
   "hubspot",
+  "salesforce",
+  "zendesk",
+  "servicenow",
+  "outreach",
+  "docusign",
 ];
 
 export function getConnectorCapability(id: string): ConnectorCapability | undefined {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -4508,6 +4508,8 @@ export interface ElectronAPI {
       personaTemplateId?: string;
       recommendedConnectors?: string[];
       tryAsking?: string[];
+      bestFitWorkflows?: ("support_ops" | "it_ops" | "sales_ops")[];
+      outcomeExamples?: string[];
       skills: Array<{
         id: string;
         name: string;

--- a/src/renderer/components/CustomizePanel.tsx
+++ b/src/renderer/components/CustomizePanel.tsx
@@ -13,6 +13,8 @@ interface PluginPackData {
   personaTemplateId?: string;
   recommendedConnectors?: string[];
   tryAsking?: string[];
+  bestFitWorkflows?: ("support_ops" | "it_ops" | "sales_ops")[];
+  outcomeExamples?: string[];
   skills: { id: string; name: string; description: string; icon?: string; enabled?: boolean }[];
   slashCommands: { name: string; description: string; skillId: string }[];
   agentRoles: {
@@ -333,6 +335,26 @@ export function CustomizePanel({
                     <Dna size={14} strokeWidth={1.5} />
                   </span>
                   <span>Includes Digital Twin</span>
+                </div>
+              )}
+              {activePack.bestFitWorkflows && activePack.bestFitWorkflows.length > 0 && (
+                <div className="cp-best-fit-row">
+                  <span className="cp-rc-label">Best for:</span>
+                  {activePack.bestFitWorkflows.map((lane) => (
+                    <span key={lane} className={`cp-best-fit-badge cp-best-fit-badge--${lane}`}>
+                      {lane === "support_ops" ? "Support Ops" : lane === "it_ops" ? "IT Ops" : "Sales Ops"}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {activePack.outcomeExamples && activePack.outcomeExamples.length > 0 && (
+                <div className="cp-outcome-examples">
+                  <span className="cp-rc-label">Outcome examples:</span>
+                  <ul className="cp-outcome-list">
+                    {activePack.outcomeExamples.map((ex, i) => (
+                      <li key={i} className="cp-outcome-item">{ex}</li>
+                    ))}
+                  </ul>
                 </div>
               )}
               {activePack.recommendedConnectors && activePack.recommendedConnectors.length > 0 && (
@@ -716,6 +738,62 @@ export function CustomizePanel({
           display: flex;
           align-items: center;
           gap: 8px;
+        }
+
+        /* Best-fit workflow badges */
+        .cp-best-fit-row {
+          display: flex;
+          align-items: center;
+          flex-wrap: wrap;
+          gap: 6px;
+          margin-top: 8px;
+        }
+
+        .cp-best-fit-badge {
+          display: inline-flex;
+          align-items: center;
+          padding: 2px 10px;
+          border-radius: 12px;
+          font-size: 11px;
+          font-weight: 600;
+          letter-spacing: 0.02em;
+          text-transform: uppercase;
+        }
+
+        .cp-best-fit-badge--support_ops {
+          background: rgba(99, 102, 241, 0.15);
+          color: #818cf8;
+          border: 1px solid rgba(99, 102, 241, 0.3);
+        }
+
+        .cp-best-fit-badge--it_ops {
+          background: rgba(239, 68, 68, 0.15);
+          color: #f87171;
+          border: 1px solid rgba(239, 68, 68, 0.3);
+        }
+
+        .cp-best-fit-badge--sales_ops {
+          background: rgba(16, 185, 129, 0.15);
+          color: #34d399;
+          border: 1px solid rgba(16, 185, 129, 0.3);
+        }
+
+        /* Outcome examples */
+        .cp-outcome-examples {
+          margin-top: 10px;
+        }
+
+        .cp-outcome-list {
+          margin: 6px 0 0 0;
+          padding-left: 18px;
+          list-style: disc;
+        }
+
+        .cp-outcome-item {
+          font-size: 12px;
+          color: var(--color-text-secondary);
+          line-height: 1.6;
+          margin-bottom: 2px;
         }
 
         /* Recommended connectors */


### PR DESCRIPTION
## Overview
Adds support for best-fit operational workflow lanes and introduces new Tier-1 connectors (Salesforce, Outreach, DocuSign) alongside enhanced plugin pack metadata.

## Changes

### Documentation
- New `best-fit-workflows.md` guide explaining Support Ops, IT Ops, and Sales Ops as primary GTM entry points
- Updated `gtm-strategy.md` with best initial wedges and ROI positioning
- Enhanced `showcase.md` with workflow-specific context blocks for DevOps, Sales, and Support sections
- Updated `index.md` with best-fit workflows feature callout
- Enhanced `plugin-packs.md` with metadata fields documentation

### Plugin Pack Metadata
- Added `bestFitWorkflows` field (array of `support_ops`, `it_ops`, `sales_ops`) to plugin manifests
- Added `outcomeExamples` field for short outcome descriptions
- Updated Customer Support, DevOps, and Sales CRM packs with new metadata
- Added Salesforce to Sales CRM recommended connectors

### Backend Support
- Extended `Tier1IntegrationProvider` type to include Salesforce, Zendesk, ServiceNow, Outreach, DocuSign
- Added full connector capabilities for new Tier-1 providers in `capabilities.ts`
- Updated `PluginManifest` type with new optional fields
- Updated IPC handlers and preload to pass new fields through
- Expanded `integration_setup` tool documentation with full provider list

### UI Components
- Enhanced CustomizePanel to render best-fit workflow badges with color-coded lanes
- Added outcome examples bulleted list in pack details
- Styled badges (Support Ops: indigo, IT Ops: red, Sales Ops: green) with borders and uppercase labels