### PR TITLE
feat(runtime): update computer-use and approval defaults

### DIFF
--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -17,14 +17,16 @@ Use computer use when the task clearly requires **a desktop GUI** that is not ex
 - **MCP connectors and APIs** for SaaS and internal systems
 - **`browser_*` tools** for web surfaces (even if the user says “browser” in passing)
 - **`run_command` / scripts** for file, git, and CLI workflows
-- **`open_application`** to launch an app; pair with `computer_*` only when the agent must then interact with that app’s UI
+- **`open_application`** to launch an app; pair with `screenshot`/`click`/`type_text` only when the agent must then interact with that app’s UI
 
-The planner and tool policy treat `computer_*` as a **controlled, last-resort lane**: tools stay deferred unless the task signals **native desktop GUI intent** (for example Calculator, System Settings, or “click the OK button in the native dialog”). That keeps routine coding and web work from accidentally taking the desktop-control path.
+The planner and tool policy treat the computer-use lane as a **controlled, last-resort path**: tools stay deferred unless the task signals **native desktop GUI intent** (for example Calculator, System Settings, or “click the OK button in the native dialog”). That keeps routine coding and web work from accidentally taking the desktop-control path.
+
+> If the task is not asking CoWork to click or type, but instead to understand a vague on-screen reference like `what is this`, `what's on the right side`, or `why is this failing`, see [Chronicle](chronicle.md). Chronicle shares the same Screen Recording prerequisite but resolves local screen context rather than driving the mouse and keyboard.
 
 ## Platform requirements
 
-- **macOS only** today. The `computer_*` family is not available on Windows or Linux builds in the same form.
-- **CoWork OS must be the app receiving OS permissions** (see below). Permissions are per-app; granting them to Terminal or another helper does not substitute.
+- **macOS only** today. The computer-use tool family is not available on Windows or Linux builds in the same form.
+- **The bundled helper binary receives macOS permissions** (see below). Granting Accessibility or Screen Recording to Terminal or another helper does not substitute.
 
 ## macOS permissions
 
@@ -32,13 +34,13 @@ Two system permissions gate computer use:
 
 | Permission | Why it matters |
 |------------|----------------|
-| **Accessibility** | Synthetic mouse and keyboard events and many automation paths require the app to be trusted for accessibility control. |
-| **Screen Recording** | Capturing the desktop for `computer_screenshot` and related flows uses Electron’s screen capture APIs, which macOS treats as screen recording. |
+| **Accessibility** | AX-first focus, press, and value-setting require the helper to be trusted for accessibility control. |
+| **Screen Recording** | Capturing the controlled window for `screenshot()` and follow-up action refreshes uses the helper’s ScreenCaptureKit path, which macOS treats as screen recording. |
 
 **Where to enable in the product**
 
-1. Open **Settings → Tools** (or the dedicated **Computer use** panel when present).
-2. Use the shortcuts into **System Settings** to enable **Accessibility** and **Screen Recording** for CoWork OS.
+1. Open **Settings → Tools → Computer use**.
+2. Use the shortcuts into **System Settings** to enable **Accessibility** and **Screen Recording** for the computer-use helper binary shown in settings.
 3. After changing **Screen Recording**, **quit and restart CoWork OS** if capture still fails—macOS sometimes caches the old state until restart.
 
 If a tool returns an error mentioning screen capture timeout or permission, re-check Screen Recording for this app and restart.
@@ -48,46 +50,36 @@ If a tool returns an error mentioning screen capture timeout or permission, re-c
 Computer use runs under a **single global session** on the machine:
 
 - Only **one** computer-use session is active at a time; starting control for a new task coordinates with the session manager.
-- When a session is active, a **translucent safety overlay** makes it obvious the agent is controlling the desktop.
 - **Esc** aborts the active computer-use session so you can interrupt quickly without hunting in the UI.
-- **Window isolation** and **shortcut guard** reduce the chance of stray clicks affecting the wrong surface or global hotkeys firing at the wrong time during automation.
+- **Sequential execution** and a **shortcut guard** reduce the chance of overlapping actions or global hotkeys firing at the wrong time during automation.
 
 The session is torn down when the task finishes or the session ends cleanly after abort.
 
-## Per-app consent (not per click)
-
-High-risk desktop automation uses **per-app session consent** instead of approving every single pointer or key event:
-
-- The first time the agent needs to affect a given **application** in a session, you may see a **consent dialog** with the app name and a suggested access tier.
-- **Consent is scoped to the current computer-use session** (and the app in question), not stored as unlimited forever-access without context.
-- You can choose a tier that matches risk:
-
-| Tier | Typical use |
-|------|-------------|
-| **`view_only`** | Screenshots and mouse movement only—no clicks or typing into that app. |
-| **`click_only`** | `computer_screenshot`, `computer_move_mouse`, and `computer_click` only—no `computer_type` or `computer_key`. |
-| **`full_control`** | Clicks, keys, and screenshots as needed for the flow—use only when you trust the task and the app. |
-| **`denied`** | Block automation for that app for the session. |
-
-The product may show **classifier-driven warnings** for sensitive surfaces (for example browsers, terminals/IDEs, Finder, or System Settings). Treat those as intentional friction: those apps amplify blast radius if mis-automated.
-
-## Built-in tools (`computer_*`)
+## Built-in tools
 
 All of these are part of the **`computer_use` built-in tool family**. They are registered together and can be enabled or prioritized alongside other built-in categories in **Settings → Tools → Built-in tools**.
 
 | Tool | Role |
 |------|------|
-| `computer_screenshot` | Capture the current desktop (or relevant surface) for vision-backed planning and verification. |
-| `computer_move_mouse` | Move the cursor without clicking—useful for hover states and safe positioning. |
-| `computer_click` | Click (including multi-click variants where supported). |
-| `computer_type` | Type text into the focused element. |
-| `computer_key` | Emit key chords or special keys; dangerous combinations are blocklisted at the tool layer. |
+| `screenshot` | Select or refresh the current controlled window and return a fresh screenshot plus `captureId`. |
+| `click` / `double_click` | Click inside the current controlled window using screenshot-relative coordinates. |
+| `move_mouse` | Move the pointer without clicking. |
+| `drag` | Drag through a screenshot-relative path in the controlled window. |
+| `scroll` | Scroll at a screenshot-relative point in the controlled window. |
+| `type_text` | Type or set text into the currently focused control. |
+| `keypress` | Emit key chords or special keys; dangerous combinations are blocklisted at the tool layer. |
+| `wait` | Pause briefly, then refresh the controlled-window screenshot. |
 
-Timeouts and error messages are designed to surface permission or capture issues clearly rather than failing silently.
+Key contract details:
+
+- Call `screenshot()` first.
+- All action coordinates are relative to the latest screenshot, not the whole desktop.
+- Successful actions return a new screenshot and `captureId`.
+- Passing a stale `captureId` fails with a refresh instruction.
 
 ## Related tools: `open_application`
 
-`open_application` can launch macOS apps by name or bundle id. For **native GUI workflows**, policy may allow `open_application` in the same steps as `computer_*` so the agent can start the target app before driving it. That is separate from **shell**-based AppleScript or one-off scripts: when the goal is **GUI interaction**, the product steers toward **`computer_*`** (and `open_application` when needed) rather than `run_applescript` as a first choice.
+`open_application` can launch macOS apps by name or bundle id. For **native GUI workflows**, policy may allow `open_application` in the same steps as `screenshot`/`click`/`type_text` so the agent can start the target app before driving it. That is separate from **shell**-based AppleScript or one-off scripts: when the goal is **GUI interaction**, the product steers toward the dedicated computer-use tools (and `open_application` when needed) rather than `run_applescript` as a first choice.
 
 ## Routing and planner behavior (operator mental model)
 
@@ -97,23 +89,24 @@ Rough order the stack encourages:
 2. **Browser tools** for web UIs.
 3. **Shell and file tools** for repo and CLI work.
 4. **`open_application`** when the missing piece is “the app is not running.”
-5. **`computer_*`** when the task still requires **native GUI** interaction.
+5. **`screenshot` + follow-up computer-use actions** when the task still requires **native GUI** interaction.
 
 **Native desktop GUI intent** is detected from the **user goal and step text** (not only from generic words like “browser” in strategy headers). Explicit mentions of native apps, windows, dialogs, or on-screen UI tend to unlock the computer-use lane; purely web or repo tasks should not.
 
 ## Settings checklist
 
 1. **Built-in tools**: Confirm the `computer_use` category is enabled if you want the agent to use this lane at all.
-2. **Permissions**: Accessibility + Screen Recording granted for CoWork OS; restart after Screen Recording changes if needed.
-3. **Risk tolerance**: Prefer **`view_only`** or **`click_only`** when full keyboard control is unnecessary.
+2. **Permissions**: Accessibility + Screen Recording granted for the helper binary; restart after Screen Recording changes if needed.
+3. **Operational model**: Expect a foreground-first controlled-window loop centered on `screenshot()` and the latest `captureId`.
+4. **Chronicle**: If your goal is contextual screen understanding rather than GUI control, enable **Settings > Memory Hub > Chronicle**, keep the dedicated **Chronicle** built-in tool category enabled, and test `screen_context_resolve` before forcing a computer-use flow.
 
 ## Security and abuse considerations
 
 Computer use is **high trust**: a mistaken or malicious task could operate any UI your user can reach. Mitigations include:
 
-- Session-wide overlay, Esc abort, and isolation/guard layers
-- Per-app tiers and warnings on sensitive app classes
-- Policy that keeps `computer_*` off the default path unless GUI intent is clear
+- Esc abort and single-session sequential execution
+- Helper-targeted permissions with inline bootstrap
+- Policy that keeps the computer-use lane off the default path unless GUI intent is clear
 - Blocklisted key combinations that could disrupt the session or OS
 
 For how this fits the wider tool-risk model, see [Security guide → Computer use](security-guide.md#computer-use-macos-security).
@@ -122,10 +115,11 @@ For how this fits the wider tool-risk model, see [Security guide → Computer us
 
 | Symptom | Things to check |
 |---------|------------------|
-| Screenshot or capture errors / timeouts | Screen Recording for CoWork OS; restart app after granting. |
-| Clicks or keys do nothing | Accessibility trust for CoWork OS; no other app stealing focus unexpectedly. |
+| Screenshot or capture errors / timeouts | Screen Recording for the helper path shown in settings; restart app after granting. |
+| Clicks or keys do nothing | Accessibility trust for the helper path shown in settings; no other app stealing focus unexpectedly. |
 | Agent uses shell or browser instead of desktop | Task may not read as native GUI; rephrase with explicit app/window/dialog language, or ensure built-in `computer_use` is enabled. |
-| Constant consent prompts | Expected when crossing **app** boundaries or escalating tier; not every click should prompt—that is by design. |
+| Agent asks for a screenshot when the task is really “what is this on screen?” | This may be a Chronicle case rather than a computer-use case; enable Chronicle and test `screen_context_resolve` with a clear on-screen prompt first. |
+| Permission bootstrap repeats | Re-check that both Accessibility and Screen Recording are granted to the helper binary, not just to CoWork OS or Terminal. |
 | Session feels “stuck” | Use **Esc** to abort the computer-use session, then cancel or adjust the task. |
 
 ## Implementation map (for contributors)
@@ -133,12 +127,11 @@ For how this fits the wider tool-risk model, see [Security guide → Computer us
 | Area | Location |
 |------|----------|
 | Tool definitions and execution | `src/electron/agent/tools/computer-use-tools.ts` |
-| Session lifecycle, overlay integration | `src/electron/computer-use/session-manager.ts`, `safety-overlay.ts`, `window-isolation.ts`, `shortcut-guard.ts` |
-| macOS permission helpers | `src/electron/computer-use/computer-use-permissions.ts` |
-| Per-app consent | `src/electron/security/app-permission-manager.ts`, renderer approval UI |
+| Helper runtime + permissions | `src/electron/computer-use/helper-runtime.ts`, `resources/computer-use/bridge.swift` |
+| Session lifecycle | `src/electron/computer-use/session-manager.ts`, `shortcut-guard.ts` |
 | Policy / routing | `src/electron/agent/tool-policy-engine.ts`, `src/electron/agent/executor.ts` |
-| Settings / IPC | `src/renderer/components/ComputerUseSettings.tsx`, `ComputerUseApprovalDialog.tsx`, IPC handlers |
+| Settings / IPC | `src/renderer/components/ComputerUseSettings.tsx`, IPC handlers |
 
 ---
 
-**See also:** [Architecture](architecture.md), [Features](features.md), [Security guide](security-guide.md), [Operator runtime visibility](operator-runtime-visibility.md).
+**See also:** [Chronicle](chronicle.md), [Architecture](architecture.md), [Features](features.md), [Security guide](security-guide.md), [Operator runtime visibility](operator-runtime-visibility.md).

--- a/docs/permission-system.md
+++ b/docs/permission-system.md
@@ -120,6 +120,8 @@ Current examples:
 - `analyze_image` is treated as export because image bytes are sent to an external vision model
 - `read_pdf_visual` is treated as export because PDF page images are sent to an external vision model
 
+By contrast, Chronicle's `screen_context_resolve` is a **local screen-context lookup**. It can read from the local passive Chronicle buffer and optionally capture a fresh local screenshot, but it does not itself export screenshot bytes to an external provider. If the task later sends an image to a provider through `analyze_image` or another export-sensitive path, that later step still enters the normal `data_export` approval lane.
+
 This is separate from the coarse workspace `network` capability:
 
 - `network: false` still blocks all network-capable and export-capable tools at the workspace boundary

--- a/package.json
+++ b/package.json
@@ -242,6 +242,10 @@
         ]
       },
       {
+        "from": "resources/computer-use",
+        "to": "computer-use"
+      },
+      {
         "from": "build/healthkit-bridge",
         "to": "healthkit-bridge"
       }

--- a/resources/computer-use/bridge.swift
+++ b/resources/computer-use/bridge.swift
@@ -1,0 +1,1569 @@
+import Foundation
+import AppKit
+import ApplicationServices
+import ScreenCaptureKit
+
+struct BridgeFailure: Error {
+	let message: String
+	let code: String
+}
+
+final class AXRefStore {
+	private var nextId: UInt64 = 0
+	private var windows: [String: AXUIElement] = [:]
+	private var elements: [String: AXUIElement] = [:]
+
+	func storeWindow(_ window: AXUIElement) -> String {
+		nextId += 1
+		let ref = "w\(nextId)"
+		windows[ref] = window
+		return ref
+	}
+
+	func storeElement(_ element: AXUIElement) -> String {
+		nextId += 1
+		let ref = "e\(nextId)"
+		elements[ref] = element
+		return ref
+	}
+
+	func window(for ref: String) -> AXUIElement? {
+		windows[ref]
+	}
+
+	func element(for ref: String) -> AXUIElement? {
+		elements[ref]
+	}
+}
+
+private struct CGWindowCandidate {
+	let windowId: UInt32
+	let title: String
+	let bounds: CGRect
+	let isOnscreen: Bool
+}
+
+final class Box<T> {
+	var value: T
+	init(_ value: T) {
+		self.value = value
+	}
+}
+
+final class Bridge {
+	private let refStore = AXRefStore()
+	private var stdinBuffer = Data()
+
+	func run() {
+		while true {
+			autoreleasepool {
+				let data = FileHandle.standardInput.availableData
+				if data.isEmpty {
+					exit(0)
+				}
+				stdinBuffer.append(data)
+				processBufferedInput()
+			}
+		}
+	}
+
+	private func processBufferedInput() {
+		let newline = Data([0x0A])
+		while let range = stdinBuffer.range(of: newline) {
+			let lineData = stdinBuffer.subdata(in: 0..<range.lowerBound)
+			stdinBuffer.removeSubrange(0..<range.upperBound)
+
+			guard !lineData.isEmpty else { continue }
+			guard let line = String(data: lineData, encoding: .utf8) else { continue }
+			handleLine(line)
+		}
+	}
+
+	private func handleLine(_ line: String) {
+		let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard !trimmed.isEmpty else { return }
+
+		let fallbackId = "invalid"
+		do {
+			guard let jsonData = trimmed.data(using: .utf8) else {
+				throw BridgeFailure(message: "Input was not valid UTF-8", code: "invalid_request")
+			}
+			guard let object = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+				throw BridgeFailure(message: "Request must be a JSON object", code: "invalid_request")
+			}
+			let id = (object["id"] as? String) ?? fallbackId
+
+			do {
+				let result = try handleRequest(object)
+				send([
+					"id": id,
+					"ok": true,
+					"result": result,
+				])
+			} catch let failure as BridgeFailure {
+				send([
+					"id": id,
+					"ok": false,
+					"error": [
+						"message": failure.message,
+						"code": failure.code,
+					],
+				])
+			} catch {
+				send([
+					"id": id,
+					"ok": false,
+					"error": [
+						"message": error.localizedDescription,
+						"code": "internal_error",
+					],
+				])
+			}
+		} catch let failure as BridgeFailure {
+			send([
+				"id": fallbackId,
+				"ok": false,
+				"error": [
+					"message": failure.message,
+					"code": failure.code,
+				],
+			])
+		} catch {
+			send([
+				"id": fallbackId,
+				"ok": false,
+				"error": [
+					"message": error.localizedDescription,
+					"code": "internal_error",
+				],
+			])
+		}
+	}
+
+	private func send(_ payload: [String: Any]) {
+		guard JSONSerialization.isValidJSONObject(payload),
+			let data = try? JSONSerialization.data(withJSONObject: payload),
+			let line = String(data: data, encoding: .utf8)
+		else {
+			return
+		}
+
+		if let out = (line + "\n").data(using: .utf8) {
+			FileHandle.standardOutput.write(out)
+		}
+	}
+
+	private func handleRequest(_ request: [String: Any]) throws -> Any {
+		let cmd = try stringArg(request, "cmd")
+
+		switch cmd {
+		case "checkPermissions":
+			return checkPermissions()
+		case "openPermissionPane":
+			return try openPermissionPane(request)
+		case "listApps":
+			return listApps()
+		case "listWindows":
+			return try listWindows(pid: Int32(try intArg(request, "pid")))
+		case "getFrontmost":
+			return try getFrontmost()
+		case "screenshot":
+			return try screenshot(request)
+		case "mouseClick":
+			return try mouseClick(request)
+		case "mouseMove":
+			return try mouseMove(request)
+		case "mouseDrag":
+			return try mouseDrag(request)
+		case "scrollAtPoint":
+			return try scrollAtPoint(request)
+		case "axPressAtPoint":
+			return try axPressAtPoint(request)
+		case "axDescribeAtPoint":
+			return try axDescribeAtPoint(request)
+		case "axFindTextInput":
+			return try axFindTextInput(request)
+		case "axFocusTextInput":
+			return try axFocusTextInput(request)
+		case "axFindFocusableElement":
+			return try axFindFocusableElement(request)
+		case "axFindActionableElement":
+			return try axFindActionableElement(request)
+		case "axFocusAtPoint":
+			return try axFocusAtPoint(request)
+		case "focusedElement":
+			return try focusedElement(request)
+		case "setValue":
+			return try setValue(request)
+		case "typeText":
+			return try typeText(request)
+		case "keyPress":
+			return try keyPress(request)
+		case "activateApp":
+			return try activateApp(request)
+		case "raiseWindow":
+			return try raiseWindow(request)
+		case "unminimizeWindow":
+			return try unminimizeWindow(request)
+		default:
+			throw BridgeFailure(message: "Unknown command '\(cmd)'", code: "unknown_command")
+		}
+	}
+
+	private func stringArg(_ request: [String: Any], _ key: String) throws -> String {
+		if let value = request[key] as? String {
+			return value
+		}
+		throw BridgeFailure(message: "Missing string argument '\(key)'", code: "invalid_args")
+	}
+
+	private func intArg(_ request: [String: Any], _ key: String) throws -> Int {
+		if let value = request[key] as? Int {
+			return value
+		}
+		if let value = request[key] as? NSNumber {
+			return value.intValue
+		}
+		if let value = request[key] as? Double {
+			return Int(value)
+		}
+		throw BridgeFailure(message: "Missing integer argument '\(key)'", code: "invalid_args")
+	}
+
+	private func optionalIntArg(_ request: [String: Any], _ key: String) -> Int? {
+		if let value = request[key] as? Int {
+			return value
+		}
+		if let value = request[key] as? NSNumber {
+			return value.intValue
+		}
+		if let value = request[key] as? Double {
+			return Int(value)
+		}
+		return nil
+	}
+
+	private func doubleArg(_ request: [String: Any], _ key: String) throws -> Double {
+		if let value = request[key] as? Double {
+			return value
+		}
+		if let value = request[key] as? NSNumber {
+			return value.doubleValue
+		}
+		if let value = request[key] as? Int {
+			return Double(value)
+		}
+		throw BridgeFailure(message: "Missing numeric argument '\(key)'", code: "invalid_args")
+	}
+
+	private func stringArrayArg(_ request: [String: Any], _ key: String) throws -> [String] {
+		guard let values = request[key] as? [Any] else {
+			throw BridgeFailure(message: "Missing string array argument '\(key)'", code: "invalid_args")
+		}
+		let strings = values.compactMap { $0 as? String }
+		guard strings.count == values.count else {
+			throw BridgeFailure(message: "Argument '\(key)' must contain only strings", code: "invalid_args")
+		}
+		return strings
+	}
+
+	private func checkPermissions() -> [String: Any] {
+		let accessibility = AXIsProcessTrusted()
+		let screenRecording: Bool
+		if #available(macOS 10.15, *) {
+			screenRecording = CGPreflightScreenCaptureAccess()
+		} else {
+			screenRecording = true
+		}
+		return [
+			"accessibility": accessibility,
+			"screenRecording": screenRecording,
+		]
+	}
+
+	private func openPermissionPane(_ request: [String: Any]) throws -> [String: Any] {
+		let kind = try stringArg(request, "kind")
+		let urlString: String
+		switch kind {
+		case "accessibility":
+			urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+		case "screenRecording", "screenrecording":
+			urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+		default:
+			throw BridgeFailure(message: "Unknown permission pane '\(kind)'", code: "invalid_args")
+		}
+
+		guard let url = URL(string: urlString) else {
+			throw BridgeFailure(message: "Invalid permission pane URL", code: "internal_error")
+		}
+		return ["opened": NSWorkspace.shared.open(url)]
+	}
+
+	private func listApps() -> [[String: Any]] {
+		let frontmostPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
+		let apps = NSWorkspace.shared.runningApplications.filter { $0.activationPolicy == .regular }
+		return apps.map { app in
+			var data: [String: Any] = [
+				"appName": app.localizedName ?? "Unknown App",
+				"pid": Int(app.processIdentifier),
+				"isFrontmost": app.processIdentifier == frontmostPid,
+			]
+			if let bundleId = app.bundleIdentifier {
+				data["bundleId"] = bundleId
+			}
+			return data
+		}
+	}
+
+	private func getFrontmost() throws -> [String: Any] {
+		guard let app = NSWorkspace.shared.frontmostApplication else {
+			throw BridgeFailure(message: "No frontmost app available", code: "frontmost_unavailable")
+		}
+		let pid = app.processIdentifier
+		let windows = try listWindows(pid: pid)
+
+		var result: [String: Any] = [
+			"appName": app.localizedName ?? "Unknown App",
+			"pid": Int(pid),
+		]
+		if let bundleId = app.bundleIdentifier {
+			result["bundleId"] = bundleId
+		}
+
+		if let chosen = windows.sorted(by: { scoreWindow($0) > scoreWindow($1) }).first {
+			result["windowTitle"] = (chosen["title"] as? String) ?? ""
+			if let windowId = chosen["windowId"] {
+				result["windowId"] = windowId
+			}
+		}
+		return result
+	}
+
+	private func scoreWindow(_ window: [String: Any]) -> Int {
+		var score = 0
+		if (window["isFocused"] as? Bool) == true { score += 100 }
+		if (window["isMain"] as? Bool) == true { score += 80 }
+		if (window["isMinimized"] as? Bool) == false { score += 40 }
+		if (window["isOnscreen"] as? Bool) == true { score += 20 }
+		if window["windowId"] != nil { score += 10 }
+		return score
+	}
+
+	private func listWindows(pid: Int32) throws -> [[String: Any]] {
+		let appElement = AXUIElementCreateApplication(pid)
+		let windows = axElementArray(appElement, attribute: kAXWindowsAttribute as CFString)
+		let candidates = cgWindowCandidates(pid: pid)
+		var usedIds = Set<UInt32>()
+
+		var output: [[String: Any]] = []
+		for window in windows {
+			let title = stringAttribute(window, attribute: kAXTitleAttribute as CFString) ?? ""
+			let frame = frameForWindow(window)
+			let candidate = bestCandidate(frame: frame, title: title, candidates: candidates, usedIds: usedIds)
+			if let candidate {
+				usedIds.insert(candidate.windowId)
+			}
+
+			let isMinimized = boolAttribute(window, attribute: kAXMinimizedAttribute as CFString) ?? false
+			let isMain = boolAttribute(window, attribute: kAXMainAttribute as CFString) ?? false
+			let isFocused = boolAttribute(window, attribute: kAXFocusedAttribute as CFString) ?? false
+			let scale = displayScaleFactor(for: frame)
+
+			var item: [String: Any] = [
+				"title": title,
+				"framePoints": [
+					"x": frame.origin.x,
+					"y": frame.origin.y,
+					"w": frame.size.width,
+					"h": frame.size.height,
+				],
+				"scaleFactor": scale,
+				"isMinimized": isMinimized,
+				"isOnscreen": candidate?.isOnscreen ?? !isMinimized,
+				"isMain": isMain,
+				"isFocused": isFocused,
+			]
+			if let candidate {
+				item["windowId"] = Int(candidate.windowId)
+			}
+			output.append(item)
+		}
+		return output
+	}
+
+	private func screenshot(_ request: [String: Any]) throws -> [String: Any] {
+		let windowId = UInt32(try intArg(request, "windowId"))
+		return try captureWindow(windowId: windowId)
+	}
+
+	private func mouseButtonSpec(_ name: String) throws -> (button: CGMouseButton, down: CGEventType, up: CGEventType) {
+		switch name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+		case "left", "":
+			return (.left, .leftMouseDown, .leftMouseUp)
+		case "right":
+			return (.right, .rightMouseDown, .rightMouseUp)
+		case "wheel", "middle":
+			return (.center, .otherMouseDown, .otherMouseUp)
+		case "back":
+			return (CGMouseButton(rawValue: 3)!, .otherMouseDown, .otherMouseUp)
+		case "forward":
+			return (CGMouseButton(rawValue: 4)!, .otherMouseDown, .otherMouseUp)
+		default:
+			throw BridgeFailure(message: "Unsupported mouse button '\(name)'", code: "invalid_args")
+		}
+	}
+
+	private func mouseClick(_ request: [String: Any]) throws -> [String: Any] {
+		let windowId = UInt32(try intArg(request, "windowId"))
+		let x = try doubleArg(request, "x")
+		let y = try doubleArg(request, "y")
+		let buttonName = (request["button"] as? String) ?? "left"
+		let clickCount = max(1, optionalIntArg(request, "clickCount") ?? 1)
+		guard let targetPid = optionalIntArg(request, "pid").map({ Int32($0) }) else {
+			throw BridgeFailure(message: "mouseClick requires pid", code: "pid_required")
+		}
+		let captureWidth = max(1.0, (try? doubleArg(request, "captureWidth")) ?? 1.0)
+		let captureHeight = max(1.0, (try? doubleArg(request, "captureHeight")) ?? 1.0)
+		let point = try mapWindowPoint(windowId: windowId, x: x, y: y, captureWidth: captureWidth, captureHeight: captureHeight)
+		let spec = try mouseButtonSpec(buttonName)
+		try postMouseClick(at: point, pid: targetPid, button: spec.button, downType: spec.down, upType: spec.up, clickCount: clickCount)
+		return ["clicked": true]
+	}
+
+	private func mouseMove(_ request: [String: Any]) throws -> [String: Any] {
+		let windowId = UInt32(try intArg(request, "windowId"))
+		let x = try doubleArg(request, "x")
+		let y = try doubleArg(request, "y")
+		guard let targetPid = optionalIntArg(request, "pid").map({ Int32($0) }) else {
+			throw BridgeFailure(message: "mouseMove requires pid", code: "pid_required")
+		}
+		let captureWidth = max(1.0, (try? doubleArg(request, "captureWidth")) ?? 1.0)
+		let captureHeight = max(1.0, (try? doubleArg(request, "captureHeight")) ?? 1.0)
+		let point = try mapWindowPoint(windowId: windowId, x: x, y: y, captureWidth: captureWidth, captureHeight: captureHeight)
+		try postMouseMove(to: point, pid: targetPid)
+		return ["moved": true]
+	}
+
+	private func mouseDrag(_ request: [String: Any]) throws -> [String: Any] {
+		let windowId = UInt32(try intArg(request, "windowId"))
+		guard let rawPath = request["path"] as? [Any], rawPath.count >= 2 else {
+			throw BridgeFailure(message: "mouseDrag requires a path with at least two points", code: "invalid_args")
+		}
+		guard let targetPid = optionalIntArg(request, "pid").map({ Int32($0) }) else {
+			throw BridgeFailure(message: "mouseDrag requires pid", code: "pid_required")
+		}
+		let captureWidth = max(1.0, (try? doubleArg(request, "captureWidth")) ?? 1.0)
+		let captureHeight = max(1.0, (try? doubleArg(request, "captureHeight")) ?? 1.0)
+		let points: [CGPoint] = try rawPath.map { raw in
+			guard let point = raw as? [String: Any] else {
+				throw BridgeFailure(message: "mouseDrag path must contain point objects", code: "invalid_args")
+			}
+			let x = try doubleArg(point, "x")
+			let y = try doubleArg(point, "y")
+			return try mapWindowPoint(
+				windowId: windowId,
+				x: x,
+				y: y,
+				captureWidth: captureWidth,
+				captureHeight: captureHeight
+			)
+		}
+		try postMouseDrag(through: points, pid: targetPid)
+		return ["dragged": true]
+	}
+
+	private func scrollAtPoint(_ request: [String: Any]) throws -> [String: Any] {
+		let windowId = UInt32(try intArg(request, "windowId"))
+		let x = try doubleArg(request, "x")
+		let y = try doubleArg(request, "y")
+		let scrollX = try intArg(request, "scrollX")
+		let scrollY = try intArg(request, "scrollY")
+		guard let targetPid = optionalIntArg(request, "pid").map({ Int32($0) }) else {
+			throw BridgeFailure(message: "scrollAtPoint requires pid", code: "pid_required")
+		}
+		let captureWidth = max(1.0, (try? doubleArg(request, "captureWidth")) ?? 1.0)
+		let captureHeight = max(1.0, (try? doubleArg(request, "captureHeight")) ?? 1.0)
+		let point = try mapWindowPoint(windowId: windowId, x: x, y: y, captureWidth: captureWidth, captureHeight: captureHeight)
+		try postScroll(at: point, pid: targetPid, scrollX: scrollX, scrollY: scrollY)
+		return ["scrolled": true]
+	}
+
+	private func axPressAtPoint(_ request: [String: Any]) throws -> [String: Any] {
+		let windowId = UInt32(try intArg(request, "windowId"))
+		let x = try doubleArg(request, "x")
+		let y = try doubleArg(request, "y")
+		guard let targetPid = optionalIntArg(request, "pid").map({ Int32($0) }) else {
+			throw BridgeFailure(message: "axPressAtPoint requires pid", code: "pid_required")
+		}
+		let captureWidth = max(1.0, (try? doubleArg(request, "captureWidth")) ?? 1.0)
+		let captureHeight = max(1.0, (try? doubleArg(request, "captureHeight")) ?? 1.0)
+
+		let point = try mapWindowPoint(windowId: windowId, x: x, y: y, captureWidth: captureWidth, captureHeight: captureHeight)
+		guard let hitElement = hitTestElement(at: point) else {
+			return ["pressed": false, "reason": "hit_test_failed"]
+		}
+
+		let result = performActionOrAncestor(startingAt: hitElement, action: kAXPressAction as CFString, targetPid: targetPid)
+		var output: [String: Any] = ["pressed": result["performed"] as? Bool ?? false]
+		if let reason = result["reason"] as? String {
+			output["reason"] = reason
+		}
+		return output
+	}
+
+	private func axDescribeAtPoint(_ request: [String: Any]) throws -> [String: Any] {
+		let windowId = UInt32(try intArg(request, "windowId"))
+		let x = try doubleArg(request, "x")
+		let y = try doubleArg(request, "y")
+		guard let targetPid = optionalIntArg(request, "pid").map({ Int32($0) }) else {
+			throw BridgeFailure(message: "axDescribeAtPoint requires pid", code: "pid_required")
+		}
+		let captureWidth = max(1.0, (try? doubleArg(request, "captureWidth")) ?? 1.0)
+		let captureHeight = max(1.0, (try? doubleArg(request, "captureHeight")) ?? 1.0)
+
+		let point = try mapWindowPoint(windowId: windowId, x: x, y: y, captureWidth: captureWidth, captureHeight: captureHeight)
+		guard let hitElement = hitTestElement(at: point) else {
+			return ["exists": false, "reason": "hit_test_failed"]
+		}
+		return describeElementOrAncestor(startingAt: hitElement, targetPid: targetPid)
+	}
+
+	private func axFindTextInput(_ request: [String: Any]) throws -> [String: Any] {
+		let pid = Int32(try intArg(request, "pid"))
+		let windowId = optionalIntArg(request, "windowId").map { UInt32($0) }
+		guard let window = windowElement(pid: pid, windowId: windowId) else {
+			return ["found": false, "reason": "window_not_found"]
+		}
+		let textRoles: Set<String> = [
+			"AXTextField", "AXTextArea", "AXTextView", "AXSearchField", "AXComboBox", "AXEditableText", "AXSecureTextField",
+		]
+		let elements = collectDescendants(startingAt: window, maxDepth: 8)
+		let ranked = elements.compactMap { candidate -> (AXUIElement, Double)? in
+			let role = self.stringAttribute(candidate, attribute: kAXRoleAttribute as CFString) ?? ""
+			var valueSettable = DarwinBoolean(false)
+			let valueStatus = AXUIElementIsAttributeSettable(candidate, kAXValueAttribute as CFString, &valueSettable)
+			let canSetValue = valueStatus == .success && valueSettable.boolValue
+			guard textRoles.contains(role) || canSetValue else { return nil }
+			return (candidate, self.scoreTextInputElement(candidate, role: role))
+		}.sorted { $0.1 > $1.1 }
+		guard let best = ranked.first else {
+			return ["found": false, "reason": "no_text_input"]
+		}
+		return rankedElementPayload(best: best, ranked: ranked, key: "found")
+	}
+
+	private func axFocusTextInput(_ request: [String: Any]) throws -> [String: Any] {
+		let found = try axFindTextInput(request)
+		guard (found["found"] as? Bool) == true, let elementRef = found["elementRef"] as? String else {
+			return found
+		}
+		guard let element = refStore.element(for: elementRef) else {
+			return ["focused": false, "reason": "element_ref_invalid"]
+		}
+		var settable = DarwinBoolean(false)
+		let status = AXUIElementIsAttributeSettable(element, kAXFocusedAttribute as CFString, &settable)
+		guard status == .success && settable.boolValue else {
+			var payload = found
+			payload["focused"] = false
+			payload["reason"] = "not_focusable"
+			return payload
+		}
+		let setStatus = AXUIElementSetAttributeValue(element, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+		var payload = found
+		payload["focused"] = (setStatus == .success)
+		if setStatus != .success {
+			payload["reason"] = "focus_failed"
+		}
+		return payload
+	}
+
+	private func axFindFocusableElement(_ request: [String: Any]) throws -> [String: Any] {
+		let pid = Int32(try intArg(request, "pid"))
+		let windowId = optionalIntArg(request, "windowId").map { UInt32($0) }
+		let preferredRoles = Set((request["roles"] as? [String] ?? []).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+		guard let window = windowElement(pid: pid, windowId: windowId) else {
+			return ["found": false, "reason": "window_not_found"]
+		}
+		let elements = collectDescendants(startingAt: window, maxDepth: 8)
+		let ranked = elements.compactMap { candidate -> (AXUIElement, Double)? in
+			let role = self.stringAttribute(candidate, attribute: kAXRoleAttribute as CFString) ?? ""
+			if !preferredRoles.isEmpty && !preferredRoles.contains(role) { return nil }
+			var focusedSettable = DarwinBoolean(false)
+			let focusStatus = AXUIElementIsAttributeSettable(candidate, kAXFocusedAttribute as CFString, &focusedSettable)
+			let canFocus = focusStatus == .success && focusedSettable.boolValue
+			let canPress = self.supportsPressAction(candidate)
+			guard canFocus || canPress else { return nil }
+			return (
+				candidate,
+				self.scoreFocusableElement(
+					candidate,
+					role: role,
+					canFocus: canFocus,
+					canPress: canPress,
+					preferredRoles: preferredRoles
+				)
+			)
+		}.sorted { $0.1 > $1.1 }
+		guard let best = ranked.first else {
+			return ["found": false, "reason": "no_focusable_element"]
+		}
+		return rankedElementPayload(best: best, ranked: ranked, key: "found")
+	}
+
+	private func axFindActionableElement(_ request: [String: Any]) throws -> [String: Any] {
+		let pid = Int32(try intArg(request, "pid"))
+		let windowId = optionalIntArg(request, "windowId").map { UInt32($0) }
+		let preferredRoles = Set((request["roles"] as? [String] ?? []).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+		guard let window = windowElement(pid: pid, windowId: windowId) else {
+			return ["found": false, "reason": "window_not_found"]
+		}
+		let elements = collectDescendants(startingAt: window, maxDepth: 8)
+		let ranked = elements.compactMap { candidate -> (AXUIElement, Double)? in
+			let role = self.stringAttribute(candidate, attribute: kAXRoleAttribute as CFString) ?? ""
+			if !preferredRoles.isEmpty && !preferredRoles.contains(role) { return nil }
+			let actions = self.actionNames(candidate)
+			guard !actions.isEmpty else { return nil }
+			return (candidate, self.scoreActionableElement(candidate, role: role, actions: actions, preferredRoles: preferredRoles))
+		}.sorted { $0.1 > $1.1 }
+		guard let best = ranked.first else {
+			return ["found": false, "reason": "no_actionable_element"]
+		}
+		return rankedElementPayload(best: best, ranked: ranked, key: "found")
+	}
+
+	private func axFocusAtPoint(_ request: [String: Any]) throws -> [String: Any] {
+		let windowId = UInt32(try intArg(request, "windowId"))
+		let x = try doubleArg(request, "x")
+		let y = try doubleArg(request, "y")
+		guard let targetPid = optionalIntArg(request, "pid").map({ Int32($0) }) else {
+			throw BridgeFailure(message: "axFocusAtPoint requires pid", code: "pid_required")
+		}
+		let captureWidth = max(1.0, (try? doubleArg(request, "captureWidth")) ?? 1.0)
+		let captureHeight = max(1.0, (try? doubleArg(request, "captureHeight")) ?? 1.0)
+
+		let point = try mapWindowPoint(windowId: windowId, x: x, y: y, captureWidth: captureWidth, captureHeight: captureHeight)
+		guard let hitElement = hitTestElement(at: point) else {
+			return ["focused": false, "reason": "hit_test_failed"]
+		}
+
+		return focusElementOrAncestor(startingAt: hitElement, targetPid: targetPid)
+	}
+
+	private func focusedElement(_ request: [String: Any]) throws -> [String: Any] {
+		let pid = Int32(try intArg(request, "pid"))
+		let app = AXUIElementCreateApplication(pid)
+		guard let focusedValue = copyAttribute(app, attribute: kAXFocusedUIElementAttribute as CFString),
+			let element = asAXElement(focusedValue)
+		else {
+			return ["exists": false]
+		}
+
+		let role = stringAttribute(element, attribute: kAXRoleAttribute as CFString) ?? ""
+		let subrole = stringAttribute(element, attribute: kAXSubroleAttribute as CFString) ?? ""
+		let secure = role == "AXSecureTextField" || subrole == "AXSecureTextField"
+
+		var settable = DarwinBoolean(false)
+		let settableStatus = AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &settable)
+		let canSetValue = settableStatus == .success && settable.boolValue
+
+		let textRoles: Set<String> = [
+			"AXTextField",
+			"AXTextArea",
+			"AXTextView",
+			"AXSearchField",
+			"AXComboBox",
+			"AXEditableText",
+			"AXSecureTextField",
+		]
+
+		let isTextInput = textRoles.contains(role) || canSetValue
+		let elementRef = refStore.storeElement(element)
+
+		return [
+			"exists": true,
+			"elementRef": elementRef,
+			"role": role,
+			"subrole": subrole,
+			"isTextInput": isTextInput,
+			"isSecure": secure,
+			"canSetValue": canSetValue,
+		]
+	}
+
+	private func setValue(_ request: [String: Any]) throws -> [String: Any] {
+		let elementRef = try stringArg(request, "elementRef")
+		let value = try stringArg(request, "value")
+		guard let element = refStore.element(for: elementRef) else {
+			throw BridgeFailure(message: "Element reference is no longer valid", code: "element_ref_invalid")
+		}
+
+		let status = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, value as CFTypeRef)
+		if status != .success {
+			throw BridgeFailure(message: "Failed to set value (AX error \(status.rawValue))", code: "set_value_failed")
+		}
+		return ["set": true]
+	}
+
+	private func typeText(_ request: [String: Any]) throws -> [String: Any] {
+		let text = try stringArg(request, "text")
+		guard let targetPid = optionalIntArg(request, "pid").map({ Int32($0) }) else {
+			throw BridgeFailure(message: "typeText requires pid", code: "pid_required")
+		}
+		try postUnicodeText(text, pid: targetPid)
+		return ["typed": true]
+	}
+
+	private func keyPress(_ request: [String: Any]) throws -> [String: Any] {
+		guard let targetPid = optionalIntArg(request, "pid").map({ Int32($0) }) else {
+			throw BridgeFailure(message: "keyPress requires pid", code: "pid_required")
+		}
+		let keyCode = optionalIntArg(request, "keyCode")
+		let keyText = request["keyText"] as? String
+		let modifiers = (try? stringArrayArg(request, "modifiers")) ?? []
+		try postKeyPress(pid: targetPid, keyCode: keyCode, keyText: keyText, modifiers: modifiers)
+		return ["pressed": true]
+	}
+
+	private func activateApp(_ request: [String: Any]) throws -> [String: Any] {
+		let pid = Int32(try intArg(request, "pid"))
+		guard let app = NSRunningApplication(processIdentifier: pid) else {
+			throw BridgeFailure(message: "Target application is not running", code: "app_not_found")
+		}
+		let activated = app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+		return ["activated": activated]
+	}
+
+	private func raiseWindow(_ request: [String: Any]) throws -> [String: Any] {
+		let pid = Int32(try intArg(request, "pid"))
+		let windowId = optionalIntArg(request, "windowId").map { UInt32($0) }
+		guard let window = windowElement(pid: pid, windowId: windowId) else {
+			return ["raised": false, "reason": "window_not_found"]
+		}
+
+		var raised = false
+		var settable = DarwinBoolean(false)
+		let mainStatus = AXUIElementIsAttributeSettable(window, kAXMainAttribute as CFString, &settable)
+		if mainStatus == .success && settable.boolValue {
+			let setStatus = AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, kCFBooleanTrue)
+			if setStatus == .success {
+				raised = true
+			}
+		}
+		let focusStatus = AXUIElementIsAttributeSettable(window, kAXFocusedAttribute as CFString, &settable)
+		if focusStatus == .success && settable.boolValue {
+			let setStatus = AXUIElementSetAttributeValue(window, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+			if setStatus == .success {
+				raised = true
+			}
+		}
+		return ["raised": raised]
+	}
+
+	private func unminimizeWindow(_ request: [String: Any]) throws -> [String: Any] {
+		let pid = Int32(try intArg(request, "pid"))
+		let windowId = optionalIntArg(request, "windowId").map { UInt32($0) }
+		guard let window = windowElement(pid: pid, windowId: windowId) else {
+			return ["unminimized": false, "reason": "window_not_found"]
+		}
+		let minimized = boolAttribute(window, attribute: kAXMinimizedAttribute as CFString) ?? false
+		if !minimized {
+			return ["unminimized": true]
+		}
+		let status = AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
+		return ["unminimized": status == .success]
+	}
+
+	private func hitTestElement(at point: CGPoint) -> AXUIElement? {
+		let systemWide = AXUIElementCreateSystemWide()
+		var hitElement: AXUIElement?
+		let status = AXUIElementCopyElementAtPosition(systemWide, Float(point.x), Float(point.y), &hitElement)
+		guard status == .success, let hitElement else { return nil }
+		return hitElement
+	}
+
+	private func performActionOrAncestor(startingAt element: AXUIElement, action: CFString, targetPid: Int32) -> [String: Any] {
+		var current: AXUIElement? = element
+		var depth = 0
+
+		while let candidate = current, depth < 10 {
+			if let pid = pidForElement(candidate), pid != targetPid {
+				return ["performed": false, "reason": "pid_mismatch", "ownerPid": Int(pid)]
+			}
+
+			if supportsAction(candidate, action: action) {
+				let actionStatus = AXUIElementPerformAction(candidate, action)
+				if actionStatus == .success {
+					return ["performed": true]
+				}
+			}
+
+			current = parentElement(candidate)
+			depth += 1
+		}
+
+		return ["performed": false, "reason": "no_matching_action"]
+	}
+
+	private func describeElementOrAncestor(startingAt element: AXUIElement, targetPid: Int32) -> [String: Any] {
+		var current: AXUIElement? = element
+		var depth = 0
+		var chain: [[String: Any]] = []
+
+		while let candidate = current, depth < 10 {
+			let pid = pidForElement(candidate)
+			let role = stringAttribute(candidate, attribute: kAXRoleAttribute as CFString) ?? ""
+			let subrole = stringAttribute(candidate, attribute: kAXSubroleAttribute as CFString) ?? ""
+			let title = stringAttribute(candidate, attribute: kAXTitleAttribute as CFString) ?? ""
+			let valueString = stringAttribute(candidate, attribute: kAXValueAttribute as CFString) ?? ""
+			var focusedSettable = DarwinBoolean(false)
+			let focusStatus = AXUIElementIsAttributeSettable(candidate, kAXFocusedAttribute as CFString, &focusedSettable)
+			var valueSettable = DarwinBoolean(false)
+			let valueStatus = AXUIElementIsAttributeSettable(candidate, kAXValueAttribute as CFString, &valueSettable)
+			chain.append([
+				"depth": depth,
+				"pid": pid as Any,
+				"role": role,
+				"subrole": subrole,
+				"title": title,
+				"value": valueString,
+				"actions": actionNames(candidate),
+				"focusSettable": focusStatus == .success && focusedSettable.boolValue,
+				"valueSettable": valueStatus == .success && valueSettable.boolValue,
+			])
+			if let pid, pid != targetPid {
+				return ["exists": true, "reason": "pid_mismatch", "ownerPid": Int(pid), "chain": chain]
+			}
+			current = parentElement(candidate)
+			depth += 1
+		}
+
+		return ["exists": true, "chain": chain]
+	}
+
+	private func focusElementOrAncestor(startingAt element: AXUIElement, targetPid: Int32) -> [String: Any] {
+		var current: AXUIElement? = element
+		var depth = 0
+
+		while let candidate = current, depth < 10 {
+			if let pid = pidForElement(candidate), pid != targetPid {
+				return ["focused": false, "reason": "pid_mismatch", "ownerPid": Int(pid)]
+			}
+
+			var settable = DarwinBoolean(false)
+			let status = AXUIElementIsAttributeSettable(candidate, kAXFocusedAttribute as CFString, &settable)
+			if status == .success && settable.boolValue {
+				let setStatus = AXUIElementSetAttributeValue(candidate, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+				if setStatus == .success {
+					return ["focused": true]
+				}
+			}
+
+			current = parentElement(candidate)
+			depth += 1
+		}
+
+		return ["focused": false, "reason": "no_focusable_ancestor"]
+	}
+
+	private func windowElement(pid: Int32, windowId: UInt32?) -> AXUIElement? {
+		let appElement = AXUIElementCreateApplication(pid)
+		let windows = axElementArray(appElement, attribute: kAXWindowsAttribute as CFString)
+		guard !windows.isEmpty else { return nil }
+		guard let windowId else {
+			return windows.first
+		}
+		let candidates = cgWindowCandidates(pid: pid)
+		for window in windows {
+			let title = stringAttribute(window, attribute: kAXTitleAttribute as CFString) ?? ""
+			let frame = frameForWindow(window)
+			if let candidate = bestCandidate(frame: frame, title: title, candidates: candidates, usedIds: []), candidate.windowId == windowId {
+				return window
+			}
+		}
+		return windows.first
+	}
+
+	private func findDescendant(startingAt root: AXUIElement, maxDepth: Int, predicate: (AXUIElement) -> Bool) -> AXUIElement? {
+		collectDescendants(startingAt: root, maxDepth: maxDepth).first(where: predicate)
+	}
+
+	private func collectDescendants(startingAt root: AXUIElement, maxDepth: Int) -> [AXUIElement] {
+		var queue: [(AXUIElement, Int)] = [(root, 0)]
+		var index = 0
+		var output: [AXUIElement] = []
+		while index < queue.count {
+			let (element, depth) = queue[index]
+			index += 1
+			output.append(element)
+			if depth >= maxDepth { continue }
+			let children = axElementArray(element, attribute: kAXChildrenAttribute as CFString)
+			for child in children {
+				queue.append((child, depth + 1))
+			}
+		}
+		return output
+	}
+
+	private func scoreTextInputElement(_ element: AXUIElement, role: String) -> Double {
+		var score = 0.0
+		if role == "AXSearchField" { score += 120 }
+		if role == "AXTextField" { score += 100 }
+		if role == "AXComboBox" { score += 80 }
+		if role == "AXTextArea" || role == "AXTextView" || role == "AXEditableText" { score += 70 }
+		if role == "AXSecureTextField" { score -= 40 }
+		if let frame = frameForElement(element) {
+			score += min(120, Double(frame.width * frame.height) / 5000.0)
+			if frame.width > 40 && frame.height > 16 { score += 20 }
+			if frame.origin.y < 220 { score += 15 }
+		} else {
+			score -= 100
+		}
+		let title = stringAttribute(element, attribute: kAXTitleAttribute as CFString) ?? ""
+		let value = stringAttribute(element, attribute: kAXValueAttribute as CFString) ?? ""
+		if !title.isEmpty { score += 10 }
+		if !value.isEmpty { score += 5 }
+		return score
+	}
+
+	private func scoreFocusableElement(
+		_ element: AXUIElement,
+		role: String,
+		canFocus: Bool,
+		canPress: Bool,
+		preferredRoles: Set<String>
+	) -> Double {
+		var score = 0.0
+		if canPress { score += 80 }
+		if canFocus { score += 70 }
+		if !preferredRoles.isEmpty && preferredRoles.contains(role) { score += 40 }
+		switch role {
+		case "AXButton": score += 60
+		case "AXTextField", "AXSearchField", "AXTextArea", "AXTextView": score += 50
+		case "AXList", "AXOutline", "AXRow", "AXCell", "AXLink": score += 35
+		case "AXGroup", "AXToolbar", "AXWindow", "AXApplication": score -= 60
+		default: break
+		}
+		if let frame = frameForElement(element) {
+			score += min(100, Double(frame.width * frame.height) / 6000.0)
+			if frame.width > 24 && frame.height > 14 { score += 10 }
+		} else {
+			score -= 100
+		}
+		if !actionNames(element).isEmpty { score += 10 }
+		return score
+	}
+
+	private func scoreActionableElement(
+		_ element: AXUIElement,
+		role: String,
+		actions: [String],
+		preferredRoles: Set<String>
+	) -> Double {
+		var score = 0.0
+		if !preferredRoles.isEmpty && preferredRoles.contains(role) { score += 40 }
+		if actions.contains(kAXPressAction as String) { score += 100 }
+		if actions.contains(kAXShowMenuAction as String) { score += 50 }
+		if actions.contains(kAXPickAction as String) { score += 45 }
+		if actions.contains(kAXConfirmAction as String) { score += 35 }
+		switch role {
+		case "AXButton": score += 70
+		case "AXLink": score += 60
+		case "AXRow", "AXCell", "AXList", "AXOutline": score += 40
+		case "AXGroup", "AXToolbar", "AXWindow", "AXApplication": score -= 60
+		default: break
+		}
+		if let frame = frameForElement(element) {
+			score += min(100, Double(frame.width * frame.height) / 6000.0)
+			if frame.width > 20 && frame.height > 14 { score += 10 }
+		} else {
+			score -= 100
+		}
+		if !actions.isEmpty { score += Double(min(actions.count, 5) * 4) }
+		return score
+	}
+
+	private func rankedElementPayload(best: (AXUIElement, Double), ranked: [(AXUIElement, Double)], key: String) -> [String: Any] {
+		var payload = elementPayload(element: best.0, key: key, score: best.1)
+		payload["confidence"] = confidenceLabel(ranked)
+		payload["candidates"] = Array(ranked.prefix(3)).map { candidate, score in
+			candidateSummary(element: candidate, score: score)
+		}
+		return payload
+	}
+
+	private func confidenceLabel(_ ranked: [(AXUIElement, Double)]) -> String {
+		guard let first = ranked.first else { return "none" }
+		guard ranked.count > 1 else { return "high" }
+		let delta = first.1 - ranked[1].1
+		if delta >= 40 { return "high" }
+		if delta >= 15 { return "medium" }
+		return "low"
+	}
+
+	private func candidateSummary(element: AXUIElement, score: Double) -> [String: Any] {
+		let role = stringAttribute(element, attribute: kAXRoleAttribute as CFString) ?? ""
+		let subrole = stringAttribute(element, attribute: kAXSubroleAttribute as CFString) ?? ""
+		let title = stringAttribute(element, attribute: kAXTitleAttribute as CFString) ?? ""
+		let value = stringAttribute(element, attribute: kAXValueAttribute as CFString) ?? ""
+		var summary: [String: Any] = [
+			"role": role,
+			"subrole": subrole,
+			"title": title,
+			"value": value,
+			"score": score,
+			"actions": actionNames(element),
+		]
+		if let frame = frameForElement(element) {
+			summary["frame"] = ["x": frame.origin.x, "y": frame.origin.y, "w": frame.width, "h": frame.height]
+		}
+		return summary
+	}
+
+	private func elementPayload(element: AXUIElement, key: String, score: Double? = nil) -> [String: Any] {
+		let role = stringAttribute(element, attribute: kAXRoleAttribute as CFString) ?? ""
+		let subrole = stringAttribute(element, attribute: kAXSubroleAttribute as CFString) ?? ""
+		let title = stringAttribute(element, attribute: kAXTitleAttribute as CFString) ?? ""
+		let value = stringAttribute(element, attribute: kAXValueAttribute as CFString) ?? ""
+		let frame = frameForElement(element)
+		let centerX = frame.map { $0.midX } ?? 0
+		let centerY = frame.map { $0.midY } ?? 0
+		var payload: [String: Any] = [
+			key: true,
+			"elementRef": refStore.storeElement(element),
+			"role": role,
+			"subrole": subrole,
+			"title": title,
+			"value": value,
+			"actions": actionNames(element),
+			"x": centerX,
+			"y": centerY,
+		]
+		let secure = role == "AXSecureTextField" || subrole == "AXSecureTextField"
+		var valueSettable = DarwinBoolean(false)
+		let valueStatus = AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &valueSettable)
+		payload["isSecure"] = secure
+		payload["canSetValue"] = valueStatus == .success && valueSettable.boolValue
+		if let frame {
+			payload["frame"] = ["x": frame.origin.x, "y": frame.origin.y, "w": frame.width, "h": frame.height]
+		}
+		if let score {
+			payload["score"] = score
+		}
+		return payload
+	}
+
+	private func frameForElement(_ element: AXUIElement) -> CGRect? {
+		let origin = pointAttribute(element, attribute: kAXPositionAttribute as CFString)
+		let size = sizeAttribute(element, attribute: kAXSizeAttribute as CFString)
+		guard let origin, let size, size.width > 0, size.height > 0 else { return nil }
+		return CGRect(origin: origin, size: size)
+	}
+
+	private func pidForElement(_ element: AXUIElement) -> Int32? {
+		var pid: pid_t = 0
+		let status = AXUIElementGetPid(element, &pid)
+		guard status == .success else { return nil }
+		return Int32(pid)
+	}
+
+	private func parentElement(_ element: AXUIElement) -> AXUIElement? {
+		guard let value = copyAttribute(element, attribute: kAXParentAttribute as CFString) else {
+			return nil
+		}
+		return asAXElement(value)
+	}
+
+	private func supportsAction(_ element: AXUIElement, action: CFString) -> Bool {
+		actionNames(element).contains(action as String)
+	}
+
+	private func supportsPressAction(_ element: AXUIElement) -> Bool {
+		supportsAction(element, action: kAXPressAction as CFString)
+	}
+
+	private func actionNames(_ element: AXUIElement) -> [String] {
+		var actionsValue: CFArray?
+		let status = AXUIElementCopyActionNames(element, &actionsValue)
+		guard status == .success else { return [] }
+		guard let actionsArray = actionsValue as? [AnyObject] else { return [] }
+		return actionsArray.compactMap { $0 as? String }
+	}
+
+	private func copyAttribute(_ element: AXUIElement, attribute: CFString) -> AnyObject? {
+		var value: AnyObject?
+		let status = AXUIElementCopyAttributeValue(element, attribute, &value)
+		guard status == .success else { return nil }
+		return value
+	}
+
+	private func boolAttribute(_ element: AXUIElement, attribute: CFString) -> Bool? {
+		guard let value = copyAttribute(element, attribute: attribute) else { return nil }
+		if let boolValue = value as? Bool {
+			return boolValue
+		}
+		if let number = value as? NSNumber {
+			return number.boolValue
+		}
+		return nil
+	}
+
+	private func stringAttribute(_ element: AXUIElement, attribute: CFString) -> String? {
+		copyAttribute(element, attribute: attribute) as? String
+	}
+
+	private func axElementArray(_ element: AXUIElement, attribute: CFString) -> [AXUIElement] {
+		guard let value = copyAttribute(element, attribute: attribute) else { return [] }
+		if let array = value as? [AXUIElement] {
+			return array
+		}
+		if let anyArray = value as? [AnyObject] {
+			return anyArray.compactMap(asAXElement)
+		}
+		return []
+	}
+
+	private func asAXElement(_ value: AnyObject) -> AXUIElement? {
+		let cfValue = value as CFTypeRef
+		guard CFGetTypeID(cfValue) == AXUIElementGetTypeID() else { return nil }
+		return unsafeBitCast(cfValue, to: AXUIElement.self)
+	}
+
+	private func pointAttribute(_ element: AXUIElement, attribute: CFString) -> CGPoint? {
+		guard let value = copyAttribute(element, attribute: attribute) else { return nil }
+		let cfValue = value as CFTypeRef
+		guard CFGetTypeID(cfValue) == AXValueGetTypeID() else { return nil }
+		let axValue = unsafeBitCast(cfValue, to: AXValue.self)
+		guard AXValueGetType(axValue) == .cgPoint else { return nil }
+		var point = CGPoint.zero
+		guard AXValueGetValue(axValue, .cgPoint, &point) else { return nil }
+		return point
+	}
+
+	private func sizeAttribute(_ element: AXUIElement, attribute: CFString) -> CGSize? {
+		guard let value = copyAttribute(element, attribute: attribute) else { return nil }
+		let cfValue = value as CFTypeRef
+		guard CFGetTypeID(cfValue) == AXValueGetTypeID() else { return nil }
+		let axValue = unsafeBitCast(cfValue, to: AXValue.self)
+		guard AXValueGetType(axValue) == .cgSize else { return nil }
+		var size = CGSize.zero
+		guard AXValueGetValue(axValue, .cgSize, &size) else { return nil }
+		return size
+	}
+
+	private func frameForWindow(_ window: AXUIElement) -> CGRect {
+		let origin = pointAttribute(window, attribute: kAXPositionAttribute as CFString) ?? .zero
+		let size = sizeAttribute(window, attribute: kAXSizeAttribute as CFString) ?? .zero
+		return CGRect(origin: origin, size: size)
+	}
+
+	private func cgWindowCandidates(pid: Int32) -> [CGWindowCandidate] {
+		guard let entries = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] else {
+			return []
+		}
+
+		var candidates: [CGWindowCandidate] = []
+		for entry in entries {
+			guard let ownerPid = (entry[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+				ownerPid == pid
+			else {
+				continue
+			}
+			let layer = (entry[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
+			if layer != 0 { continue }
+			guard let windowNumber = (entry[kCGWindowNumber as String] as? NSNumber)?.uint32Value else {
+				continue
+			}
+			guard let boundsDict = entry[kCGWindowBounds as String] as? [String: Any],
+				let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary)
+			else {
+				continue
+			}
+
+			let title = (entry[kCGWindowName as String] as? String) ?? ""
+			let isOnscreen = (entry[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? true
+			candidates.append(CGWindowCandidate(windowId: windowNumber, title: title, bounds: bounds, isOnscreen: isOnscreen))
+		}
+		return candidates
+	}
+
+	private func bestCandidate(
+		frame: CGRect,
+		title: String,
+		candidates: [CGWindowCandidate],
+		usedIds: Set<UInt32>
+	) -> CGWindowCandidate? {
+		var best: (candidate: CGWindowCandidate, score: Double)?
+		let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+		for candidate in candidates where !usedIds.contains(candidate.windowId) {
+			var score = 0.0
+			let candidateTitle = candidate.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+			if !normalizedTitle.isEmpty {
+				if candidateTitle == normalizedTitle {
+					score += 100
+				} else if candidateTitle.contains(normalizedTitle) {
+					score += 50
+				}
+			}
+
+			let dx = abs(candidate.bounds.origin.x - frame.origin.x)
+			let dy = abs(candidate.bounds.origin.y - frame.origin.y)
+			let dw = abs(candidate.bounds.size.width - frame.size.width)
+			let dh = abs(candidate.bounds.size.height - frame.size.height)
+			score -= Double(dx + dy + dw + dh) / 20.0
+
+			if let currentBest = best {
+				if score > currentBest.score {
+					best = (candidate, score)
+				}
+			} else {
+				best = (candidate, score)
+			}
+		}
+
+		return best?.candidate
+	}
+
+	private func displayScaleFactor(for frame: CGRect) -> Double {
+		var displayCount: UInt32 = 0
+		guard CGGetOnlineDisplayList(0, nil, &displayCount) == .success, displayCount > 0 else {
+			return Double(NSScreen.main?.backingScaleFactor ?? 1.0)
+		}
+
+		var displays = Array(repeating: CGDirectDisplayID(), count: Int(displayCount))
+		guard CGGetOnlineDisplayList(displayCount, &displays, &displayCount) == .success else {
+			return Double(NSScreen.main?.backingScaleFactor ?? 1.0)
+		}
+
+		var chosenDisplay: CGDirectDisplayID?
+		var chosenArea: CGFloat = -1
+		for display in displays {
+			let bounds = CGDisplayBounds(display)
+			let overlap = bounds.intersection(frame)
+			let area = overlap.isNull ? 0 : overlap.width * overlap.height
+			if area > chosenArea {
+				chosenArea = area
+				chosenDisplay = display
+			}
+		}
+
+		guard let display = chosenDisplay, let mode = CGDisplayCopyDisplayMode(display) else {
+			return Double(NSScreen.main?.backingScaleFactor ?? 1.0)
+		}
+
+		let width = Double(mode.width)
+		guard width > 0 else { return 1.0 }
+		let scale = Double(mode.pixelWidth) / width
+		return scale > 0 ? scale : 1.0
+	}
+
+	private func captureWindow(windowId: UInt32) throws -> [String: Any] {
+		guard #available(macOS 14.0, *) else {
+			throw BridgeFailure(message: "Window capture requires macOS 14+", code: "unsupported_os")
+		}
+
+		let semaphore = DispatchSemaphore(value: 0)
+		let capturedImage = Box<CGImage?>(nil)
+		let capturedError = Box<Error?>(nil)
+
+		let task = Task {
+			defer { semaphore.signal() }
+			do {
+				if Task.isCancelled {
+					return
+				}
+				let shareable = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+				guard let window = shareable.windows.first(where: { $0.windowID == windowId }) else {
+					throw BridgeFailure(message: "Window \(windowId) is not available for capture", code: "window_not_found")
+				}
+
+				let filter = SCContentFilter(desktopIndependentWindow: window)
+				let config = SCStreamConfiguration()
+				config.showsCursor = false
+				if #available(macOS 14.0, *) {
+					config.ignoreShadowsSingleWindow = true
+				}
+
+				let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+				capturedImage.value = image
+			} catch {
+				capturedError.value = error
+			}
+		}
+
+		if semaphore.wait(timeout: .now() + .seconds(12)) == .timedOut {
+			task.cancel()
+			if let payload = try systemScreenshotWindow(windowId: windowId) {
+				return payload
+			}
+			throw BridgeFailure(message: "Screenshot timed out while capturing window \(windowId)", code: "screenshot_timeout")
+		}
+
+		if let error = capturedError.value {
+			if let payload = try systemScreenshotWindow(windowId: windowId) {
+				return payload
+			}
+			if let failure = error as? BridgeFailure {
+				throw failure
+			}
+			throw BridgeFailure(message: "Screenshot failed: \(error.localizedDescription)", code: "screenshot_failed")
+		}
+
+		guard let image = capturedImage.value else {
+			if let payload = try systemScreenshotWindow(windowId: windowId) {
+				return payload
+			}
+			throw BridgeFailure(message: "Screenshot failed", code: "screenshot_failed")
+		}
+
+		return try screenshotPayload(image: image, windowId: windowId)
+	}
+
+	private func screenshotPayload(image: CGImage, windowId: UInt32) throws -> [String: Any] {
+		guard let pngData = NSBitmapImageRep(cgImage: image).representation(using: .png, properties: [:]) else {
+			throw BridgeFailure(message: "Failed to encode screenshot as PNG", code: "encoding_failed")
+		}
+
+		let bounds = currentWindowBounds(windowId: windowId)
+		let scale = bounds.map { displayScaleFactor(for: $0) } ?? 1.0
+
+		return [
+			"pngBase64": pngData.base64EncodedString(),
+			"width": image.width,
+			"height": image.height,
+			"scaleFactor": scale,
+		]
+	}
+
+	private func systemScreenshotWindow(windowId: UInt32) throws -> [String: Any]? {
+		let tempUrl = FileManager.default.temporaryDirectory.appendingPathComponent("cowork-cu-\(UUID().uuidString).png")
+		defer { try? FileManager.default.removeItem(at: tempUrl) }
+
+		let process = Process()
+		process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+		process.arguments = ["-x", "-l", String(windowId), tempUrl.path]
+		try process.run()
+		process.waitUntilExit()
+		guard process.terminationStatus == 0 else { return nil }
+		guard let data = try? Data(contentsOf: tempUrl), !data.isEmpty else { return nil }
+		guard let imageRep = NSBitmapImageRep(data: data), let cgImage = imageRep.cgImage else { return nil }
+		return try screenshotPayload(image: cgImage, windowId: windowId)
+	}
+
+	private func currentWindowBounds(windowId: UInt32) -> CGRect? {
+		if #available(macOS 14.0, *), let scBounds = currentWindowBoundsViaScreenCaptureKit(windowId: windowId) {
+			return scBounds
+		}
+
+		guard let descriptions = CGWindowListCreateDescriptionFromArray([NSNumber(value: windowId)] as CFArray) as? [[String: Any]],
+			let first = descriptions.first,
+			let boundsDict = first[kCGWindowBounds as String] as? [String: Any],
+			let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary)
+		else {
+			return nil
+		}
+		return bounds
+	}
+
+	@available(macOS 14.0, *)
+	private func currentWindowBoundsViaScreenCaptureKit(windowId: UInt32) -> CGRect? {
+		let semaphore = DispatchSemaphore(value: 0)
+		let output = Box<CGRect?>(nil)
+
+		let task = Task {
+			defer { semaphore.signal() }
+			do {
+				if Task.isCancelled {
+					return
+				}
+				let shareable = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+				if let window = shareable.windows.first(where: { $0.windowID == windowId }) {
+					output.value = window.frame
+				}
+			} catch {
+				output.value = nil
+			}
+		}
+
+		if semaphore.wait(timeout: .now() + .seconds(2)) == .timedOut {
+			task.cancel()
+			return nil
+		}
+		return output.value
+	}
+
+	private func mapWindowPoint(
+		windowId: UInt32,
+		x: Double,
+		y: Double,
+		captureWidth: Double,
+		captureHeight: Double
+	) throws -> CGPoint {
+		guard let bounds = currentWindowBounds(windowId: windowId) else {
+			throw BridgeFailure(message: "Target window is no longer available", code: "window_not_found")
+		}
+
+		let relX = min(max(x / captureWidth, 0), 1)
+		let relY = min(max(y / captureHeight, 0), 1)
+		let screenX = bounds.origin.x + bounds.size.width * relX
+		let screenY = bounds.origin.y + bounds.size.height * relY
+		return CGPoint(x: screenX, y: screenY)
+	}
+
+	private func modifierFlags(_ modifiers: [String]) throws -> CGEventFlags {
+		var flags: CGEventFlags = []
+		for modifier in modifiers {
+			switch modifier.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+			case "command", "cmd":
+				flags.insert(.maskCommand)
+			case "control", "ctrl":
+				flags.insert(.maskControl)
+			case "option", "alt":
+				flags.insert(.maskAlternate)
+			case "shift":
+				flags.insert(.maskShift)
+			case "":
+				continue
+			default:
+				throw BridgeFailure(message: "Unsupported modifier '\(modifier)'", code: "invalid_args")
+			}
+		}
+		return flags
+	}
+
+	private func postEvent(_ event: CGEvent, pid: Int32) {
+		event.postToPid(pid)
+	}
+
+	private func postMouseMove(to point: CGPoint, pid: Int32) throws {
+		guard let move = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) else {
+			throw BridgeFailure(message: "Failed to create mouse move event", code: "input_failed")
+		}
+		postEvent(move, pid: pid)
+	}
+
+	private func postMouseClick(
+		at point: CGPoint,
+		pid: Int32,
+		button: CGMouseButton,
+		downType: CGEventType,
+		upType: CGEventType,
+		clickCount: Int
+	) throws {
+		try postMouseMove(to: point, pid: pid)
+		for index in 0..<clickCount {
+			guard let down = CGEvent(mouseEventSource: nil, mouseType: downType, mouseCursorPosition: point, mouseButton: button),
+				let up = CGEvent(mouseEventSource: nil, mouseType: upType, mouseCursorPosition: point, mouseButton: button)
+			else {
+				throw BridgeFailure(message: "Failed to create mouse click event", code: "input_failed")
+			}
+			down.setIntegerValueField(.mouseEventClickState, value: Int64(index + 1))
+			up.setIntegerValueField(.mouseEventClickState, value: Int64(index + 1))
+			postEvent(down, pid: pid)
+			usleep(12_000)
+			postEvent(up, pid: pid)
+			if index + 1 < clickCount {
+				usleep(50_000)
+			}
+		}
+	}
+
+	private func postMouseDrag(through points: [CGPoint], pid: Int32) throws {
+		guard points.count >= 2 else {
+			throw BridgeFailure(message: "mouseDrag requires at least two points", code: "invalid_args")
+		}
+		let start = points[0]
+		try postMouseMove(to: start, pid: pid)
+		guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: start, mouseButton: .left) else {
+			throw BridgeFailure(message: "Failed to create mouse down event", code: "input_failed")
+		}
+		postEvent(down, pid: pid)
+		usleep(50_000)
+		for point in points.dropFirst() {
+			guard let drag = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDragged, mouseCursorPosition: point, mouseButton: .left) else {
+				throw BridgeFailure(message: "Failed to create mouse drag event", code: "input_failed")
+			}
+			postEvent(drag, pid: pid)
+			usleep(10_000)
+		}
+		guard let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: points[points.count - 1], mouseButton: .left) else {
+			throw BridgeFailure(message: "Failed to create mouse up event", code: "input_failed")
+		}
+		postEvent(up, pid: pid)
+	}
+
+	private func postScroll(at point: CGPoint, pid: Int32, scrollX: Int, scrollY: Int) throws {
+		try postMouseMove(to: point, pid: pid)
+		guard let scroll = CGEvent(
+			scrollWheelEvent2Source: nil,
+			units: .line,
+			wheelCount: 2,
+			wheel1: Int32(scrollY),
+			wheel2: Int32(scrollX),
+			wheel3: 0
+		) else {
+			throw BridgeFailure(message: "Failed to create scroll event", code: "input_failed")
+		}
+		postEvent(scroll, pid: pid)
+	}
+
+	private func postUnicodeText(_ text: String, pid: Int32) throws {
+		for scalar in text.unicodeScalars {
+			let char = String(scalar)
+			guard let down = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+				let up = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)
+			else {
+				throw BridgeFailure(message: "Failed to create unicode key event", code: "input_failed")
+			}
+			setUnicodeString(event: down, text: char)
+			setUnicodeString(event: up, text: char)
+			postEvent(down, pid: pid)
+			usleep(8_000)
+			postEvent(up, pid: pid)
+		}
+	}
+
+	private func postKeyPress(pid: Int32, keyCode: Int?, keyText: String?, modifiers: [String]) throws {
+		let flags = try modifierFlags(modifiers)
+		if let keyCode {
+			guard let down = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(keyCode), keyDown: true),
+				let up = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(keyCode), keyDown: false)
+			else {
+				throw BridgeFailure(message: "Failed to create key press event", code: "input_failed")
+			}
+			down.flags = flags
+			up.flags = flags
+			postEvent(down, pid: pid)
+			usleep(8_000)
+			postEvent(up, pid: pid)
+			return
+		}
+
+		guard let keyText, !keyText.isEmpty else {
+			throw BridgeFailure(message: "keyPress requires keyCode or keyText", code: "invalid_args")
+		}
+		guard let down = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+			let up = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)
+		else {
+			throw BridgeFailure(message: "Failed to create unicode key event", code: "input_failed")
+		}
+		down.flags = flags
+		up.flags = flags
+		setUnicodeString(event: down, text: keyText)
+		setUnicodeString(event: up, text: keyText)
+		postEvent(down, pid: pid)
+		usleep(8_000)
+		postEvent(up, pid: pid)
+	}
+
+	private func setUnicodeString(event: CGEvent, text: String) {
+		var utf16 = Array(text.utf16)
+		utf16.withUnsafeMutableBufferPointer { buffer in
+			guard let base = buffer.baseAddress else { return }
+			event.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: base)
+		}
+	}
+}
+
+let bridge = Bridge()
+bridge.run()

--- a/src/electron/agent/__tests__/executor-tool-allowlist.test.ts
+++ b/src/electron/agent/__tests__/executor-tool-allowlist.test.ts
@@ -114,11 +114,35 @@ describe("TaskExecutor tool allow-list semantics", () => {
     );
 
     expect(allowlist.has("open_application")).toBe(true);
-    expect(allowlist.has("computer_screenshot")).toBe(true);
-    expect(allowlist.has("computer_click")).toBe(true);
-    expect(allowlist.has("computer_type")).toBe(true);
-    expect(allowlist.has("computer_key")).toBe(true);
-    expect(allowlist.has("computer_move_mouse")).toBe(true);
+    expect(allowlist.has("screenshot")).toBe(true);
+    expect(allowlist.has("click")).toBe(true);
+    expect(allowlist.has("type_text")).toBe(true);
+    expect(allowlist.has("keypress")).toBe(true);
+    expect(allowlist.has("move_mouse")).toBe(true);
+    expect(allowlist.has("run_command")).toBe(false);
+    expect(allowlist.has("run_applescript")).toBe(false);
+  });
+
+  it("keeps run_command available for terminal-style native steps with explicit shell intent", () => {
+    const executor = Object.create(TaskExecutor.prototype) as Any;
+    executor.task = {
+      title: "Open Terminal",
+      prompt: "Open Terminal and run git status.",
+      agentConfig: {
+        taskIntent: "execution",
+      },
+    };
+    executor.getEffectiveExecutionMode = vi.fn().mockReturnValue("execute");
+
+    const allowlist = (TaskExecutor as Any).prototype.buildStepToolAllowlist.call(
+      executor,
+      { requiredTools: new Set<string>() },
+      "analysis",
+      "operations",
+      "Open Terminal and run git status in the current repo.",
+    );
+
+    expect(allowlist.has("run_command")).toBe(true);
   });
 
   it("includes parse_document but not read_pdf_visual for ordinary PDF reading steps", () => {

--- a/src/electron/agent/tools/__tests__/builtin-settings.test.ts
+++ b/src/electron/agent/tools/__tests__/builtin-settings.test.ts
@@ -71,10 +71,10 @@ describe("BuiltinToolsSettingsManager - webfetch category", () => {
       expect(defaults.categories.search.priority).toBe("normal");
     });
 
-    it("should default to per-command run_command approval mode", () => {
+    it("should default to single-bundle run_command approval mode", () => {
       const defaults = BuiltinToolsSettingsManager.getDefaultSettings();
-      expect(defaults.runCommandApprovalMode).toBe("per_command");
-      expect(BuiltinToolsSettingsManager.getRunCommandApprovalMode()).toBe("per_command");
+      expect(defaults.runCommandApprovalMode).toBe("single_bundle");
+      expect(BuiltinToolsSettingsManager.getRunCommandApprovalMode()).toBe("single_bundle");
     });
 
     it("should default Codex runtime mode to native", () => {
@@ -154,18 +154,30 @@ describe("BuiltinToolsSettingsManager - webfetch category", () => {
       expect(toolsByCategory.search).toContain("web_search");
     });
 
-    it("should include computer_* tools in computer_use category", () => {
+    it("should include Pi-style computer-use tools in computer_use category", () => {
       const toolsByCategory = BuiltinToolsSettingsManager.getToolsByCategory();
 
       expect(toolsByCategory.computer_use).toBeDefined();
-      expect(toolsByCategory.computer_use).toContain("computer_screenshot");
-      expect(toolsByCategory.computer_use).toContain("computer_click");
-      expect(toolsByCategory.computer_use).toContain("computer_type");
+      expect(toolsByCategory.computer_use).toContain("screenshot");
+      expect(toolsByCategory.computer_use).toContain("click");
+      expect(toolsByCategory.computer_use).toContain("type_text");
+    });
+
+    it("should include screen_context_resolve in chronicle category", () => {
+      const toolsByCategory = BuiltinToolsSettingsManager.getToolsByCategory();
+
+      expect(toolsByCategory.chronicle).toBeDefined();
+      expect(toolsByCategory.chronicle).toContain("screen_context_resolve");
     });
 
     it("should default-enable computer_use category", () => {
       const defaults = BuiltinToolsSettingsManager.getDefaultSettings();
       expect(defaults.categories.computer_use.enabled).toBe(true);
+    });
+
+    it("should default-enable chronicle category", () => {
+      const defaults = BuiltinToolsSettingsManager.getDefaultSettings();
+      expect(defaults.categories.chronicle.enabled).toBe(true);
     });
   });
 

--- a/src/electron/agent/tools/__tests__/runtime-tool-definition.test.ts
+++ b/src/electron/agent/tools/__tests__/runtime-tool-definition.test.ts
@@ -65,4 +65,11 @@ describe("runtime tool definition metadata", () => {
     expect(pdfMetadata.approvalKind).toBe("data_export");
     expect(pdfMetadata.sideEffectLevel).toBe("high");
   });
+
+  it("treats screen_context_resolve as a read-parallel local screen lookup", () => {
+    const metadata = getDefaultRuntimeToolMetadata("screen_context_resolve");
+    expect(metadata.readOnly).toBe(true);
+    expect(metadata.concurrencyClass).toBe("read_parallel");
+    expect(metadata.approvalKind).toBe("none");
+  });
 });

--- a/src/electron/agent/tools/builtin-settings.ts
+++ b/src/electron/agent/tools/builtin-settings.ts
@@ -44,6 +44,7 @@ export interface BuiltinToolsSettings {
     skill: ToolCategoryConfig;
     shell: ToolCategoryConfig;
     image: ToolCategoryConfig;
+    chronicle: ToolCategoryConfig;
     computer_use: ToolCategoryConfig;
   };
   // Individual tool overrides (tool name -> override)
@@ -108,7 +109,12 @@ const DEFAULT_SETTINGS: BuiltinToolsSettings = {
     image: {
       enabled: true,
       priority: "normal",
-      description: "AI image generation (requires Gemini API)",
+      description: "AI image generation (Gemini, OpenAI, OpenAI OAuth, Azure, OpenRouter)",
+    },
+    chronicle: {
+      enabled: true,
+      priority: "normal",
+      description: "Chronicle screen-context tools (local passive screen recall and disambiguation)",
     },
     computer_use: {
       enabled: true,
@@ -119,7 +125,7 @@ const DEFAULT_SETTINGS: BuiltinToolsSettings = {
   toolOverrides: {},
   toolTimeouts: {},
   toolAutoApprove: {},
-  runCommandApprovalMode: "per_command",
+  runCommandApprovalMode: "single_bundle",
   codexRuntimeMode: "native",
   version: "1.0.0",
 };
@@ -186,11 +192,16 @@ const TOOL_CATEGORIES: Record<string, keyof BuiltinToolsSettings["categories"]> 
   get_app_paths: "system",
   run_applescript: "system",
   // Computer use tools
-  computer_screenshot: "computer_use",
-  computer_click: "computer_use",
-  computer_type: "computer_use",
-  computer_key: "computer_use",
-  computer_move_mouse: "computer_use",
+  screen_context_resolve: "chronicle",
+  screenshot: "computer_use",
+  click: "computer_use",
+  double_click: "computer_use",
+  move_mouse: "computer_use",
+  drag: "computer_use",
+  scroll: "computer_use",
+  type_text: "computer_use",
+  keypress: "computer_use",
+  wait: "computer_use",
   batch_image_process: "computer_use",
   // File tools
   read_file: "file",
@@ -209,6 +220,7 @@ const TOOL_CATEGORIES: Record<string, keyof BuiltinToolsSettings["categories"]> 
   generate_spreadsheet: "skill",
   create_document: "skill",
   generate_document: "skill",
+  compile_latex: "skill",
   edit_document: "skill",
   edit_pdf_region: "skill",
   create_presentation: "skill",
@@ -359,7 +371,9 @@ export class BuiltinToolsSettingsManager {
       toolTimeouts: settings.toolTimeouts || {},
       toolAutoApprove: settings.toolAutoApprove || {},
       runCommandApprovalMode:
-        settings.runCommandApprovalMode === "single_bundle" ? "single_bundle" : "per_command",
+        settings.runCommandApprovalMode === "per_command"
+          ? "per_command"
+          : defaults.runCommandApprovalMode,
       codexRuntimeMode: settings.codexRuntimeMode === "acpx" ? "acpx" : "native",
       version: settings.version || defaults.version,
     };
@@ -438,7 +452,9 @@ export class BuiltinToolsSettingsManager {
    */
   static getRunCommandApprovalMode(): RunCommandApprovalMode {
     const settings = this.loadSettings();
-    return settings.runCommandApprovalMode === "single_bundle" ? "single_bundle" : "per_command";
+    return settings.runCommandApprovalMode === "per_command"
+      ? "per_command"
+      : this.getDefaultSettings().runCommandApprovalMode;
   }
 
   /**

--- a/src/electron/agent/tools/computer-use-tools.ts
+++ b/src/electron/agent/tools/computer-use-tools.ts
@@ -1,29 +1,24 @@
-import { exec } from "child_process";
-import { promisify } from "util";
-import * as os from "os";
 import * as crypto from "crypto";
 import { Workspace } from "../../../shared/types";
 import { AgentDaemon } from "../daemon";
 import { LLMTool } from "../llm/types";
-import type { AppAccessLevel } from "../../security/app-permission-manager";
 import { ComputerUseSessionManager } from "../../computer-use/session-manager";
 import {
-  getMacScreenCaptureAccessStatus,
-  checkAccessibilityTrusted,
-} from "../../computer-use/computer-use-permissions";
+  ComputerUseHelperRuntime,
+  type ComputerUseHelperApp,
+  type ComputerUseHelperKeypressSpec,
+  type ComputerUseHelperMouseButton,
+  type ComputerUseHelperFramePoints,
+  type ComputerUseHelperWindow,
+  isRecoverableScreenshotError,
+} from "../../computer-use/helper-runtime";
 
-type Any = any; // oxlint-disable-line typescript-eslint(no-explicit-any)
+const CUA_CAPTURE_REFRESH_WAIT_MS = 150;
+const CUA_SCREENSHOT_RETRY_WAIT_MS = 250;
+const DEFAULT_WAIT_MS = 1_000;
+const MAX_WAIT_MS = 30_000;
+const CONTROLLED_WINDOW_ERROR = "No controlled window is selected. Call screenshot() first.";
 
-const execAsync = promisify(exec);
-
-const CUA_ACTION_TIMEOUT_MS = 15_000;
-const SCREENSHOT_MAX_DIMENSION = 2560;
-const DESKTOP_CAPTURER_TIMEOUT_MS = 12_000;
-
-/**
- * Blocked key combinations that must never be emitted during computer use.
- * These are OS-level shortcuts that could disrupt the session or compromise safety.
- */
 const BLOCKED_KEY_COMBOS = new Set([
   "cmd+tab",
   "command+tab",
@@ -40,782 +35,1184 @@ function normalizeKeysForBlocklist(keys: string[]): string {
   return keys.map((k) => k.toLowerCase().trim()).sort().join("+");
 }
 
-function getElectronScreen(): Any {
-  try {
-    // oxlint-disable-next-line typescript-eslint(no-require-imports)
-    const electron = require("electron") as Any;
-    return electron?.screen;
-  } catch {
-    return undefined;
-  }
+export type ComputerUseMouseButton = "left" | "right" | "wheel" | "back" | "forward";
+
+interface ComputerUseTargetState {
+  appName: string;
+  bundleId?: string;
+  pid: number;
+  windowId: number;
+  windowTitle: string;
+  framePoints: ComputerUseHelperFramePoints;
+  scaleFactor: number;
+  isMinimized: boolean;
+  isOnscreen: boolean;
+  isMain: boolean;
+  isFocused: boolean;
 }
 
-function getElectronDesktopCapturer(): Any {
-  try {
-    // oxlint-disable-next-line typescript-eslint(no-require-imports)
-    const electron = require("electron") as Any;
-    return electron?.desktopCapturer;
-  } catch {
-    return undefined;
-  }
-}
-
-export type CUAClickButton = "left" | "right" | "middle";
-export type CUAClickType = "single" | "double" | "triple";
-
-export interface CUAScreenshotResult {
-  base64: string;
+interface ComputerUseCaptureState {
+  id: string;
+  windowId: number;
   width: number;
   height: number;
+  scaleFactor: number;
+  imageBase64: string;
   hash: string;
+  createdAt: number;
 }
 
-async function getDesktopSourcesWithTimeout(
-  desktopCapturer: Any,
-  opts: { types: string[]; thumbnailSize: { width: number; height: number } },
-  timeoutMs: number,
-): Promise<Any[]> {
-  const promise = desktopCapturer.getSources(opts);
-  const timeout = new Promise<never>((_, reject) => {
-    setTimeout(() => {
-      reject(
-        new Error(
-          "Screen capture timed out. Grant Screen Recording for CoWork OS in System Settings > Privacy & Security > Screen Recording, then restart the app if needed.",
-        ),
-      );
-    }, timeoutMs);
+interface PersistedComputerUseState {
+  currentTarget: ComputerUseTargetState | null;
+  currentCapture: ComputerUseCaptureState | null;
+}
+
+export interface ComputerUseToolResult {
+  captureId: string;
+  imageBase64: string;
+  mediaType: "image/png";
+  width: number;
+  height: number;
+  scaleFactor: number;
+  createdAt: number;
+  target: {
+    appName: string;
+    bundleId?: string;
+    pid: number;
+    windowId: number;
+    windowTitle: string;
+    framePoints: ComputerUseHelperFramePoints;
+  };
+  action?: string;
+  note?: string;
+}
+
+interface ScreenshotSelection {
+  app?: string;
+  windowTitle?: string;
+}
+
+interface ActionPreparationResult {
+  target: ComputerUseTargetState;
+  capture: ComputerUseCaptureState;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
   });
-  return (await Promise.race([promise, timeout])) as Any[];
+}
+
+function normalizeQuery(value: string | undefined): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function formatWindowChoice(appName: string, windowTitle: string): string {
+  return windowTitle.trim() ? `${appName} — ${windowTitle}` : `${appName} — <untitled window>`;
+}
+
+function exactOrContainsScore(value: string | undefined, query: string): number {
+  const normalizedValue = normalizeQuery(value);
+  if (!query) return 0;
+  if (!normalizedValue) return 0;
+  if (normalizedValue === query) return 100;
+  if (normalizedValue.startsWith(query)) return 70;
+  if (normalizedValue.includes(query)) return 50;
+  return 0;
+}
+
+function scoreWindow(window: ComputerUseHelperWindow): number {
+  let score = 0;
+  if (window.isFocused) score += 100;
+  if (window.isMain) score += 80;
+  if (!window.isMinimized) score += 40;
+  if (window.isOnscreen) score += 20;
+  if (typeof window.windowId === "number") score += 10;
+  if (window.title.trim()) score += 5;
+  return score;
+}
+
+function requireFiniteCoordinate(label: string, value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number.`);
+  }
+  return value;
+}
+
+function requireIntegerInRange(label: string, value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number.`);
+  }
+  const rounded = Math.trunc(value);
+  if (rounded < min || rounded > max) {
+    throw new Error(`${label} must be between ${min} and ${max}.`);
+  }
+  return rounded;
+}
+
+function validatePointInCapture(
+  x: number,
+  y: number,
+  capture: ComputerUseCaptureState,
+  errorPrefix = "Coordinates",
+): void {
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    throw new Error(`${errorPrefix} must be finite numbers.`);
+  }
+  if (x < 0 || y < 0 || x >= capture.width || y >= capture.height) {
+    throw new Error(
+      `${errorPrefix} (${Math.round(x)},${Math.round(y)}) are outside the latest screenshot bounds (${capture.width}x${capture.height}). Call screenshot() again and retry.`,
+    );
+  }
+}
+
+function frameDistanceScore(
+  current: ComputerUseHelperFramePoints,
+  previous: ComputerUseHelperFramePoints,
+): number {
+  const dx = Math.abs(current.x - previous.x);
+  const dy = Math.abs(current.y - previous.y);
+  const dw = Math.abs(current.w - previous.w);
+  const dh = Math.abs(current.h - previous.h);
+  return dx + dy + dw + dh;
+}
+
+const MAC_VIRTUAL_KEY_CODES: Record<string, number> = {
+  a: 0,
+  s: 1,
+  d: 2,
+  f: 3,
+  h: 4,
+  g: 5,
+  z: 6,
+  x: 7,
+  c: 8,
+  v: 9,
+  b: 11,
+  q: 12,
+  w: 13,
+  e: 14,
+  r: 15,
+  y: 16,
+  t: 17,
+  "1": 18,
+  "2": 19,
+  "3": 20,
+  "4": 21,
+  "6": 22,
+  "5": 23,
+  "=": 24,
+  "9": 25,
+  "7": 26,
+  "-": 27,
+  "8": 28,
+  "0": 29,
+  "]": 30,
+  o: 31,
+  u: 32,
+  "[": 33,
+  i: 34,
+  p: 35,
+  l: 37,
+  j: 38,
+  "'": 39,
+  k: 40,
+  ";": 41,
+  "\\": 42,
+  ",": 43,
+  "/": 44,
+  n: 45,
+  m: 46,
+  ".": 47,
+  "`": 50,
+};
+
+function parseKeypressSpec(pid: number, keys: string[]): ComputerUseHelperKeypressSpec {
+  const modifiers: string[] = [];
+  let keyText: string | null = null;
+  let keyCode: number | null = null;
+
+  for (const key of keys) {
+    const trimmed = key.trim();
+    const lower = trimmed.toLowerCase();
+    if (lower === "cmd" || lower === "command") {
+      modifiers.push("command");
+      continue;
+    }
+    if (lower === "ctrl" || lower === "control") {
+      modifiers.push("control");
+      continue;
+    }
+    if (lower === "alt" || lower === "option") {
+      modifiers.push("option");
+      continue;
+    }
+    if (lower === "shift") {
+      modifiers.push("shift");
+      continue;
+    }
+
+    if (lower === "return" || lower === "enter") {
+      keyCode = 36;
+    } else if (lower === "escape" || lower === "esc") {
+      keyCode = 53;
+    } else if (lower === "tab") {
+      keyCode = 48;
+    } else if (lower === "space") {
+      keyCode = 49;
+    } else if (lower === "delete" || lower === "backspace") {
+      keyCode = 51;
+    } else if (lower === "up") {
+      keyCode = 126;
+    } else if (lower === "down") {
+      keyCode = 125;
+    } else if (lower === "left") {
+      keyCode = 123;
+    } else if (lower === "right") {
+      keyCode = 124;
+    } else if (lower === "home") {
+      keyCode = 115;
+    } else if (lower === "end") {
+      keyCode = 119;
+    } else if (lower === "pageup") {
+      keyCode = 116;
+    } else if (lower === "pagedown") {
+      keyCode = 121;
+    } else if (lower.startsWith("f") && /^f\d{1,2}$/.test(lower)) {
+      const fkeyMap: Record<string, number> = {
+        f1: 122,
+        f2: 120,
+        f3: 99,
+        f4: 118,
+        f5: 96,
+        f6: 97,
+        f7: 98,
+        f8: 100,
+        f9: 101,
+        f10: 109,
+        f11: 103,
+        f12: 111,
+      };
+      keyCode = fkeyMap[lower] ?? null;
+    } else if (lower in MAC_VIRTUAL_KEY_CODES) {
+      keyCode = MAC_VIRTUAL_KEY_CODES[lower];
+    } else if (trimmed.length === 1) {
+      keyText = trimmed;
+    } else {
+      keyText = trimmed;
+    }
+  }
+
+  if (keyCode === null && !keyText) {
+    throw new Error(`Could not resolve key combination: ${keys.join("+")}`);
+  }
+  if (modifiers.length > 0 && keyCode === null && keyText) {
+    const originalText = keyText;
+    const lowered = originalText.toLowerCase();
+    if (lowered in MAC_VIRTUAL_KEY_CODES) {
+      keyCode = MAC_VIRTUAL_KEY_CODES[lowered];
+      keyText = null;
+      if (originalText !== lowered && !modifiers.includes("shift")) {
+        modifiers.push("shift");
+      }
+    }
+  }
+
+  return {
+    pid,
+    ...(keyCode !== null ? { keyCode } : { keyText: keyText! }),
+    ...(modifiers.length > 0 ? { modifiers } : {}),
+  };
 }
 
 /**
- * ComputerUseTools provides native OS-level mouse, keyboard, and screenshot
- * control for computer use agent (CUA) workflows.
- *
- * On macOS this uses AppleScript / CoreGraphics via shell commands.
- * A single computer-use session per machine applies: per-app consent for the session,
- * safety overlay, and Esc to stop.
+ * Pi-style computer-use tools:
+ * - stateful target window chosen by screenshot()
+ * - helper-managed permissions and window capture
+ * - every successful action returns a fresh screenshot + captureId
  */
 export class ComputerUseTools {
-  private lastScreenshotHash: string | null = null;
+  private static persistedState = new Map<string, PersistedComputerUseState>();
+
+  private currentTarget: ComputerUseTargetState | null = null;
+  private currentCapture: ComputerUseCaptureState | null = null;
 
   constructor(
     private workspace: Workspace,
     private daemon: AgentDaemon,
     private taskId: string,
-  ) {}
+  ) {
+    const saved = ComputerUseTools.persistedState.get(taskId);
+    this.currentTarget = saved?.currentTarget ?? null;
+    this.currentCapture = saved?.currentCapture ?? null;
+  }
 
   setWorkspace(workspace: Workspace): void {
     this.workspace = workspace;
+  }
+
+  private helper(): ComputerUseHelperRuntime {
+    return ComputerUseHelperRuntime.getInstance();
   }
 
   private session(): ComputerUseSessionManager {
     return ComputerUseSessionManager.getInstance();
   }
 
-  private pm() {
-    return this.session().acquire(this.taskId, this.daemon);
+  private persistState(): void {
+    ComputerUseTools.persistedState.set(this.taskId, {
+      currentTarget: this.currentTarget,
+      currentCapture: this.currentCapture,
+    });
   }
 
-  // ───────────── Accessibility permission check ─────────────
-
-  /**
-   * Check (and optionally prompt) for macOS Accessibility permission.
-   * Returns true if granted.
-   */
-  async checkAccessibilityPermission(): Promise<boolean> {
-    if (os.platform() !== "darwin") {
-      return false;
+  private async ensureReady(): Promise<void> {
+    if (process.platform !== "darwin") {
+      throw new Error("Computer use is only supported on macOS.");
     }
-    return checkAccessibilityTrusted(true);
-  }
-
-  private async ensureAccessibility(): Promise<void> {
-    if (os.platform() !== "darwin") {
-      throw new Error("Computer use tools are currently only supported on macOS");
-    }
-    const granted = await this.checkAccessibilityPermission();
-    if (!granted) {
-      throw new Error(
-        "Accessibility permission is required for computer use. " +
-          "Please grant access in System Settings > Privacy & Security > Accessibility.",
-      );
-    }
-  }
-
-  private async ensureScreenCaptureAllowed(): Promise<void> {
-    if (os.platform() !== "darwin") return;
-    const status = getMacScreenCaptureAccessStatus();
-    if (status === "denied") {
-      throw new Error(
-        "Screen Recording is denied for CoWork OS. Enable it in System Settings > Privacy & Security > Screen Recording, then restart the app.",
-      );
-    }
-    // "not-determined" / "unknown" — still attempt capture (may prompt / register app)
-  }
-
-  private async ensureAppPermission(
-    toolName: string,
-    minimumLevel: AppAccessLevel,
-    reason: string,
-  ): Promise<{ name: string; bundleId: string }> {
+    this.session().acquire(this.taskId, this.daemon);
     this.session().checkNotAborted();
-    const pm = this.pm();
-    const app = await this.getFrontmostApp();
-    const existing = pm.getPermission(app.name, app.bundleId);
-    if (!existing || !pm.isToolAllowed(app.name, toolName, app.bundleId)) {
-      const granted = await pm.requestPermission(app.name, app.bundleId, minimumLevel, reason);
-      if (granted === "denied" || !pm.isToolAllowed(app.name, toolName, app.bundleId)) {
-        throw new Error(
-          `Computer use access for ${app.name} is not approved for this session (${minimumLevel}).`,
-        );
-      }
-      await this.session().onAppPermissionGranted();
-    }
-
-    return app;
+    await this.helper().ensureReadyWithInteractivePermissions();
   }
 
-  // ───────────── Mouse control ─────────────
+  private async bringTargetToFront(target: ComputerUseTargetState): Promise<void> {
+    await this.helper().unminimizeWindow(target.pid, target.windowId);
+    await this.helper().activateApp(target.pid);
+    await this.helper().raiseWindow(target.pid, target.windowId);
+    await sleep(CUA_CAPTURE_REFRESH_WAIT_MS);
+  }
 
-  async moveMouse(x: number, y: number): Promise<{ success: boolean; x: number; y: number }> {
-    await this.ensureAccessibility();
-    this.session().updateActionStatus("Moving pointer…");
-    const app = await this.ensureAppPermission(
-      "computer_move_mouse",
-      "view_only",
-      "Move the cursor in the frontmost application.",
-    );
+  private makeCaptureState(
+    target: ComputerUseTargetState,
+    payload: { pngBase64: string; width: number; height: number; scaleFactor: number },
+  ): ComputerUseCaptureState {
+    const imageBuffer = Buffer.from(payload.pngBase64, "base64");
+    const hash = crypto.createHash("sha256").update(imageBuffer).digest("hex").slice(0, 16);
+    return {
+      id: `cap_${Date.now()}_${hash}`,
+      windowId: target.windowId,
+      width: payload.width,
+      height: payload.height,
+      scaleFactor: payload.scaleFactor,
+      imageBase64: payload.pngBase64,
+      hash,
+      createdAt: Date.now(),
+    };
+  }
 
-    this.daemon.logEvent(this.taskId, "tool_call", {
-      tool: "computer_move_mouse",
-      appName: app.name,
+  private buildResult(action?: string, note?: string): ComputerUseToolResult {
+    if (!this.currentTarget || !this.currentCapture) {
+      throw new Error("Computer-use state is missing the current target screenshot.");
+    }
+    return {
+      captureId: this.currentCapture.id,
+      imageBase64: this.currentCapture.imageBase64,
+      mediaType: "image/png",
+      width: this.currentCapture.width,
+      height: this.currentCapture.height,
+      scaleFactor: this.currentCapture.scaleFactor,
+      createdAt: this.currentCapture.createdAt,
+      target: {
+        appName: this.currentTarget.appName,
+        bundleId: this.currentTarget.bundleId,
+        pid: this.currentTarget.pid,
+        windowId: this.currentTarget.windowId,
+        windowTitle: this.currentTarget.windowTitle,
+        framePoints: this.currentTarget.framePoints,
+      },
+      ...(action ? { action } : {}),
+      ...(note ? { note } : {}),
+    };
+  }
+
+  private async captureTarget(toolName: string, note?: string): Promise<ComputerUseToolResult> {
+    if (!this.currentTarget) {
+      throw new Error(CONTROLLED_WINDOW_ERROR);
+    }
+    let payload;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        payload = await this.helper().screenshot(this.currentTarget.windowId);
+        break;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (
+          attempt > 0 ||
+          (!isRecoverableScreenshotError(error) && !/audio\/video capture failure/i.test(message))
+        ) {
+          throw error;
+        }
+        this.currentTarget = await this.refreshCurrentTarget();
+        await this.bringTargetToFront(this.currentTarget);
+        await sleep(CUA_SCREENSHOT_RETRY_WAIT_MS);
+      }
+    }
+    if (!payload) {
+      throw new Error("Failed to capture the current controlled window.");
+    }
+    this.currentCapture = this.makeCaptureState(this.currentTarget, payload);
+    this.persistState();
+    this.daemon.logEvent(this.taskId, "tool_result", {
+      tool: toolName,
+      success: true,
+      captureId: this.currentCapture.id,
+      width: payload.width,
+      height: payload.height,
+      targetApp: this.currentTarget.appName,
+      windowId: this.currentTarget.windowId,
+      windowTitle: this.currentTarget.windowTitle,
+    });
+    return this.buildResult(toolName, note);
+  }
+
+  private toTargetState(app: ComputerUseHelperApp, window: ComputerUseHelperWindow): ComputerUseTargetState {
+    if (typeof window.windowId !== "number") {
+      throw new Error(
+        `The selected window in ${app.appName} cannot be controlled because macOS did not expose a stable window id.`,
+      );
+    }
+    return {
+      appName: app.appName,
       bundleId: app.bundleId,
-      x,
-      y,
+      pid: app.pid,
+      windowId: window.windowId,
+      windowTitle: window.title,
+      framePoints: window.framePoints,
+      scaleFactor: window.scaleFactor,
+      isMinimized: window.isMinimized,
+      isOnscreen: window.isOnscreen,
+      isMain: window.isMain,
+      isFocused: window.isFocused,
+    };
+  }
+
+  private async resolveFrontmostTarget(): Promise<ComputerUseTargetState> {
+    const frontmost = await this.helper().getFrontmost();
+    const frontmostApp: ComputerUseHelperApp = {
+      appName: frontmost.appName,
+      bundleId: frontmost.bundleId,
+      pid: frontmost.pid,
+      isFrontmost: true,
+    };
+    const windows = await this.helper().listWindows(frontmost.pid);
+    if (windows.length === 0) {
+      throw new Error(`No controllable windows were found for ${frontmost.appName}.`);
+    }
+    const preferredWindow =
+      windows.find((entry) => entry.windowId === frontmost.windowId) ||
+      windows.sort((a, b) => scoreWindow(b) - scoreWindow(a))[0];
+    return this.toTargetState(frontmostApp, preferredWindow);
+  }
+
+  private chooseRefreshFallbackWindow(
+    windows: ComputerUseHelperWindow[],
+    previous: ComputerUseTargetState,
+  ): ComputerUseHelperWindow | null {
+    const controllable = windows.filter((entry) => typeof entry.windowId === "number");
+    if (controllable.length === 0) {
+      return null;
+    }
+
+    const visible = controllable.filter((entry) => !entry.isMinimized && entry.isOnscreen);
+    if (visible.length === 1) {
+      return visible[0];
+    }
+
+    const ranked = (visible.length > 0 ? visible : controllable)
+      .map((entry) => ({
+        entry,
+        score:
+          (entry.isFocused ? 120 : 0) +
+          (entry.isMain ? 80 : 0) +
+          (!entry.isMinimized ? 30 : 0) +
+          (entry.isOnscreen ? 20 : 0) -
+          frameDistanceScore(entry.framePoints, previous.framePoints) / 20,
+      }))
+      .sort((a, b) => b.score - a.score);
+
+    if (ranked.length === 1) {
+      return ranked[0].entry;
+    }
+    if (ranked.length > 1 && ranked[0].score >= ranked[1].score + 25) {
+      return ranked[0].entry;
+    }
+    return null;
+  }
+
+  private async findRetargetedApp(previous: ComputerUseTargetState): Promise<ComputerUseHelperApp | null> {
+    const previousAppName = normalizeQuery(previous.appName);
+    const previousBundleId = normalizeQuery(previous.bundleId);
+    const candidates = (await this.helper().listApps())
+      .filter((app) => app.pid !== previous.pid)
+      .map((app) => {
+        const appName = normalizeQuery(app.appName);
+        const bundleId = normalizeQuery(app.bundleId);
+        const sameBundle = Boolean(previousBundleId) && bundleId === previousBundleId;
+        const sameAppName = Boolean(previousAppName) && appName === previousAppName;
+        if (!sameBundle && !sameAppName) {
+          return null;
+        }
+        return {
+          app,
+          score: (sameBundle ? 200 : 0) + (sameAppName ? 120 : 0) + (app.isFrontmost ? 40 : 0),
+        };
+      })
+      .filter((entry): entry is { app: ComputerUseHelperApp; score: number } => entry !== null)
+      .sort((a, b) => b.score - a.score);
+
+    return candidates[0]?.app ?? null;
+  }
+
+  private async refreshCurrentTarget(): Promise<ComputerUseTargetState> {
+    if (!this.currentTarget) {
+      throw new Error(CONTROLLED_WINDOW_ERROR);
+    }
+    let targetApp = {
+      appName: this.currentTarget.appName,
+      bundleId: this.currentTarget.bundleId,
+      pid: this.currentTarget.pid,
+    };
+    let windows = await this.helper().listWindows(targetApp.pid);
+    let refreshed =
+      windows.find((entry) => entry.windowId === this.currentTarget?.windowId) ||
+      windows.find((entry) => normalizeQuery(entry.title) === normalizeQuery(this.currentTarget?.windowTitle)) ||
+      this.chooseRefreshFallbackWindow(windows, this.currentTarget);
+
+    if (!refreshed) {
+      const retargetedApp = await this.findRetargetedApp(this.currentTarget);
+      if (retargetedApp) {
+        targetApp = {
+          appName: retargetedApp.appName,
+          bundleId: retargetedApp.bundleId,
+          pid: retargetedApp.pid,
+        };
+        windows = await this.helper().listWindows(targetApp.pid);
+        refreshed =
+          windows.find((entry) => normalizeQuery(entry.title) === normalizeQuery(this.currentTarget?.windowTitle)) ||
+          this.chooseRefreshFallbackWindow(windows, this.currentTarget);
+      }
+    }
+
+    if (!refreshed) {
+      throw new Error(
+        `The controlled window "${this.currentTarget.windowTitle || this.currentTarget.appName}" is no longer available. Call screenshot() to retarget.`,
+      );
+    }
+    this.currentTarget = {
+      ...this.currentTarget,
+      appName: targetApp.appName,
+      bundleId: targetApp.bundleId,
+      pid: targetApp.pid,
+      windowId: refreshed.windowId ?? this.currentTarget.windowId,
+      windowTitle: refreshed.title,
+      framePoints: refreshed.framePoints,
+      scaleFactor: refreshed.scaleFactor,
+      isMinimized: refreshed.isMinimized,
+      isOnscreen: refreshed.isOnscreen,
+      isMain: refreshed.isMain,
+      isFocused: refreshed.isFocused,
+    };
+    this.persistState();
+    return this.currentTarget;
+  }
+
+  private pickSingleMatch<T>(
+    entries: T[],
+    getLabel: (entry: T) => string,
+    getScore: (entry: T) => number,
+    emptyMessage: string,
+    ambiguousMessage: string,
+  ): T {
+    if (entries.length === 0) {
+      throw new Error(emptyMessage);
+    }
+    const ranked = [...entries]
+      .map((entry) => ({ entry, score: getScore(entry), label: getLabel(entry) }))
+      .filter((candidate) => candidate.score > 0)
+      .sort((a, b) => b.score - a.score || a.label.localeCompare(b.label));
+
+    if (ranked.length === 0) {
+      throw new Error(emptyMessage);
+    }
+    if (ranked.length > 1 && ranked[0].score === ranked[1].score) {
+      const choices = ranked
+        .slice(0, 5)
+        .map((candidate) => candidate.label)
+        .join(", ");
+      throw new Error(`${ambiguousMessage} Matching targets: ${choices}`);
+    }
+    return ranked[0].entry;
+  }
+
+  private async resolveTargetFromSelection(selection: ScreenshotSelection): Promise<ComputerUseTargetState> {
+    const appQuery = normalizeQuery(selection.app);
+    const windowQuery = normalizeQuery(selection.windowTitle);
+    if (!appQuery && !windowQuery) {
+      return await this.resolveFrontmostTarget();
+    }
+
+    const apps = await this.helper().listApps();
+    const candidateApps = appQuery
+      ? apps.filter((app) => {
+          const best = Math.max(
+            exactOrContainsScore(app.appName, appQuery),
+            exactOrContainsScore(app.bundleId, appQuery),
+          );
+          return best > 0;
+        })
+      : apps;
+
+    if (candidateApps.length === 0) {
+      throw new Error(`No running app matches "${selection.app}".`);
+    }
+
+    const scoredCandidates: Array<{
+      app: ComputerUseHelperApp;
+      window: ComputerUseHelperWindow;
+      score: number;
+    }> = [];
+
+    for (const app of candidateApps) {
+      const windows = await this.helper().listWindows(app.pid);
+      for (const window of windows) {
+        const appScore = appQuery
+          ? Math.max(
+              exactOrContainsScore(app.appName, appQuery),
+              exactOrContainsScore(app.bundleId, appQuery),
+            )
+          : app.isFrontmost
+            ? 5
+            : 0;
+        const windowScore = windowQuery
+          ? exactOrContainsScore(window.title, windowQuery)
+          : scoreWindow(window);
+        if (windowQuery && windowScore === 0) continue;
+        const score = appScore + windowScore + (window.isFocused ? 25 : 0) + (window.isMain ? 10 : 0);
+        if (score <= 0) continue;
+        scoredCandidates.push({ app, window, score });
+      }
+    }
+
+    if (scoredCandidates.length === 0) {
+      if (candidateApps.length === 1) {
+        const fallbackWindows = await this.helper().listWindows(candidateApps[0].pid);
+        const fallbackWindow = this.chooseRefreshFallbackWindow(fallbackWindows, {
+          appName: candidateApps[0].appName,
+          bundleId: candidateApps[0].bundleId,
+          pid: candidateApps[0].pid,
+          windowId: -1,
+          windowTitle: selection.windowTitle || "",
+          framePoints: { x: 0, y: 0, w: 0, h: 0 },
+          scaleFactor: 1,
+          isMinimized: false,
+          isOnscreen: true,
+          isMain: false,
+          isFocused: false,
+        });
+        if (fallbackWindow) {
+          return this.toTargetState(candidateApps[0], fallbackWindow);
+        }
+      }
+      const label = selection.windowTitle ? `window "${selection.windowTitle}"` : "a controllable window";
+      throw new Error(`Could not find ${label}${selection.app ? ` in ${selection.app}` : ""}.`);
+    }
+
+    const chosen = this.pickSingleMatch(
+      scoredCandidates,
+      (candidate) => formatWindowChoice(candidate.app.appName, candidate.window.title),
+      (candidate) => candidate.score,
+      `Could not find a controllable window for ${selection.app || "the requested target"}.`,
+      "Multiple windows match the requested target.",
+    );
+    return this.toTargetState(chosen.app, chosen.window);
+  }
+
+  private requireCurrentCapture(captureId?: string): ComputerUseCaptureState {
+    if (!this.currentTarget || !this.currentCapture) {
+      throw new Error(CONTROLLED_WINDOW_ERROR);
+    }
+    if (this.currentCapture.windowId !== this.currentTarget.windowId) {
+      throw new Error("The current capture no longer matches the controlled window. Call screenshot() to refresh.");
+    }
+    if (captureId && captureId !== this.currentCapture.id) {
+      throw new Error(`captureId ${captureId} is stale. Call screenshot() to refresh and use the newest capture.`);
+    }
+    return this.currentCapture;
+  }
+
+  private async prepareAction(toolName: string, captureId?: string): Promise<ActionPreparationResult> {
+    await this.ensureReady();
+    const target = await this.refreshCurrentTarget();
+    const capture = this.requireCurrentCapture(captureId);
+    this.daemon.logEvent(this.taskId, "tool_call", {
+      tool: toolName,
+      targetApp: target.appName,
+      bundleId: target.bundleId,
+      windowId: target.windowId,
+      captureId: capture.id,
+    });
+    await this.bringTargetToFront(target);
+    return { target, capture };
+  }
+
+  async screenshot(selection: ScreenshotSelection = {}): Promise<ComputerUseToolResult> {
+    await this.ensureReady();
+    this.daemon.logEvent(this.taskId, "tool_call", {
+      tool: "screenshot",
+      app: selection.app,
+      windowTitle: selection.windowTitle,
+      hadCurrentTarget: Boolean(this.currentTarget),
     });
 
-    try {
-      const script = `
-do shell script "python3 -c '
-import Quartz
-Quartz.CGEventPost(Quartz.kCGHIDEventTap, Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventMouseMoved, (${x}, ${y}), Quartz.kCGMouseButtonLeft))
-'"`;
-      await execAsync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, {
-        timeout: CUA_ACTION_TIMEOUT_MS,
-      });
+    this.currentTarget =
+      selection.app || selection.windowTitle
+        ? await this.resolveTargetFromSelection(selection)
+        : this.currentTarget
+          ? await this.refreshCurrentTarget().catch(async () => await this.resolveFrontmostTarget())
+          : await this.resolveFrontmostTarget();
 
-      this.daemon.logEvent(this.taskId, "tool_result", {
-        tool: "computer_move_mouse",
-        success: true,
-      });
-
-      return { success: true, x, y };
-    } catch (error: Any) {
-      this.daemon.logEvent(this.taskId, "tool_error", {
-        tool: "computer_move_mouse",
-        error: error.message,
-      });
-      throw new Error(`Failed to move mouse: ${error.message}`);
-    }
+    this.persistState();
+    await this.bringTargetToFront(this.currentTarget);
+    return await this.captureTarget("screenshot");
   }
 
   async click(
     x: number,
     y: number,
-    button: CUAClickButton = "left",
-    clickType: CUAClickType = "single",
-  ): Promise<{ success: boolean; x: number; y: number }> {
-    await this.ensureAccessibility();
-    this.session().updateActionStatus("Clicking…");
-    const app = await this.ensureAppPermission(
-      "computer_click",
-      "click_only",
-      "Send a click to the frontmost application.",
-    );
-
-    this.daemon.logEvent(this.taskId, "tool_call", {
-      tool: "computer_click",
-      appName: app.name,
-      bundleId: app.bundleId,
-      x,
-      y,
-      button,
-      clickType,
-    });
-
+    button: ComputerUseMouseButton = "left",
+    captureId?: string,
+  ): Promise<ComputerUseToolResult> {
+    const { target, capture } = await this.prepareAction("click", captureId);
+    validatePointInCapture(x, y, capture);
     try {
-      const clickCount = clickType === "double" ? 2 : clickType === "triple" ? 3 : 1;
-      const mouseButton =
-        button === "right"
-          ? "Quartz.kCGMouseButtonRight"
-          : button === "middle"
-            ? "Quartz.kCGMouseButtonCenter"
-            : "Quartz.kCGMouseButtonLeft";
-      const downEvent =
-        button === "right" ? "Quartz.kCGEventRightMouseDown" : "Quartz.kCGEventLeftMouseDown";
-      const upEvent =
-        button === "right" ? "Quartz.kCGEventRightMouseUp" : "Quartz.kCGEventLeftMouseUp";
-
-      const pyScript = `
-import Quartz, time
-pos = (${x}, ${y})
-for i in range(${clickCount}):
-    down = Quartz.CGEventCreateMouseEvent(None, ${downEvent}, pos, ${mouseButton})
-    Quartz.CGEventSetIntegerValueField(down, Quartz.kCGMouseEventClickState, i + 1)
-    Quartz.CGEventPost(Quartz.kCGHIDEventTap, down)
-    up = Quartz.CGEventCreateMouseEvent(None, ${upEvent}, pos, ${mouseButton})
-    Quartz.CGEventSetIntegerValueField(up, Quartz.kCGMouseEventClickState, i + 1)
-    Quartz.CGEventPost(Quartz.kCGHIDEventTap, up)
-    if i < ${clickCount} - 1:
-        time.sleep(0.05)
-`;
-      await execAsync(`python3 -c ${JSON.stringify(pyScript)}`, {
-        timeout: CUA_ACTION_TIMEOUT_MS,
-      });
-
-      this.daemon.logEvent(this.taskId, "tool_result", {
-        tool: "computer_click",
-        success: true,
-      });
-
-      return { success: true, x, y };
-    } catch (error: Any) {
+      if (button === "left") {
+        const axResult = await this.helper().axPressAtPoint({
+          windowId: target.windowId,
+          pid: target.pid,
+          x,
+          y,
+          captureWidth: capture.width,
+          captureHeight: capture.height,
+        });
+        if (!axResult.pressed) {
+          const focusResult = await this.helper().axFocusAtPoint({
+            windowId: target.windowId,
+            pid: target.pid,
+            x,
+            y,
+            captureWidth: capture.width,
+            captureHeight: capture.height,
+          });
+          if (!focusResult.focused) {
+            await this.helper().mouseClick({
+              windowId: target.windowId,
+              pid: target.pid,
+              x,
+              y,
+              captureWidth: capture.width,
+              captureHeight: capture.height,
+              button: button as ComputerUseHelperMouseButton,
+              clickCount: 1,
+            });
+          }
+        }
+      } else {
+        await this.helper().mouseClick({
+          windowId: target.windowId,
+          pid: target.pid,
+          x,
+          y,
+          captureWidth: capture.width,
+          captureHeight: capture.height,
+          button: button as ComputerUseHelperMouseButton,
+          clickCount: 1,
+        });
+      }
+      return await this.captureTarget("click");
+    } catch (error) {
       this.daemon.logEvent(this.taskId, "tool_error", {
-        tool: "computer_click",
-        error: error.message,
+        tool: "click",
+        error: error instanceof Error ? error.message : String(error),
       });
-      throw new Error(`Failed to click: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async doubleClick(x: number, y: number, captureId?: string): Promise<ComputerUseToolResult> {
+    const { target, capture } = await this.prepareAction("double_click", captureId);
+    validatePointInCapture(x, y, capture);
+    try {
+      await this.helper().mouseClick({
+        windowId: target.windowId,
+        pid: target.pid,
+        x,
+        y,
+        captureWidth: capture.width,
+        captureHeight: capture.height,
+        button: "left",
+        clickCount: 2,
+      });
+      return await this.captureTarget("double_click");
+    } catch (error) {
+      this.daemon.logEvent(this.taskId, "tool_error", {
+        tool: "double_click",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  async moveMouse(x: number, y: number, captureId?: string): Promise<ComputerUseToolResult> {
+    const { target, capture } = await this.prepareAction("move_mouse", captureId);
+    validatePointInCapture(x, y, capture);
+    try {
+      await this.helper().mouseMove({
+        windowId: target.windowId,
+        pid: target.pid,
+        x,
+        y,
+        captureWidth: capture.width,
+        captureHeight: capture.height,
+      });
+      return await this.captureTarget("move_mouse");
+    } catch (error) {
+      this.daemon.logEvent(this.taskId, "tool_error", {
+        tool: "move_mouse",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
     }
   }
 
   async drag(
-    fromX: number,
-    fromY: number,
-    toX: number,
-    toY: number,
-  ): Promise<{ success: boolean }> {
-    await this.ensureAccessibility();
-    this.session().updateActionStatus("Dragging…");
-    const app = await this.ensureAppPermission(
-      "computer_click",
-      "click_only",
-      "Drag inside the frontmost application.",
-    );
-
-    this.daemon.logEvent(this.taskId, "tool_call", {
-      tool: "computer_click",
-      appName: app.name,
-      bundleId: app.bundleId,
-      action: "drag",
-      fromX,
-      fromY,
-      toX,
-      toY,
+    path: Array<{ x: number; y: number }>,
+    captureId?: string,
+  ): Promise<ComputerUseToolResult> {
+    if (!Array.isArray(path) || path.length < 2) {
+      throw new Error("drag requires a path with at least two points.");
+    }
+    const { target, capture } = await this.prepareAction("drag", captureId);
+    const normalizedPath = path.map((point, index) => {
+      const px = requireFiniteCoordinate(`path[${index}].x`, point.x);
+      const py = requireFiniteCoordinate(`path[${index}].y`, point.y);
+      validatePointInCapture(px, py, capture, `path[${index}]`);
+      return { x: px, y: py };
     });
-
     try {
-      const pyScript = `
-import Quartz, time
-start = (${fromX}, ${fromY})
-end = (${toX}, ${toY})
-down = Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventLeftMouseDown, start, Quartz.kCGMouseButtonLeft)
-Quartz.CGEventPost(Quartz.kCGHIDEventTap, down)
-time.sleep(0.1)
-steps = 20
-for i in range(1, steps + 1):
-    t = i / steps
-    cx = start[0] + (end[0] - start[0]) * t
-    cy = start[1] + (end[1] - start[1]) * t
-    drag = Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventLeftMouseDragged, (cx, cy), Quartz.kCGMouseButtonLeft)
-    Quartz.CGEventPost(Quartz.kCGHIDEventTap, drag)
-    time.sleep(0.01)
-up = Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventLeftMouseUp, end, Quartz.kCGMouseButtonLeft)
-Quartz.CGEventPost(Quartz.kCGHIDEventTap, up)
-`;
-      await execAsync(`python3 -c ${JSON.stringify(pyScript)}`, {
-        timeout: CUA_ACTION_TIMEOUT_MS,
+      await this.helper().mouseDrag({
+        windowId: target.windowId,
+        pid: target.pid,
+        path: normalizedPath,
+        captureWidth: capture.width,
+        captureHeight: capture.height,
       });
-
-      this.daemon.logEvent(this.taskId, "tool_result", {
-        tool: "computer_click",
-        action: "drag",
-        success: true,
-      });
-
-      return { success: true };
-    } catch (error: Any) {
+      return await this.captureTarget("drag");
+    } catch (error) {
       this.daemon.logEvent(this.taskId, "tool_error", {
-        tool: "computer_click",
-        action: "drag",
-        error: error.message,
+        tool: "drag",
+        error: error instanceof Error ? error.message : String(error),
       });
-      throw new Error(`Failed to drag: ${error.message}`);
-    }
-  }
-
-  async typeText(text: string): Promise<{ success: boolean; length: number }> {
-    if (!text || typeof text !== "string") {
-      throw new Error("Invalid text: must be a non-empty string");
-    }
-
-    await this.ensureAccessibility();
-    this.session().updateActionStatus("Typing…");
-    const app = await this.ensureAppPermission(
-      "computer_type",
-      "full_control",
-      "Type text into the frontmost application.",
-    );
-
-    this.daemon.logEvent(this.taskId, "tool_call", {
-      tool: "computer_type",
-      appName: app.name,
-      bundleId: app.bundleId,
-      textLength: text.length,
-    });
-
-    try {
-      const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-      const script = `tell application "System Events" to keystroke "${escaped}"`;
-      await execAsync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, {
-        timeout: CUA_ACTION_TIMEOUT_MS,
-      });
-
-      this.daemon.logEvent(this.taskId, "tool_result", {
-        tool: "computer_type",
-        success: true,
-      });
-
-      return { success: true, length: text.length };
-    } catch (error: Any) {
-      this.daemon.logEvent(this.taskId, "tool_error", {
-        tool: "computer_type",
-        error: error.message,
-      });
-      throw new Error(`Failed to type text: ${error.message}`);
-    }
-  }
-
-  async pressKeys(keys: string[]): Promise<{ success: boolean; keys: string[] }> {
-    if (!Array.isArray(keys) || keys.length === 0) {
-      throw new Error("Invalid keys: must be a non-empty array of key names");
-    }
-
-    const normalized = normalizeKeysForBlocklist(keys);
-    if (BLOCKED_KEY_COMBOS.has(normalized)) {
-      throw new Error(
-        `Blocked key combination: ${keys.join("+")}. ` +
-          "This system shortcut is not allowed during computer use sessions.",
-      );
-    }
-
-    await this.ensureAccessibility();
-    this.session().updateActionStatus("Key input…");
-    const app = await this.ensureAppPermission(
-      "computer_key",
-      "full_control",
-      "Send keyboard input to the frontmost application.",
-    );
-
-    this.daemon.logEvent(this.taskId, "tool_call", {
-      tool: "computer_key",
-      appName: app.name,
-      bundleId: app.bundleId,
-      keys,
-    });
-
-    try {
-      const modifiers: string[] = [];
-      let keyChar: string | null = null;
-      let keyCode: number | null = null;
-
-      for (const k of keys) {
-        const lower = k.toLowerCase().trim();
-        if (lower === "cmd" || lower === "command") {
-          modifiers.push("command down");
-        } else if (lower === "ctrl" || lower === "control") {
-          modifiers.push("control down");
-        } else if (lower === "alt" || lower === "option") {
-          modifiers.push("option down");
-        } else if (lower === "shift") {
-          modifiers.push("shift down");
-        } else if (lower === "return" || lower === "enter") {
-          keyCode = 36;
-        } else if (lower === "escape" || lower === "esc") {
-          keyCode = 53;
-        } else if (lower === "tab") {
-          keyCode = 48;
-        } else if (lower === "space") {
-          keyCode = 49;
-        } else if (lower === "delete" || lower === "backspace") {
-          keyCode = 51;
-        } else if (lower === "up") {
-          keyCode = 126;
-        } else if (lower === "down") {
-          keyCode = 125;
-        } else if (lower === "left") {
-          keyCode = 123;
-        } else if (lower === "right") {
-          keyCode = 124;
-        } else if (lower.startsWith("f") && /^f\d{1,2}$/.test(lower)) {
-          const fkeyMap: Record<string, number> = {
-            f1: 122,
-            f2: 120,
-            f3: 99,
-            f4: 118,
-            f5: 96,
-            f6: 97,
-            f7: 98,
-            f8: 100,
-            f9: 101,
-            f10: 109,
-            f11: 103,
-            f12: 111,
-          };
-          keyCode = fkeyMap[lower] ?? null;
-        } else if (lower.length === 1) {
-          keyChar = lower;
-        } else {
-          keyChar = k;
-        }
-      }
-
-      const modString = modifiers.length > 0 ? ` using {${modifiers.join(", ")}}` : "";
-      let script: string;
-      if (keyCode !== null) {
-        script = `tell application "System Events" to key code ${keyCode}${modString}`;
-      } else if (keyChar !== null) {
-        const escaped = keyChar.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-        script = `tell application "System Events" to keystroke "${escaped}"${modString}`;
-      } else {
-        throw new Error(`Could not resolve key combination: ${keys.join("+")}`);
-      }
-
-      await execAsync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, {
-        timeout: CUA_ACTION_TIMEOUT_MS,
-      });
-
-      this.daemon.logEvent(this.taskId, "tool_result", {
-        tool: "computer_key",
-        success: true,
-      });
-
-      return { success: true, keys };
-    } catch (error: Any) {
-      this.daemon.logEvent(this.taskId, "tool_error", {
-        tool: "computer_key",
-        error: error.message,
-      });
-      throw new Error(`Failed to press keys: ${error.message}`);
-    }
-  }
-
-  async takeScreenshot(): Promise<CUAScreenshotResult> {
-    await this.ensureScreenCaptureAllowed();
-    this.session().updateActionStatus("Capturing screen…");
-    const app = await this.ensureAppPermission(
-      "computer_screenshot",
-      "view_only",
-      "Capture a screenshot of the screen for the frontmost application context.",
-    );
-    this.daemon.logEvent(this.taskId, "tool_call", {
-      tool: "computer_screenshot",
-      appName: app.name,
-      bundleId: app.bundleId,
-    });
-
-    try {
-      const desktopCapturer = getElectronDesktopCapturer();
-      if (!desktopCapturer) {
-        throw new Error("Screenshot capture is only available in the desktop (Electron) runtime");
-      }
-
-      const electronScreen = getElectronScreen();
-      const display = electronScreen?.getPrimaryDisplay();
-      const scaleFactor = display?.scaleFactor ?? 2;
-      const workArea = display?.workAreaSize ?? { width: 1920, height: 1080 };
-
-      const captureWidth = Math.min(workArea.width * scaleFactor, SCREENSHOT_MAX_DIMENSION);
-      const captureHeight = Math.min(workArea.height * scaleFactor, SCREENSHOT_MAX_DIMENSION);
-
-      const sources = await getDesktopSourcesWithTimeout(
-        desktopCapturer,
-        {
-          types: ["screen"],
-          thumbnailSize: { width: captureWidth, height: captureHeight },
-        },
-        DESKTOP_CAPTURER_TIMEOUT_MS,
-      );
-
-      if (sources.length === 0) {
-        throw new Error("No screen sources available for capture");
-      }
-
-      const primaryId = display?.id;
-      let primaryScreen = sources[0];
-      if (primaryId !== undefined) {
-        const match = sources.find((s: Any) => String(s.display_id) === String(primaryId));
-        if (match) primaryScreen = match;
-      }
-
-      const image = primaryScreen.thumbnail;
-
-      if (image.isEmpty()) {
-        throw new Error(
-          "Failed to capture screenshot — image is empty. Check Screen Recording permission and restart CoWork OS after granting.",
-        );
-      }
-
-      const pngData = image.toPNG();
-      const base64 = pngData.toString("base64");
-      const hash = crypto.createHash("sha256").update(pngData).digest("hex").slice(0, 16);
-      const size = image.getSize();
-
-      this.lastScreenshotHash = hash;
-
-      this.daemon.logEvent(this.taskId, "tool_result", {
-        tool: "computer_screenshot",
-        success: true,
-        width: size.width,
-        height: size.height,
-      });
-
-      return {
-        base64,
-        width: size.width,
-        height: size.height,
-        hash,
-      };
-    } catch (error: Any) {
-      this.daemon.logEvent(this.taskId, "tool_error", {
-        tool: "computer_screenshot",
-        error: error.message,
-      });
-      throw new Error(`Failed to take screenshot: ${error.message}`);
-    }
-  }
-
-  async detectScreenChange(): Promise<{ changed: boolean; previousHash: string | null; currentHash: string }> {
-    const previousHash = this.lastScreenshotHash;
-    const fresh = await this.takeScreenshot();
-    return {
-      changed: previousHash !== null && fresh.hash !== previousHash,
-      previousHash,
-      currentHash: fresh.hash,
-    };
-  }
-
-  async getFrontmostApp(): Promise<{ name: string; bundleId: string }> {
-    if (os.platform() !== "darwin") {
-      throw new Error("Frontmost app detection is only supported on macOS");
-    }
-
-    try {
-      const { stdout: appName } = await execAsync(
-        `osascript -e 'tell application "System Events" to get name of first process whose frontmost is true'`,
-        { timeout: 5000 },
-      );
-      const { stdout: bundleId } = await execAsync(
-        `osascript -e 'tell application "System Events" to get bundle identifier of first process whose frontmost is true'`,
-        { timeout: 5000 },
-      );
-      return {
-        name: appName.trim(),
-        bundleId: bundleId.trim(),
-      };
-    } catch (error: Any) {
-      throw new Error(`Failed to detect frontmost app: ${error.message}`);
+      throw error;
     }
   }
 
   async scroll(
     x: number,
     y: number,
-    direction: "up" | "down" | "left" | "right",
-    amount: number = 3,
-  ): Promise<{ success: boolean }> {
-    await this.ensureAccessibility();
-    this.session().updateActionStatus("Scrolling…");
-    const app = await this.ensureAppPermission(
-      "computer_click",
-      "click_only",
-      "Scroll inside the frontmost application.",
-    );
-
-    this.daemon.logEvent(this.taskId, "tool_call", {
-      tool: "computer_click",
-      appName: app.name,
-      bundleId: app.bundleId,
-      action: "scroll",
-      x,
-      y,
-      direction,
-      amount,
-    });
-
+    scrollX: number,
+    scrollY: number,
+    captureId?: string,
+  ): Promise<ComputerUseToolResult> {
+    const { target, capture } = await this.prepareAction("scroll", captureId);
+    validatePointInCapture(x, y, capture);
+    const normalizedScrollX = requireIntegerInRange("scrollX", scrollX, -10_000, 10_000);
+    const normalizedScrollY = requireIntegerInRange("scrollY", scrollY, -10_000, 10_000);
     try {
-      const scrollY = direction === "up" ? amount : direction === "down" ? -amount : 0;
-      const scrollX = direction === "left" ? amount : direction === "right" ? -amount : 0;
-
-      const pyScript = `
-import Quartz
-move = Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventMouseMoved, (${x}, ${y}), Quartz.kCGMouseButtonLeft)
-Quartz.CGEventPost(Quartz.kCGHIDEventTap, move)
-scroll = Quartz.CGEventCreateScrollWheelEvent(None, Quartz.kCGScrollEventUnitLine, 2, ${scrollY}, ${scrollX})
-Quartz.CGEventPost(Quartz.kCGHIDEventTap, scroll)
-`;
-      await execAsync(`python3 -c ${JSON.stringify(pyScript)}`, {
-        timeout: CUA_ACTION_TIMEOUT_MS,
+      await this.helper().scrollAtPoint({
+        windowId: target.windowId,
+        pid: target.pid,
+        x,
+        y,
+        captureWidth: capture.width,
+        captureHeight: capture.height,
+        scrollX: normalizedScrollX,
+        scrollY: normalizedScrollY,
       });
-
-      this.daemon.logEvent(this.taskId, "tool_result", {
-        tool: "computer_click",
-        action: "scroll",
-        success: true,
-      });
-
-      return { success: true };
-    } catch (error: Any) {
+      return await this.captureTarget("scroll");
+    } catch (error) {
       this.daemon.logEvent(this.taskId, "tool_error", {
-        tool: "computer_click",
-        action: "scroll",
-        error: error.message,
+        tool: "scroll",
+        error: error instanceof Error ? error.message : String(error),
       });
-      throw new Error(`Failed to scroll: ${error.message}`);
+      throw error;
     }
   }
 
-  static getToolDefinitions(options?: { headless?: boolean }): LLMTool[] {
-    if (options?.headless) {
-      return [];
+  async typeText(text: string): Promise<ComputerUseToolResult> {
+    if (typeof text !== "string" || text.length === 0) {
+      throw new Error("type_text requires a non-empty text string.");
     }
+    await this.ensureReady();
+    const target = await this.refreshCurrentTarget();
+    this.daemon.logEvent(this.taskId, "tool_call", {
+      tool: "type_text",
+      targetApp: target.appName,
+      bundleId: target.bundleId,
+      windowId: target.windowId,
+      textLength: text.length,
+    });
+    await this.bringTargetToFront(target);
+    try {
+      const focused = await this.helper().focusedElement(target.pid);
+      if (focused.exists && focused.canSetValue && !focused.isSecure && focused.elementRef) {
+        await this.helper().setValue(focused.elementRef, text);
+      } else {
+        let focusedTextInput: Awaited<ReturnType<ComputerUseHelperRuntime["axFocusTextInput"]>>;
+        try {
+          focusedTextInput = await this.helper().axFocusTextInput({
+            pid: target.pid,
+            windowId: target.windowId,
+          });
+        } catch {
+          focusedTextInput = { focused: false };
+        }
+        if (
+          focusedTextInput.focused &&
+          focusedTextInput.canSetValue &&
+          !focusedTextInput.isSecure &&
+          focusedTextInput.elementRef
+        ) {
+          await this.helper().setValue(focusedTextInput.elementRef, text);
+        } else {
+          await this.helper().typeText(text, target.pid);
+        }
+      }
+      return await this.captureTarget("type_text");
+    } catch (error) {
+      this.daemon.logEvent(this.taskId, "tool_error", {
+        tool: "type_text",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
 
-    if (os.platform() !== "darwin") {
+  async pressKeys(keys: string[]): Promise<ComputerUseToolResult> {
+    if (!Array.isArray(keys) || keys.length === 0) {
+      throw new Error("keypress requires a non-empty keys array.");
+    }
+    const normalized = normalizeKeysForBlocklist(keys);
+    if (BLOCKED_KEY_COMBOS.has(normalized)) {
+      throw new Error(`Blocked key combination: ${keys.join("+")}.`);
+    }
+    await this.ensureReady();
+    const target = await this.refreshCurrentTarget();
+    this.daemon.logEvent(this.taskId, "tool_call", {
+      tool: "keypress",
+      targetApp: target.appName,
+      bundleId: target.bundleId,
+      windowId: target.windowId,
+      keys,
+    });
+    await this.bringTargetToFront(target);
+    try {
+      await this.helper().pressKeys(parseKeypressSpec(target.pid, keys));
+      return await this.captureTarget("keypress");
+    } catch (error) {
+      this.daemon.logEvent(this.taskId, "tool_error", {
+        tool: "keypress",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  async wait(ms?: number): Promise<ComputerUseToolResult> {
+    const delayMs = ms === undefined ? DEFAULT_WAIT_MS : requireIntegerInRange("ms", ms, 0, MAX_WAIT_MS);
+    await this.ensureReady();
+    await this.refreshCurrentTarget();
+    this.requireCurrentCapture();
+    this.daemon.logEvent(this.taskId, "tool_call", {
+      tool: "wait",
+      ms: delayMs,
+    });
+    await sleep(delayMs);
+    return await this.captureTarget("wait");
+  }
+
+  static getToolDefinitions(options?: { headless?: boolean }): LLMTool[] {
+    if (options?.headless || process.platform !== "darwin") {
       return [];
     }
 
     return [
       {
-        name: "computer_screenshot",
+        name: "screenshot",
         description:
-          "Take a screenshot of the current screen for visual analysis in native macOS apps. " +
-          "Preferred for desktop GUI tasks after open_application launches the app. " +
-          "Use this before computer_click / computer_type / computer_key so you can act on what is visible. Returns a base64-encoded PNG image.",
+          "Capture the current controlled window in a native macOS app. Call this first. " +
+          "Passing app and/or windowTitle retargets control to that window. Returns a fresh captureId and PNG image.",
         input_schema: {
           type: "object",
-          properties: {},
+          properties: {
+            app: {
+              type: "string",
+              description: "Optional app name or bundle id to retarget before capturing.",
+            },
+            windowTitle: {
+              type: "string",
+              description: "Optional window title filter to retarget before capturing.",
+            },
+          },
           required: [],
         },
       },
       {
-        name: "computer_click",
+        name: "click",
         description:
-          "Click at specific screen coordinates in native macOS apps. Preferred for normal GUI interaction in apps like Calculator, Notes, Finder, System Settings, Xcode, and Simulator. " +
-          "Use after taking a screenshot to interact with visible UI elements. Supports left/right/middle click, double-click, triple-click, drag, and scroll.",
+          "Click inside the current controlled window using screenshot-relative coordinates. " +
+          "Use the latest captureId to guard against stale state. Returns a fresh screenshot.",
         input_schema: {
           type: "object",
           properties: {
-            x: {
-              type: "number",
-              description: "X coordinate on screen (pixels from left edge)",
-            },
-            y: {
-              type: "number",
-              description: "Y coordinate on screen (pixels from top edge)",
-            },
+            x: { type: "number", description: "Window-relative X coordinate from the latest screenshot." },
+            y: { type: "number", description: "Window-relative Y coordinate from the latest screenshot." },
             button: {
               type: "string",
-              enum: ["left", "right", "middle"],
-              description: "Mouse button to click (default: left)",
+              enum: ["left", "right", "wheel", "back", "forward"],
+              description: "Mouse button to click. Defaults to left.",
             },
-            clickType: {
+            captureId: {
               type: "string",
-              enum: ["single", "double", "triple"],
-              description: "Click type (default: single)",
-            },
-            action: {
-              type: "string",
-              enum: ["click", "drag", "scroll"],
-              description: "Action type (default: click). For drag, provide toX/toY. For scroll, provide direction.",
-            },
-            toX: {
-              type: "number",
-              description: "Destination X for drag action",
-            },
-            toY: {
-              type: "number",
-              description: "Destination Y for drag action",
-            },
-            direction: {
-              type: "string",
-              enum: ["up", "down", "left", "right"],
-              description: "Scroll direction (for scroll action)",
-            },
-            amount: {
-              type: "number",
-              description: "Scroll amount in lines (default: 3, for scroll action)",
+              description: "Optional validation token from the latest screenshot().",
             },
           },
           required: ["x", "y"],
         },
       },
       {
-        name: "computer_type",
+        name: "double_click",
         description:
-          "Type text at the current cursor position using OS-level keyboard input in native macOS apps. " +
-          "Preferred over run_applescript for entering text into focused GUI fields. " +
-          "The text is typed character by character as real keyboard input.",
+          "Double-click inside the current controlled window using screenshot-relative coordinates. Returns a fresh screenshot.",
+        input_schema: {
+          type: "object",
+          properties: {
+            x: { type: "number", description: "Window-relative X coordinate from the latest screenshot." },
+            y: { type: "number", description: "Window-relative Y coordinate from the latest screenshot." },
+            captureId: {
+              type: "string",
+              description: "Optional validation token from the latest screenshot().",
+            },
+          },
+          required: ["x", "y"],
+        },
+      },
+      {
+        name: "move_mouse",
+        description:
+          "Move the pointer inside the current controlled window using screenshot-relative coordinates. Returns a fresh screenshot.",
+        input_schema: {
+          type: "object",
+          properties: {
+            x: { type: "number", description: "Window-relative X coordinate from the latest screenshot." },
+            y: { type: "number", description: "Window-relative Y coordinate from the latest screenshot." },
+            captureId: {
+              type: "string",
+              description: "Optional validation token from the latest screenshot().",
+            },
+          },
+          required: ["x", "y"],
+        },
+      },
+      {
+        name: "drag",
+        description:
+          "Drag through a series of screenshot-relative points inside the current controlled window. Returns a fresh screenshot.",
+        input_schema: {
+          type: "object",
+          properties: {
+            path: {
+              type: "array",
+              description: "Ordered drag path in screenshot-relative coordinates.",
+              items: {
+                type: "object",
+                properties: {
+                  x: { type: "number" },
+                  y: { type: "number" },
+                },
+                required: ["x", "y"],
+              },
+            },
+            captureId: {
+              type: "string",
+              description: "Optional validation token from the latest screenshot().",
+            },
+          },
+          required: ["path"],
+        },
+      },
+      {
+        name: "scroll",
+        description:
+          "Scroll at a screenshot-relative point inside the current controlled window. scrollX and scrollY are signed line deltas. Returns a fresh screenshot.",
+        input_schema: {
+          type: "object",
+          properties: {
+            x: { type: "number", description: "Window-relative X coordinate from the latest screenshot." },
+            y: { type: "number", description: "Window-relative Y coordinate from the latest screenshot." },
+            scrollX: { type: "number", description: "Signed horizontal scroll delta in lines." },
+            scrollY: { type: "number", description: "Signed vertical scroll delta in lines." },
+            captureId: {
+              type: "string",
+              description: "Optional validation token from the latest screenshot().",
+            },
+          },
+          required: ["x", "y", "scrollX", "scrollY"],
+        },
+      },
+      {
+        name: "type_text",
+        description:
+          "Type or set text into the currently focused control of the current controlled window. Returns a fresh screenshot.",
         input_schema: {
           type: "object",
           properties: {
             text: {
               type: "string",
-              description: "The text to type",
+              description: "The text to enter into the focused control.",
             },
           },
           required: ["text"],
         },
       },
       {
-        name: "computer_key",
+        name: "keypress",
         description:
-          "Press a key combination using OS-level keyboard input in native macOS apps. " +
-          "Preferred over run_applescript for shortcuts and non-text keys during GUI automation. " +
-          "Use this for keyboard shortcuts like Cmd+C, Cmd+V, Return, Escape, etc. Provide an array of key names to press simultaneously. " +
-          "Modifier keys: cmd/command, ctrl/control, alt/option, shift. " +
-          "Special keys: return, escape, tab, space, delete, up, down, left, right, f1-f12.",
+          "Send a key or key chord to the current controlled window. Modifier keys: cmd/command, ctrl/control, alt/option, shift. Returns a fresh screenshot.",
         input_schema: {
           type: "object",
           properties: {
             keys: {
               type: "array",
               items: { type: "string" },
-              description:
-                'Array of key names to press together, e.g. ["cmd", "c"] for Cmd+C, ' +
-                '["return"] for Enter, ["cmd", "shift", "s"] for Cmd+Shift+S',
+              description: 'Array of key names to press together, e.g. ["cmd", "c"] or ["return"].',
             },
           },
           required: ["keys"],
         },
       },
       {
-        name: "computer_move_mouse",
+        name: "wait",
         description:
-          "Move the mouse cursor to specific screen coordinates without clicking in native macOS apps. " +
-          "Use this to hover over elements or position the cursor before other computer_* actions.",
+          "Pause briefly and then refresh the current controlled window screenshot. Useful after async UI transitions.",
         input_schema: {
           type: "object",
           properties: {
-            x: {
+            ms: {
               type: "number",
-              description: "X coordinate on screen (pixels from left edge)",
-            },
-            y: {
-              type: "number",
-              description: "Y coordinate on screen (pixels from top edge)",
+              description: `Optional wait duration in milliseconds (default ${DEFAULT_WAIT_MS}).`,
             },
           },
-          required: ["x", "y"],
+          required: [],
         },
       },
     ];

--- a/src/electron/agent/tools/runtime-tool-definition.ts
+++ b/src/electron/agent/tools/runtime-tool-definition.ts
@@ -7,6 +7,7 @@ import type {
   RuntimeToolResultKind,
   RuntimeToolSideEffectLevel,
 } from "../../../shared/types";
+import { isComputerUseToolName } from "../../../shared/computer-use-contract";
 import type { LLMTool } from "../llm/types";
 import { getToolExposureMetadata } from "../tool-policy-engine";
 import {
@@ -49,6 +50,7 @@ const READ_PARALLEL_TOOLS = new Set([
   "browser_get_text",
   "browser_screenshot",
   "browser_wait",
+  "screen_context_resolve",
 ]);
 
 const EXCLUSIVE_TOOLS = new Set([
@@ -125,7 +127,7 @@ function inferConcurrencyClass(toolName: string): RuntimeToolConcurrencyClass {
   if (EXCLUSIVE_TOOLS.has(toolName)) return "exclusive";
   if (toolName.startsWith("browser_") || toolName.startsWith("canvas_")) return "serial_only";
   if (toolName.endsWith("_action")) return "serial_only";
-  if (toolName.startsWith("computer_")) return "serial_only";
+  if (isComputerUseToolName(toolName)) return "serial_only";
   if (isArtifactGenerationToolName(toolName) || isFileMutationToolName(toolName)) return "exclusive";
   if (
     toolName.startsWith("read_") ||
@@ -160,7 +162,7 @@ function inferReadOnly(toolName: string, concurrencyClass: RuntimeToolConcurrenc
 
 function inferInterruptBehavior(toolName: string, readOnly: boolean): RuntimeToolInterruptBehavior {
   if (toolName === "run_command") return "cancel";
-  if (toolName.startsWith("browser_") || toolName.startsWith("computer_")) return "cancel";
+  if (toolName.startsWith("browser_") || isComputerUseToolName(toolName)) return "cancel";
   return readOnly ? "cancel" : "block";
 }
 
@@ -183,7 +185,7 @@ function inferSideEffectLevel(toolName: string, readOnly: boolean): RuntimeToolS
   if (readOnly) return "none";
   if (toolName === "analyze_image" || toolName === "read_pdf_visual") return "high";
   if (toolName === "delete_file" || toolName.endsWith("_action")) return "high";
-  if (toolName === "run_command" || toolName.startsWith("browser_") || toolName.startsWith("computer_")) {
+  if (toolName === "run_command" || toolName.startsWith("browser_") || isComputerUseToolName(toolName)) {
     return "medium";
   }
   return "low";

--- a/src/electron/computer-use/helper-runtime.ts
+++ b/src/electron/computer-use/helper-runtime.ts
@@ -1,0 +1,815 @@
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "child_process";
+import { createHash } from "crypto";
+import { existsSync } from "fs";
+import { access, chmod, mkdir, readFile, writeFile } from "fs/promises";
+import { constants as fsConstants } from "fs";
+import * as path from "path";
+import { getUserDataDir } from "../utils/user-data-dir";
+
+type Any = any; // oxlint-disable-line typescript-eslint/no-explicit-any
+
+const HELPER_DIR = path.join(getUserDataDir(), "computer-use-helper");
+const HELPER_PATH = path.join(HELPER_DIR, "bridge");
+const HELPER_STAMP_PATH = path.join(HELPER_DIR, "bridge.sha256");
+const HELPER_SETUP_TIMEOUT_MS = 60_000;
+const HELPER_COMMAND_TIMEOUT_MS = 20_000;
+
+export interface ComputerUseHelperStatus {
+  helperPath: string;
+  sourcePath: string | null;
+  installed: boolean;
+  accessibility: boolean;
+  screenRecording: boolean;
+  error?: string;
+}
+
+export interface ComputerUseHelperApp {
+  appName: string;
+  bundleId?: string;
+  pid: number;
+  isFrontmost?: boolean;
+}
+
+export interface ComputerUseHelperFramePoints {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface ComputerUseHelperWindow {
+  windowId?: number;
+  title: string;
+  framePoints: ComputerUseHelperFramePoints;
+  scaleFactor: number;
+  isMinimized: boolean;
+  isOnscreen: boolean;
+  isMain: boolean;
+  isFocused: boolean;
+}
+
+export interface ComputerUseFrontmostApp {
+  appName: string;
+  bundleId?: string;
+  pid: number;
+  windowTitle?: string;
+  windowId?: number;
+}
+
+export interface ComputerUseScreenshotPayload {
+  pngBase64: string;
+  width: number;
+  height: number;
+  scaleFactor: number;
+}
+
+export interface ComputerUseAxPressResult {
+  pressed: boolean;
+  reason?: string;
+}
+
+export interface ComputerUseAxFocusResult {
+  focused: boolean;
+  reason?: string;
+}
+
+export interface ComputerUseFocusedElementResult {
+  exists: boolean;
+  elementRef?: string;
+  role?: string;
+  subrole?: string;
+  isTextInput?: boolean;
+  isSecure?: boolean;
+  canSetValue?: boolean;
+}
+
+export interface ComputerUseAxElementResult {
+  found?: boolean;
+  focused?: boolean;
+  exists?: boolean;
+  elementRef?: string;
+  role?: string;
+  subrole?: string;
+  title?: string;
+  value?: string;
+  x?: number;
+  y?: number;
+  score?: number;
+  confidence?: string;
+  actions?: string[];
+  isTextInput?: boolean;
+  isSecure?: boolean;
+  canSetValue?: boolean;
+  reason?: string;
+}
+
+export type ComputerUseHelperMouseButton = "left" | "right" | "wheel" | "back" | "forward";
+
+export interface ComputerUseHelperKeypressSpec {
+  pid: number;
+  keyCode?: number;
+  keyText?: string;
+  modifiers?: string[];
+}
+
+interface PendingRequest {
+  cmd: string;
+  resolve: (value: Any) => void;
+  reject: (reason?: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+class HelperTransportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HelperTransportError";
+  }
+}
+
+export class HelperCommandError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "HelperCommandError";
+  }
+}
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error(String(error));
+}
+
+export function isRecoverableScreenshotError(error: unknown): boolean {
+  return (
+    error instanceof HelperCommandError &&
+    (error.code === "screenshot_timeout" || error.code === "window_not_found" || error.code === "screenshot_failed")
+  );
+}
+
+function isPackagedElectronApp(): boolean {
+  try {
+    // oxlint-disable-next-line typescript-eslint/no-require-imports
+    const electron = require("electron") as Any;
+    return electron?.app?.isPackaged === true;
+  } catch {
+    return false;
+  }
+}
+
+function getBundledHelperSourcePath(): string | null {
+  if (process.platform !== "darwin") return null;
+  const candidates: string[] = [];
+  if (
+    isPackagedElectronApp() &&
+    typeof process.resourcesPath === "string" &&
+    process.resourcesPath.length > 0
+  ) {
+    candidates.push(path.join(process.resourcesPath, "computer-use", "bridge.swift"));
+  }
+  if (typeof process.cwd === "function") {
+    candidates.push(path.join(process.cwd(), "resources", "computer-use", "bridge.swift"));
+  }
+  candidates.push(path.resolve(__dirname, "../../../resources/computer-use/bridge.swift"));
+  candidates.push(path.resolve(__dirname, "../../../../resources/computer-use/bridge.swift"));
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+async function isExecutable(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getElectronDialog(): { showMessageBox: (options: Any) => Promise<{ response: number }> } | null {
+  try {
+    // oxlint-disable-next-line typescript-eslint/no-require-imports
+    const electron = require("electron") as Any;
+    return electron?.dialog ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function sha256(buffer: Buffer): string {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+export class ComputerUseHelperRuntime {
+  private static instance: ComputerUseHelperRuntime | null = null;
+
+  static getInstance(): ComputerUseHelperRuntime {
+    if (!ComputerUseHelperRuntime.instance) {
+      ComputerUseHelperRuntime.instance = new ComputerUseHelperRuntime();
+    }
+    return ComputerUseHelperRuntime.instance;
+  }
+
+  static resetForTesting(): void {
+    ComputerUseHelperRuntime.instance = null;
+  }
+
+  private helper: ChildProcessWithoutNullStreams | null = null;
+  private helperStdoutBuffer = "";
+  private requestSequence = 0;
+  private pending = new Map<string, PendingRequest>();
+  private queueTail: Promise<void> = Promise.resolve();
+
+  getHelperPath(): string {
+    return HELPER_PATH;
+  }
+
+  getHelperSourcePath(): string | null {
+    return getBundledHelperSourcePath();
+  }
+
+  async getStatus(): Promise<ComputerUseHelperStatus> {
+    const sourcePath = this.getHelperSourcePath();
+    const installed = await isExecutable(HELPER_PATH);
+    if (!installed) {
+      return {
+        helperPath: HELPER_PATH,
+        sourcePath,
+        installed: false,
+        accessibility: false,
+        screenRecording: false,
+      };
+    }
+
+    try {
+      const status = await this.checkPermissions();
+      return {
+        helperPath: HELPER_PATH,
+        sourcePath,
+        installed: true,
+        accessibility: status.accessibility,
+        screenRecording: status.screenRecording,
+      };
+    } catch (error) {
+      return {
+        helperPath: HELPER_PATH,
+        sourcePath,
+        installed: true,
+        accessibility: false,
+        screenRecording: false,
+        error: normalizeError(error).message,
+      };
+    }
+  }
+
+  async ensureReadyWithInteractivePermissions(): Promise<void> {
+    if (process.platform !== "darwin") {
+      throw new Error("Computer use is only supported on macOS.");
+    }
+    await this.ensureHelperInstalled();
+    await this.ensureHelperProcess();
+    await this.ensurePermissionsInteractive();
+  }
+
+  stop(): void {
+    this.rejectAllPending(new HelperTransportError("Computer-use helper stopped."));
+    const helper = this.helper;
+    this.helper = null;
+    this.helperStdoutBuffer = "";
+    if (helper && helper.exitCode === null && !helper.killed) {
+      helper.kill("SIGTERM");
+    }
+  }
+
+  async listApps(): Promise<ComputerUseHelperApp[]> {
+    const result = await this.bridgeCommand<unknown>("listApps");
+    const rawApps = Array.isArray(result) ? result : [];
+    const apps: Array<ComputerUseHelperApp | null> = rawApps.map((entry): ComputerUseHelperApp | null => {
+        const record = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : null;
+        if (!record) return null;
+        const pid = Number(record.pid);
+        if (!Number.isFinite(pid) || pid <= 0) return null;
+        return {
+          appName: typeof record.appName === "string" ? record.appName : "Unknown App",
+          bundleId: typeof record.bundleId === "string" ? record.bundleId : undefined,
+          pid: Math.trunc(pid),
+          isFrontmost: record.isFrontmost === true,
+        };
+      });
+    return apps.filter((entry): entry is ComputerUseHelperApp => entry !== null);
+  }
+
+  async listWindows(pid: number): Promise<ComputerUseHelperWindow[]> {
+    const result = await this.bridgeCommand<unknown>("listWindows", { pid });
+    const rawWindows = Array.isArray(result) ? result : [];
+    return rawWindows.map((entry) => {
+      const record = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : {};
+      const frame = record.framePoints && typeof record.framePoints === "object"
+        ? (record.framePoints as Record<string, unknown>)
+        : {};
+      return {
+        windowId:
+          typeof record.windowId === "number" && Number.isFinite(record.windowId)
+            ? Math.trunc(record.windowId)
+            : undefined,
+        title: typeof record.title === "string" ? record.title : "",
+        framePoints: {
+          x: Number(frame.x) || 0,
+          y: Number(frame.y) || 0,
+          w: Math.max(1, Number(frame.w) || 1),
+          h: Math.max(1, Number(frame.h) || 1),
+        },
+        scaleFactor: Math.max(1, Number(record.scaleFactor) || 1),
+        isMinimized: record.isMinimized === true,
+        isOnscreen: record.isOnscreen !== false,
+        isMain: record.isMain === true,
+        isFocused: record.isFocused === true,
+      };
+    });
+  }
+
+  async getFrontmost(): Promise<ComputerUseFrontmostApp> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("getFrontmost");
+    const pid = Number(result.pid);
+    if (!Number.isFinite(pid) || pid <= 0) {
+      throw new Error("No frontmost app is available for computer use.");
+    }
+    return {
+      appName: typeof result.appName === "string" ? result.appName : "Unknown App",
+      bundleId: typeof result.bundleId === "string" ? result.bundleId : undefined,
+      pid: Math.trunc(pid),
+      windowTitle: typeof result.windowTitle === "string" ? result.windowTitle : undefined,
+      windowId:
+        typeof result.windowId === "number" && Number.isFinite(result.windowId)
+          ? Math.trunc(result.windowId)
+          : undefined,
+    };
+  }
+
+  async screenshot(windowId: number): Promise<ComputerUseScreenshotPayload> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("screenshot", {
+      windowId,
+    }, 25_000);
+    const pngBase64 = typeof result.pngBase64 === "string" ? result.pngBase64 : "";
+    if (!pngBase64) {
+      throw new Error("Computer-use helper returned an invalid screenshot payload.");
+    }
+    return {
+      pngBase64,
+      width: Math.max(1, Math.trunc(Number(result.width) || 1)),
+      height: Math.max(1, Math.trunc(Number(result.height) || 1)),
+      scaleFactor: Math.max(1, Number(result.scaleFactor) || 1),
+    };
+  }
+
+  async axPressAtPoint(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<ComputerUseAxPressResult> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("axPressAtPoint", args);
+    return {
+      pressed: result.pressed === true,
+      reason: typeof result.reason === "string" ? result.reason : undefined,
+    };
+  }
+
+  async axFocusAtPoint(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<ComputerUseAxFocusResult> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("axFocusAtPoint", args);
+    return {
+      focused: result.focused === true,
+      reason: typeof result.reason === "string" ? result.reason : undefined,
+    };
+  }
+
+  async axDescribeAtPoint(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<Record<string, unknown>> {
+    return await this.bridgeCommand<Record<string, unknown>>("axDescribeAtPoint", args);
+  }
+
+  async axFindTextInput(args: {
+    pid: number;
+    windowId?: number;
+  }): Promise<ComputerUseAxElementResult> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("axFindTextInput", args);
+    return this.parseAxElementResult(result);
+  }
+
+  async axFocusTextInput(args: {
+    pid: number;
+    windowId?: number;
+  }): Promise<ComputerUseAxElementResult> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("axFocusTextInput", args);
+    return this.parseAxElementResult(result);
+  }
+
+  async axFindFocusableElement(args: {
+    pid: number;
+    windowId?: number;
+    roles?: string[];
+  }): Promise<ComputerUseAxElementResult> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("axFindFocusableElement", args);
+    return this.parseAxElementResult(result);
+  }
+
+  async axFindActionableElement(args: {
+    pid: number;
+    windowId?: number;
+    roles?: string[];
+  }): Promise<ComputerUseAxElementResult> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("axFindActionableElement", args);
+    return this.parseAxElementResult(result);
+  }
+
+  async focusedElement(pid: number): Promise<ComputerUseFocusedElementResult> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("focusedElement", { pid });
+    return {
+      exists: result.exists === true,
+      elementRef: typeof result.elementRef === "string" ? result.elementRef : undefined,
+      role: typeof result.role === "string" ? result.role : undefined,
+      subrole: typeof result.subrole === "string" ? result.subrole : undefined,
+      isTextInput: result.isTextInput === true,
+      isSecure: result.isSecure === true,
+      canSetValue: result.canSetValue === true,
+    };
+  }
+
+  async setValue(elementRef: string, value: string): Promise<void> {
+    await this.bridgeCommand("setValue", { elementRef, value });
+  }
+
+  async mouseClick(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+    button?: ComputerUseHelperMouseButton;
+    clickCount?: number;
+  }): Promise<void> {
+    await this.bridgeCommand("mouseClick", args);
+  }
+
+  async mouseMove(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<void> {
+    await this.bridgeCommand("mouseMove", args);
+  }
+
+  async mouseDrag(args: {
+    windowId: number;
+    pid: number;
+    path: Array<{ x: number; y: number }>;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<void> {
+    await this.bridgeCommand("mouseDrag", args, 30_000);
+  }
+
+  async scrollAtPoint(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+    scrollX: number;
+    scrollY: number;
+  }): Promise<void> {
+    await this.bridgeCommand("scrollAtPoint", args);
+  }
+
+  async typeText(text: string, pid: number): Promise<void> {
+    await this.bridgeCommand(
+      "typeText",
+      { text, pid },
+      Math.min(90_000, Math.max(HELPER_COMMAND_TIMEOUT_MS, text.length * 25 + 4_000)),
+    );
+  }
+
+  async pressKeys(spec: ComputerUseHelperKeypressSpec): Promise<void> {
+    await this.bridgeCommand("keyPress", { ...spec });
+  }
+
+  async activateApp(pid: number): Promise<void> {
+    await this.bridgeCommand("activateApp", { pid });
+  }
+
+  async raiseWindow(pid: number, windowId?: number): Promise<void> {
+    await this.bridgeCommand("raiseWindow", {
+      pid,
+      ...(typeof windowId === "number" ? { windowId } : {}),
+    }).catch(() => undefined);
+  }
+
+  async unminimizeWindow(pid: number, windowId?: number): Promise<void> {
+    await this.bridgeCommand("unminimizeWindow", {
+      pid,
+      ...(typeof windowId === "number" ? { windowId } : {}),
+    }).catch(() => undefined);
+  }
+
+  async openPermissionPane(kind: "accessibility" | "screenRecording"): Promise<void> {
+    await this.ensureHelperInstalled();
+    await this.ensureHelperProcess();
+    await this.bridgeCommand("openPermissionPane", { kind });
+  }
+
+  private async withRuntimeLock<T>(work: () => Promise<T>): Promise<T> {
+    const previous = this.queueTail;
+    let release!: () => void;
+    this.queueTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous.catch(() => undefined);
+    try {
+      return await work();
+    } finally {
+      release();
+    }
+  }
+
+  private async ensureHelperInstalled(): Promise<void> {
+    const sourcePath = this.getHelperSourcePath();
+    if (!sourcePath) {
+      throw new Error("Computer-use helper source is missing from bundled resources.");
+    }
+    await mkdir(HELPER_DIR, { recursive: true });
+    const source = await readFile(sourcePath);
+    const nextStamp = sha256(source);
+    const currentStamp = existsSync(HELPER_STAMP_PATH)
+      ? await readFile(HELPER_STAMP_PATH, "utf8").catch(() => "")
+      : "";
+    const helperIsExecutable = await isExecutable(HELPER_PATH);
+    if (helperIsExecutable && currentStamp.trim() === nextStamp) {
+      return;
+    }
+
+    const compileArgs = [
+      "swiftc",
+      "-O",
+      "-framework",
+      "AppKit",
+      "-framework",
+      "ApplicationServices",
+      "-framework",
+      "ScreenCaptureKit",
+      sourcePath,
+      "-o",
+      HELPER_PATH,
+    ];
+    const compile = spawnSync("xcrun", compileArgs, {
+      encoding: "utf8",
+      env: process.env,
+      timeout: HELPER_SETUP_TIMEOUT_MS,
+    });
+    if (compile.status !== 0) {
+      const output = [compile.stderr, compile.stdout].filter(Boolean).join("\n").trim();
+      throw new Error(
+        `Failed to build the computer-use helper with xcrun swiftc.${output ? `\n${output}` : ""}`,
+      );
+    }
+
+    await chmod(HELPER_PATH, 0o755);
+    spawnSync("codesign", ["--force", "--sign", "-", HELPER_PATH], {
+      encoding: "utf8",
+      env: process.env,
+      timeout: 15_000,
+    });
+    await writeFile(HELPER_STAMP_PATH, `${nextStamp}\n`, "utf8");
+  }
+
+  private async ensureHelperProcess(): Promise<ChildProcessWithoutNullStreams> {
+    if (this.helper && this.helper.exitCode === null && !this.helper.killed) {
+      return this.helper;
+    }
+    if (!(await isExecutable(HELPER_PATH))) {
+      throw new HelperTransportError(`Computer-use helper is missing at ${HELPER_PATH}.`);
+    }
+
+    const child = spawn(HELPER_PATH, [], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+
+    child.stdout.on("data", (chunk: string) => {
+      this.handleHelperStdoutChunk(chunk);
+    });
+    child.stderr.on("data", () => {
+      // Helper diagnostics stay local to the runtime.
+    });
+    child.on("error", (error) => {
+      if (this.helper === child) {
+        this.helper = null;
+      }
+      this.rejectAllPending(new HelperTransportError(`Computer-use helper crashed: ${error.message}`));
+    });
+    child.on("exit", (code, signal) => {
+      if (this.helper === child) {
+        this.helper = null;
+      }
+      const reason = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
+      this.rejectAllPending(new HelperTransportError(`Computer-use helper exited (${reason}).`));
+    });
+
+    this.helper = child;
+    this.helperStdoutBuffer = "";
+    return child;
+  }
+
+  private handleHelperStdoutChunk(chunk: string): void {
+    this.helperStdoutBuffer += chunk;
+    while (true) {
+      const newlineIndex = this.helperStdoutBuffer.indexOf("\n");
+      if (newlineIndex < 0) break;
+      const line = this.helperStdoutBuffer.slice(0, newlineIndex).trim();
+      this.helperStdoutBuffer = this.helperStdoutBuffer.slice(newlineIndex + 1);
+      if (!line) continue;
+
+      let parsed: Any;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const id = typeof parsed?.id === "string" ? parsed.id : "";
+      if (!id) continue;
+      const pending = this.pending.get(id);
+      if (!pending) continue;
+      this.pending.delete(id);
+      clearTimeout(pending.timer);
+      if (parsed.ok === true) {
+        pending.resolve(parsed.result);
+      } else {
+        const message =
+          typeof parsed?.error?.message === "string"
+            ? parsed.error.message
+            : `Computer-use helper command '${pending.cmd}' failed.`;
+        const code = typeof parsed?.error?.code === "string" ? parsed.error.code : undefined;
+        pending.reject(new HelperCommandError(message, code));
+      }
+    }
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      this.pending.delete(id);
+      pending.reject(error);
+    }
+  }
+
+  private async bridgeCommand<T = unknown>(
+    cmd: string,
+    args: Record<string, unknown> = {},
+    timeoutMs = HELPER_COMMAND_TIMEOUT_MS,
+  ): Promise<T> {
+    return await this.withRuntimeLock(async () => {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const helper = await this.ensureHelperProcess();
+        const id = `req_${++this.requestSequence}`;
+        try {
+          const result = await new Promise<T>((resolve, reject) => {
+            const payload = `${JSON.stringify({ id, cmd, ...args })}\n`;
+            const timer = setTimeout(() => {
+              this.pending.delete(id);
+              reject(
+                new HelperTransportError(
+                  `Computer-use helper command '${cmd}' timed out after ${timeoutMs}ms.`,
+                ),
+              );
+            }, timeoutMs);
+
+            this.pending.set(id, {
+              cmd,
+              resolve,
+              reject,
+              timer,
+            });
+
+            helper.stdin.write(payload, (error) => {
+              if (!error) return;
+              const pending = this.pending.get(id);
+              if (!pending) return;
+              clearTimeout(pending.timer);
+              this.pending.delete(id);
+              reject(
+                new HelperTransportError(
+                  `Failed to send command '${cmd}' to the computer-use helper: ${error.message}`,
+                ),
+              );
+            });
+          });
+          return result;
+        } catch (error) {
+          if (error instanceof HelperTransportError && attempt === 0) {
+            this.stop();
+            continue;
+          }
+          throw normalizeError(error);
+        }
+      }
+      throw new Error(`Computer-use helper command '${cmd}' failed.`);
+    });
+  }
+
+  private async checkPermissions(): Promise<{ accessibility: boolean; screenRecording: boolean }> {
+    const result = await this.bridgeCommand<Record<string, unknown>>("checkPermissions");
+    return {
+      accessibility: result.accessibility === true,
+      screenRecording: result.screenRecording === true,
+    };
+  }
+
+  private async ensurePermissionsInteractive(): Promise<void> {
+    let status = await this.checkPermissions();
+    if (status.accessibility && status.screenRecording) {
+      return;
+    }
+
+    const dialog = getElectronDialog();
+    if (!dialog) {
+      throw new Error(
+        `Computer use needs Accessibility and Screen Recording for the helper at ${HELPER_PATH}. Start CoWork in the desktop runtime and retry.`,
+      );
+    }
+
+    while (!status.accessibility || !status.screenRecording) {
+      const buttons: string[] = [];
+      if (!status.accessibility) buttons.push("Open Accessibility Settings");
+      if (!status.screenRecording) buttons.push("Open Screen Recording Settings");
+      buttons.push("Recheck", "Cancel");
+
+      const response = await dialog.showMessageBox({
+        type: "warning",
+        buttons,
+        defaultId: 0,
+        cancelId: buttons.length - 1,
+        noLink: true,
+        message: "Computer use requires helper permissions",
+        detail:
+          `Grant Accessibility and Screen Recording to the computer-use helper:\n${HELPER_PATH}\n\n` +
+          "Accessibility is required for AX-based interaction and Screen Recording is required for window screenshots. " +
+          "After enabling permissions in System Settings, return here and choose Recheck.",
+      });
+
+      const choice = buttons[response.response] || "Cancel";
+      if (choice === "Cancel") {
+        throw new Error(
+          `Computer-use permission setup was cancelled. Grant permissions to ${HELPER_PATH} and retry.`,
+        );
+      }
+      if (choice === "Open Accessibility Settings") {
+        await this.openPermissionPane("accessibility");
+      } else if (choice === "Open Screen Recording Settings") {
+        await this.openPermissionPane("screenRecording");
+      }
+
+      status = await this.checkPermissions();
+    }
+  }
+
+  private parseAxElementResult(result: Record<string, unknown>): ComputerUseAxElementResult {
+    return {
+      found: result.found === true,
+      focused: result.focused === true,
+      exists: result.exists === true,
+      elementRef: typeof result.elementRef === "string" ? result.elementRef : undefined,
+      role: typeof result.role === "string" ? result.role : undefined,
+      subrole: typeof result.subrole === "string" ? result.subrole : undefined,
+      title: typeof result.title === "string" ? result.title : undefined,
+      value: typeof result.value === "string" ? result.value : undefined,
+      x: typeof result.x === "number" && Number.isFinite(result.x) ? result.x : undefined,
+      y: typeof result.y === "number" && Number.isFinite(result.y) ? result.y : undefined,
+      score: typeof result.score === "number" && Number.isFinite(result.score) ? result.score : undefined,
+      confidence: typeof result.confidence === "string" ? result.confidence : undefined,
+      actions: Array.isArray(result.actions) ? result.actions.filter((entry): entry is string => typeof entry === "string") : undefined,
+      isTextInput: result.isTextInput === true,
+      isSecure: result.isSecure === true,
+      canSetValue: result.canSetValue === true,
+      reason: typeof result.reason === "string" ? result.reason : undefined,
+    };
+  }
+}

--- a/src/electron/computer-use/session-manager.ts
+++ b/src/electron/computer-use/session-manager.ts
@@ -1,12 +1,11 @@
 /**
- * Single active computer-use session: overlay, isolation, shortcuts, per-app permissions.
+ * Single active computer-use session with minimal guards:
+ * - one task owns computer use at a time
+ * - Esc aborts the active session
+ * - no per-app approval, overlay, or isolation layer
  */
 
 import type { BrowserWindow } from "electron";
-import { AppPermissionManager } from "../security/app-permission-manager";
-import { classifyApp, formatAccessLevelForUi } from "./app-risk-profile";
-import { CUASafetyOverlay } from "./safety-overlay";
-import { WindowIsolation } from "./window-isolation";
 import { ShortcutGuard } from "./shortcut-guard";
 
 export type ComputerUseSessionEndReason = "completed" | "aborted" | "manual";
@@ -41,20 +40,15 @@ export class ComputerUseSessionManager {
     return ComputerUseSessionManager.instance;
   }
 
-  /** Test-only reset */
   static resetForTesting(): void {
     ComputerUseSessionManager.instance = null;
   }
 
   private activeTaskId: string | null = null;
   private daemon: ComputerUseDaemonLike | null = null;
-  private appPermissionManager: AppPermissionManager | null = null;
-  private readonly overlay = new CUASafetyOverlay();
-  private readonly isolation = new WindowIsolation();
   private readonly shortcutGuard = new ShortcutGuard();
   private aborted = false;
   private mainWindowGetter: (() => BrowserWindow | null) | null = null;
-  private mainWindowWasVisible = false;
   private notifyHandler: ((e: ComputerUseSessionEvent) => void) | null = null;
 
   private constructor() {}
@@ -71,79 +65,39 @@ export class ComputerUseSessionManager {
     return this.activeTaskId;
   }
 
-  /** Active session's permission map, if any. */
-  getAppPermissionManagerOrNull(): AppPermissionManager | null {
-    return this.appPermissionManager;
+  getAppPermissionManagerOrNull(): null {
+    return null;
   }
 
   isAborted(): boolean {
     return this.aborted;
   }
 
-  /**
-   * Begin or continue a session for this task. Throws if another task holds the lock.
-   */
-  acquire(taskId: string, daemon: ComputerUseDaemonLike): AppPermissionManager {
+  acquire(taskId: string, daemon: ComputerUseDaemonLike): void {
     if (this.activeTaskId && this.activeTaskId !== taskId) {
       throw new Error(
         "Computer use is already active for another task. Finish or cancel that task first.",
       );
     }
 
-    if (!this.activeTaskId) {
-      this.activeTaskId = taskId;
-      this.daemon = daemon;
-      this.aborted = false;
-
-      const pm = new AppPermissionManager(`cua-session-${taskId}-${Date.now()}`);
-      pm.onPermissionRequest = async (request) => {
-        const profile = classifyApp(request.bundleId || "", request.appName);
-        const description = `Allow ${formatAccessLevelForUi(request.requestedLevel)} for "${request.appName}" this session?`;
-        const approved = await daemon.requestApproval(
-          taskId,
-          "computer_use",
-          description,
-          {
-            kind: "computer_use_app_grant",
-            appName: request.appName,
-            bundleId: request.bundleId,
-            requestedLevel: request.requestedLevel,
-            reason: request.reason,
-            riskClass: profile.riskClass,
-            maxSuggestedLevel: profile.maxSuggestedLevel,
-            sentinelWarning: profile.sentinelWarning,
-          },
-          { allowAutoApprove: false },
-        );
-        return approved ? request.requestedLevel : "denied";
-      };
-
-      this.appPermissionManager = pm;
-
-      this.overlay.show();
-      this.overlay.updateStatus("Preparing…");
-
-      this.shortcutGuard.enable(() => {
-        void this.abortSession(taskId);
-      });
-
-      const mw = this.mainWindowGetter?.() ?? null;
-      if (mw && !mw.isDestroyed() && mw.isVisible()) {
-        this.mainWindowWasVisible = true;
-        mw.hide();
-      }
-
-      daemon.logEvent(taskId, "computer_use_session_started", {});
-      this.emitNotify({ type: "session_started", taskId });
+    if (this.activeTaskId) {
+      return;
     }
 
-    return this.appPermissionManager!;
+    this.activeTaskId = taskId;
+    this.daemon = daemon;
+    this.aborted = false;
+    void (this.mainWindowGetter?.() ?? null);
+
+    this.shortcutGuard.enable(() => {
+      void this.abortSession(taskId);
+    });
+
+    daemon.logEvent(taskId, "computer_use_session_started", { mode: "helper_runtime" });
+    this.emitNotify({ type: "session_started", taskId });
   }
 
-  updateActionStatus(label: string): void {
-    if (!this.activeTaskId) return;
-    this.overlay.updateStatus(label);
-  }
+  updateActionStatus(_label: string): void {}
 
   checkNotAborted(): void {
     if (this.aborted) {
@@ -151,30 +105,15 @@ export class ComputerUseSessionManager {
     }
   }
 
-  /**
-   * Re-run window isolation after app list changes (best-effort).
-   */
-  async refreshIsolation(): Promise<void> {
-    if (!this.activeTaskId || !this.appPermissionManager) return;
-    const names = this.appPermissionManager.getActivePermissions().map((p) => p.appName);
-    if (names.length === 0) return;
-    try {
-      await this.isolation.isolate(names, { keepHostProcessesVisible: false });
-    } catch {
-      // isolation is best-effort
-    }
-  }
+  async refreshIsolation(): Promise<void> {}
 
-  async onAppPermissionGranted(): Promise<void> {
-    await this.refreshIsolation();
-  }
+  async onAppPermissionGranted(): Promise<void> {}
 
   endSessionIfOwner(taskId: string, reason: ComputerUseSessionEndReason = "completed"): void {
     if (this.activeTaskId !== taskId) return;
     void this.cleanupInternal(taskId, reason);
   }
 
-  /** User or Esc — abort and tear down */
   async abortSession(taskId: string): Promise<void> {
     if (this.activeTaskId !== taskId) return;
     this.aborted = true;
@@ -184,9 +123,9 @@ export class ComputerUseSessionManager {
 
   async endSessionManual(): Promise<void> {
     if (!this.activeTaskId) return;
-    const tid = this.activeTaskId;
-    this.daemon?.logEvent(tid, "computer_use_session_ended", { reason: "manual" });
-    await this.cleanupInternal(tid, "manual");
+    const taskId = this.activeTaskId;
+    this.daemon?.logEvent(taskId, "computer_use_session_ended", { reason: "manual" });
+    await this.cleanupInternal(taskId, "manual");
   }
 
   private emitNotify(event: ComputerUseSessionEvent): void {
@@ -204,29 +143,13 @@ export class ComputerUseSessionManager {
     if (this.activeTaskId !== taskId) return;
 
     this.shortcutGuard.disable();
-    this.overlay.hide();
-
-    try {
-      await this.isolation.restore();
-    } catch {
-      // best-effort
-    }
-
-    this.appPermissionManager?.revokeAll();
-    this.appPermissionManager = null;
-
-    const mw = this.mainWindowGetter?.() ?? null;
-    if (this.mainWindowWasVisible && mw && !mw.isDestroyed()) {
-      mw.show();
-    }
-    this.mainWindowWasVisible = false;
 
     this.activeTaskId = null;
-    const d = this.daemon;
+    const daemon = this.daemon;
     this.daemon = null;
 
     if (reason === "completed") {
-      d?.logEvent(taskId, "computer_use_session_ended", { reason: "task_finished" });
+      daemon?.logEvent(taskId, "computer_use_session_ended", { reason: "task_finished" });
     }
 
     this.emitNotify({ type: "session_ended", taskId, reason });

--- a/src/electron/computer-use/shortcut-guard.ts
+++ b/src/electron/computer-use/shortcut-guard.ts
@@ -7,7 +7,7 @@
  *
  * Limitation: Electron's globalShortcut cannot intercept all macOS system
  * shortcuts (e.g. Cmd+Tab, Cmd+Space are handled by the OS before Electron
- * sees them). For those, the ComputerUseTools blocklist in computer_key
+ * sees them). For those, the ComputerUseTools blocklist in keypress
  * provides a secondary safety net.
  */
 

--- a/src/electron/security/__tests__/permission-settings-manager.test.ts
+++ b/src/electron/security/__tests__/permission-settings-manager.test.ts
@@ -52,6 +52,15 @@ describe("PermissionSettingsManager", () => {
     ]);
   });
 
+  it("falls back to dangerous_only when no settings are stored", () => {
+    repository.load.mockReturnValue(undefined);
+
+    const settings = PermissionSettingsManager.loadSettings();
+
+    expect(settings.defaultMode).toBe("dangerous_only");
+    expect(settings.rules).toEqual([]);
+  });
+
   it("appends deduplicated profile rules and persists them", () => {
     repository.load.mockReturnValue({
       version: 1,

--- a/src/electron/security/permission-settings-manager.ts
+++ b/src/electron/security/permission-settings-manager.ts
@@ -13,7 +13,7 @@ export interface PermissionSettings {
 
 const DEFAULT_SETTINGS: PermissionSettings = {
   version: 1,
-  defaultMode: "default",
+  defaultMode: "dangerous_only",
   rules: [],
 };
 
@@ -79,7 +79,7 @@ export class PermissionSettingsManager {
   private static normalizeSettings(settings: PermissionSettings): PermissionSettings {
     return {
       version: 1,
-      defaultMode: settings?.defaultMode || "default",
+      defaultMode: settings?.defaultMode || "dangerous_only",
       rules: Array.isArray(settings?.rules)
         ? settings.rules
             .filter((rule): rule is PermissionRule => !!rule && typeof rule === "object")

--- a/src/renderer/components/PermissionSettingsPanel.tsx
+++ b/src/renderer/components/PermissionSettingsPanel.tsx
@@ -6,6 +6,7 @@ import type {
   PermissionSettingsData,
   PersistedPermissionRule,
 } from "../../shared/types";
+import type { BuiltinToolsSettings as BuiltinToolsSettingsData } from "../../electron/agent/tools/builtin-settings";
 
 type RuleDraft = {
   effect: "allow" | "deny" | "ask";
@@ -17,9 +18,11 @@ type RuleDraft = {
   serverName: string;
 };
 
+type ApprovalExperiencePreset = "standard" | "fewer_prompts" | "custom";
+
 const DEFAULT_SETTINGS: PermissionSettingsData = {
   version: 1,
-  defaultMode: "default",
+  defaultMode: "dangerous_only",
   rules: [],
 };
 
@@ -82,8 +85,66 @@ export function buildScope(draft: RuleDraft): PermissionRuleScope {
   }
 }
 
+export function applyFewerApprovalPromptsPreset<T extends BuiltinToolsSettingsData>(
+  permissionSettings: PermissionSettingsData,
+  builtinSettings: T,
+): {
+  permissionSettings: PermissionSettingsData;
+  builtinSettings: T;
+} {
+  return {
+    permissionSettings: {
+      ...permissionSettings,
+      defaultMode: "dangerous_only",
+    },
+    builtinSettings: {
+      ...builtinSettings,
+      runCommandApprovalMode: "single_bundle",
+    },
+  };
+}
+
+export function applyStandardApprovalPromptsPreset<T extends BuiltinToolsSettingsData>(
+  permissionSettings: PermissionSettingsData,
+  builtinSettings: T,
+): {
+  permissionSettings: PermissionSettingsData;
+  builtinSettings: T;
+} {
+  return {
+    permissionSettings: {
+      ...permissionSettings,
+      defaultMode: "default",
+    },
+    builtinSettings: {
+      ...builtinSettings,
+      runCommandApprovalMode: "per_command",
+    },
+  };
+}
+
+export function detectApprovalExperiencePreset(
+  permissionSettings: PermissionSettingsData,
+  builtinSettings: Pick<BuiltinToolsSettingsData, "runCommandApprovalMode">,
+): ApprovalExperiencePreset {
+  if (
+    permissionSettings.defaultMode === "dangerous_only" &&
+    builtinSettings.runCommandApprovalMode === "single_bundle"
+  ) {
+    return "fewer_prompts";
+  }
+  if (
+    permissionSettings.defaultMode === "default" &&
+    builtinSettings.runCommandApprovalMode === "per_command"
+  ) {
+    return "standard";
+  }
+  return "custom";
+}
+
 export function PermissionSettingsPanel({ workspaceId }: PermissionSettingsPanelProps) {
   const [settings, setSettings] = useState<PermissionSettingsData>(DEFAULT_SETTINGS);
+  const [builtinSettings, setBuiltinSettings] = useState<BuiltinToolsSettingsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [ruleDraft, setRuleDraft] = useState<RuleDraft>(DEFAULT_RULE_DRAFT);
@@ -94,6 +155,10 @@ export function PermissionSettingsPanel({ workspaceId }: PermissionSettingsPanel
 
   useEffect(() => {
     void loadSettings();
+  }, []);
+
+  useEffect(() => {
+    void loadBuiltinSettings();
   }, []);
 
   useEffect(() => {
@@ -113,6 +178,16 @@ export function PermissionSettingsPanel({ workspaceId }: PermissionSettingsPanel
     }
   };
 
+  const loadBuiltinSettings = async () => {
+    try {
+      const loaded = await window.electronAPI.getBuiltinToolsSettings();
+      setBuiltinSettings(loaded);
+    } catch (error) {
+      console.error("Failed to load built-in tools settings:", error);
+      setBuiltinSettings(null);
+    }
+  };
+
   const saveSettings = async (next: PermissionSettingsData) => {
     try {
       setSaving(true);
@@ -122,6 +197,43 @@ export function PermissionSettingsPanel({ workspaceId }: PermissionSettingsPanel
     } catch (error) {
       console.error("Failed to save permission settings:", error);
       setStatusMessage("Failed to save permission settings.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const approvalPreset = useMemo(() => {
+    if (!builtinSettings) return "custom";
+    return detectApprovalExperiencePreset(settings, builtinSettings);
+  }, [builtinSettings, settings]);
+
+  const applyApprovalPreset = async (preset: Exclude<ApprovalExperiencePreset, "custom">) => {
+    if (!builtinSettings) {
+      setStatusMessage("Built-in tools settings are unavailable right now.");
+      return;
+    }
+
+    const next =
+      preset === "fewer_prompts"
+        ? applyFewerApprovalPromptsPreset(settings, builtinSettings)
+        : applyStandardApprovalPromptsPreset(settings, builtinSettings);
+
+    try {
+      setSaving(true);
+      await Promise.all([
+        window.electronAPI.savePermissionSettings(next.permissionSettings),
+        window.electronAPI.saveBuiltinToolsSettings(next.builtinSettings),
+      ]);
+      setSettings(next.permissionSettings);
+      setBuiltinSettings(next.builtinSettings);
+      setStatusMessage(
+        preset === "fewer_prompts"
+          ? "Fewer approval prompts enabled."
+          : "Standard approval prompts restored.",
+      );
+    } catch (error) {
+      console.error("Failed to apply approval preset:", error);
+      setStatusMessage("Failed to update approval settings.");
     } finally {
       setSaving(false);
     }
@@ -229,6 +341,38 @@ export function PermissionSettingsPanel({ workspaceId }: PermissionSettingsPanel
       </p>
 
       <div className="settings-subsection">
+        <h4 style={{ margin: "0 0 8px" }}>Approval experience</h4>
+        <p className="settings-hint">
+          Fewer prompts keeps approvals for deletes, risky shell commands, browser/system actions,
+          and external side effects, while letting routine repo work proceed with less friction.
+        </p>
+        <p className="settings-hint" style={{ marginTop: "6px" }}>
+          Current:{" "}
+          {approvalPreset === "fewer_prompts"
+            ? "Fewer prompts"
+            : approvalPreset === "standard"
+              ? "Standard prompts"
+              : "Custom"}
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", marginTop: "10px" }}>
+          <button
+            className="button-small button-secondary"
+            onClick={() => void applyApprovalPreset("fewer_prompts")}
+            disabled={saving || !builtinSettings}
+          >
+            Use fewer prompts
+          </button>
+          <button
+            className="button-small button-secondary"
+            onClick={() => void applyApprovalPreset("standard")}
+            disabled={saving || !builtinSettings}
+          >
+            Restore standard prompts
+          </button>
+        </div>
+      </div>
+
+      <div className="settings-subsection">
         <label className="settings-label">Default permission mode</label>
         <select
           className="settings-select"
@@ -248,7 +392,8 @@ export function PermissionSettingsPanel({ workspaceId }: PermissionSettingsPanel
           <option value="bypass_permissions">Bypass permissions</option>
         </select>
         <p className="settings-hint">
-          This mode applies when no explicit permission rule matches.
+          This mode applies when no explicit permission rule matches. For everyday repo work,
+          `dangerous_only` is the lower-noise option.
         </p>
       </div>
 

--- a/src/renderer/components/__tests__/permission-settings-panel.test.ts
+++ b/src/renderer/components/__tests__/permission-settings-panel.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { buildScope, scopeToLabel } from "../PermissionSettingsPanel";
+import {
+  applyFewerApprovalPromptsPreset,
+  applyStandardApprovalPromptsPreset,
+  buildScope,
+  detectApprovalExperiencePreset,
+  scopeToLabel,
+} from "../PermissionSettingsPanel";
+
+const builtinCategories = {
+  code: { enabled: true, priority: "high" as const },
+  webfetch: { enabled: true, priority: "high" as const },
+  browser: { enabled: true, priority: "normal" as const },
+  search: { enabled: true, priority: "normal" as const },
+  system: { enabled: true, priority: "normal" as const },
+  file: { enabled: true, priority: "normal" as const },
+  skill: { enabled: true, priority: "normal" as const },
+  shell: { enabled: true, priority: "normal" as const },
+  image: { enabled: true, priority: "normal" as const },
+  chronicle: { enabled: true, priority: "normal" as const },
+  computer_use: { enabled: true, priority: "normal" as const },
+};
 
 describe("PermissionSettingsPanel helpers", () => {
   it("renders domain-scoped rules without returning an object", () => {
@@ -28,5 +48,64 @@ describe("PermissionSettingsPanel helpers", () => {
       toolName: "web_fetch",
       domain: "docs.example.com",
     });
+  });
+
+  it("applies the fewer-prompts preset", () => {
+    const result = applyFewerApprovalPromptsPreset(
+      {
+        version: 1,
+        defaultMode: "default",
+        rules: [],
+      },
+      {
+        categories: builtinCategories,
+        toolOverrides: {},
+        toolTimeouts: {},
+        toolAutoApprove: {},
+        runCommandApprovalMode: "per_command",
+        codexRuntimeMode: "native",
+        version: "1.0.0",
+      },
+    );
+
+    expect(result.permissionSettings.defaultMode).toBe("dangerous_only");
+    expect(result.builtinSettings.runCommandApprovalMode).toBe("single_bundle");
+  });
+
+  it("detects the fewer-prompts preset", () => {
+    expect(
+      detectApprovalExperiencePreset(
+        {
+          version: 1,
+          defaultMode: "dangerous_only",
+          rules: [],
+        },
+        {
+          runCommandApprovalMode: "single_bundle",
+        },
+      ),
+    ).toBe("fewer_prompts");
+  });
+
+  it("restores the standard approval preset", () => {
+    const result = applyStandardApprovalPromptsPreset(
+      {
+        version: 1,
+        defaultMode: "dangerous_only",
+        rules: [],
+      },
+      {
+        categories: builtinCategories,
+        toolOverrides: {},
+        toolTimeouts: {},
+        toolAutoApprove: {},
+        runCommandApprovalMode: "single_bundle",
+        codexRuntimeMode: "native",
+        version: "1.0.0",
+      },
+    );
+
+    expect(result.permissionSettings.defaultMode).toBe("default");
+    expect(result.builtinSettings.runCommandApprovalMode).toBe("per_command");
   });
 });

--- a/src/shared/__tests__/shell-permission-intents.test.ts
+++ b/src/shared/__tests__/shell-permission-intents.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { classifyShellPermissionDecision } from "../shell-permission-intents";
+
+describe("classifyShellPermissionDecision", () => {
+  it("detects explicit enable phrases", () => {
+    expect(classifyShellPermissionDecision("enable shell")).toBe("enable_shell");
+    expect(classifyShellPermissionDecision("please turn on shell access")).toBe(
+      "enable_shell",
+    );
+  });
+
+  it("detects continue-without-shell phrases", () => {
+    expect(classifyShellPermissionDecision("continue without shell")).toBe(
+      "continue_without_shell",
+    );
+    expect(classifyShellPermissionDecision("go ahead, limited best effort is fine")).toBe(
+      "continue_without_shell",
+    );
+  });
+
+  it("returns unknown for unrelated text", () => {
+    expect(classifyShellPermissionDecision("show me the logs")).toBe("unknown");
+  });
+});

--- a/src/shared/computer-use-contract.ts
+++ b/src/shared/computer-use-contract.ts
@@ -1,0 +1,19 @@
+export const COMPUTER_USE_TOOL_NAMES = [
+  "screenshot",
+  "click",
+  "double_click",
+  "move_mouse",
+  "drag",
+  "scroll",
+  "type_text",
+  "keypress",
+  "wait",
+] as const;
+
+export type ComputerUseToolName = (typeof COMPUTER_USE_TOOL_NAMES)[number];
+
+const COMPUTER_USE_TOOL_NAME_SET = new Set<string>(COMPUTER_USE_TOOL_NAMES);
+
+export function isComputerUseToolName(toolName: string): toolName is ComputerUseToolName {
+  return COMPUTER_USE_TOOL_NAME_SET.has(String(toolName || "").trim());
+}

--- a/src/shared/shell-permission-intents.ts
+++ b/src/shared/shell-permission-intents.ts
@@ -1,0 +1,35 @@
+export type ShellPermissionDecision =
+  | "enable_shell"
+  | "continue_without_shell"
+  | "unknown";
+
+export function classifyShellPermissionDecision(text: string): ShellPermissionDecision {
+  const lower = String(text || "")
+    .toLowerCase()
+    .trim();
+  if (!lower) return "unknown";
+
+  if (/^(?:yes|yep|yeah|sure|ok|okay|please do|do it)[.!]?$/i.test(lower)) {
+    return "enable_shell";
+  }
+  if (/^(?:no|nope|nah)[.!]?$/i.test(lower)) {
+    return "continue_without_shell";
+  }
+  if (
+    /\b(?:enable|turn on|allow|grant)\b[\s\S]{0,20}\bshell\b/.test(lower) ||
+    /\bshell\b[\s\S]{0,20}\b(?:enable|enabled|on|allow|grant)\b/.test(lower)
+  ) {
+    return "enable_shell";
+  }
+  if (
+    /\b(?:continue|proceed|go ahead|move on)\b/.test(lower) ||
+    /\bwithout shell\b/.test(lower) ||
+    /\b(?:don['’]?t|do not)\s+enable\s+shell\b/.test(lower) ||
+    /\bbest effort\b/.test(lower) ||
+    /\blimited\b/.test(lower)
+  ) {
+    return "continue_without_shell";
+  }
+
+  return "unknown";
+}

--- a/tests/tools/builtin-settings.test.ts
+++ b/tests/tools/builtin-settings.test.ts
@@ -89,7 +89,7 @@ describe('BuiltinToolsSettingsManager', () => {
         toolOverrides: {},
         toolTimeouts: {},
         toolAutoApprove: {},
-        runCommandApprovalMode: 'per_command',
+        runCommandApprovalMode: 'single_bundle',
         version: '1.0.0',
       };
 
@@ -126,7 +126,7 @@ describe('BuiltinToolsSettingsManager', () => {
       // Should have merged the image category from defaults
       expect(settings.categories.image).toBeDefined();
       expect(settings.categories.image.enabled).toBe(true);
-      expect(settings.runCommandApprovalMode).toBe('per_command');
+      expect(settings.runCommandApprovalMode).toBe('single_bundle');
     });
 
     it('should cache settings after first load', () => {
@@ -438,9 +438,9 @@ describe('BuiltinToolsSettingsManager', () => {
       expect(defaults.categories.image.enabled).toBe(true);
     });
 
-    it('should use per-command shell approval mode by default', () => {
+    it('should use single-bundle shell approval mode by default', () => {
       const defaults = BuiltinToolsSettingsManager.getDefaultSettings();
-      expect(defaults.runCommandApprovalMode).toBe('per_command');
+      expect(defaults.runCommandApprovalMode).toBe('single_bundle');
     });
 
     it('should have all categories at normal priority by default', () => {
@@ -472,13 +472,13 @@ describe('BuiltinToolsSettingsManager', () => {
       expect(BuiltinToolsSettingsManager.getRunCommandApprovalMode()).toBe('single_bundle');
     });
 
-    it('falls back to per_command for unknown values', () => {
+    it('falls back to single_bundle for unknown values', () => {
       const settings = BuiltinToolsSettingsManager.getDefaultSettings() as any;
       settings.runCommandApprovalMode = 'unexpected_mode';
       mockStoredSettings = settings;
       BuiltinToolsSettingsManager.clearCache();
 
-      expect(BuiltinToolsSettingsManager.getRunCommandApprovalMode()).toBe('per_command');
+      expect(BuiltinToolsSettingsManager.getRunCommandApprovalMode()).toBe('single_bundle');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Reworks computer-use tools around the helper runtime and Pi-style tool names.
- Adds the Swift computer-use bridge to packaged resources.
- Adds shared shell-permission intent helpers and updates runtime tool metadata.
- Lowers default approval noise via dangerous-only permissions and single-bundle shell approval defaults.

## Validation
- npm run type-check
- npx vitest run src/electron/agent/skills/__tests__/image-generator-oauth.test.ts src/electron/hooks/__tests__/server.test.ts
- Previous full-stack validation: npm run skills:check:core

## Notes
This PR is the next layer after the merged startup fix, bundled skills, and unused-logo cleanup PRs.