### PR TITLE
feat(artifacts): add rich presentation and latex previews

### DIFF
--- a/src/electron/agent/tools/__tests__/document-tools.test.ts
+++ b/src/electron/agent/tools/__tests__/document-tools.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { randomUUID } from "crypto";
 import { describe, expect, it, vi } from "vitest";
 import { DocumentTools } from "../document-tools";
+import { compileLatex } from "../../../utils/document-generators/latex-compiler";
 
 // Mock the generator modules since they depend on external packages
 vi.mock("../../../utils/document-generators/pdf-generator", () => ({
@@ -44,6 +45,18 @@ vi.mock("../../../utils/document-generators/html-page-generator", () => ({
     size: 11111,
   }),
 }));
+vi.mock("../../../utils/document-generators/latex-compiler", () => ({
+  compileLatex: vi.fn().mockResolvedValue({
+    success: true,
+    sourcePath: "/workspace/paper.tex",
+    pdfPath: "/workspace/paper.pdf",
+    path: "/workspace/paper.pdf",
+    logPath: "/workspace/paper.log",
+    engine: "tectonic",
+    size: 33333,
+    diagnostic: "ok",
+  }),
+}));
 vi.mock("../../../voice", () => ({
   getVoiceService: vi.fn(() => ({
     speak: vi.fn().mockResolvedValue(Buffer.from("audio")),
@@ -56,8 +69,9 @@ describe("DocumentTools", () => {
   it("getToolDefinitions returns all tool definitions", () => {
     const defs = DocumentTools.getToolDefinitions();
 
-    expect(defs).toHaveLength(6);
+    expect(defs).toHaveLength(7);
     const names = defs.map((d) => d.name);
+    expect(names).toContain("compile_latex");
     expect(names).toContain("generate_document");
     expect(names).toContain("generate_presentation");
     expect(names).toContain("generate_spreadsheet");
@@ -119,6 +133,57 @@ describe("DocumentTools", () => {
 
     // sanitizeFilename should strip path traversal via path.basename
     expect(result.success).toBe(true);
+  });
+
+  it("compileLatex calls the compiler and registers the PDF artifact with source metadata", async () => {
+    const registerArtifact = vi.fn();
+    const tools = new DocumentTools("/workspace", "task-1", registerArtifact);
+
+    const result = await tools.compileLatex({
+      sourcePath: "paper.tex",
+      outputPath: "paper.pdf",
+      engine: "auto",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.path).toBe("/workspace/paper.pdf");
+    expect(compileLatex).toHaveBeenCalledWith({
+      workspacePath: "/workspace",
+      sourcePath: "paper.tex",
+      outputPath: "paper.pdf",
+      engine: "auto",
+    });
+    expect(registerArtifact).toHaveBeenCalledWith(
+      "task-1",
+      "/workspace/paper.pdf",
+      "application/pdf",
+      expect.objectContaining({
+        sourcePath: "/workspace/paper.tex",
+        logPath: "/workspace/paper.log",
+        engine: "tectonic",
+        type: "latex_pdf",
+      }),
+    );
+  });
+
+  it("compileLatex does not register an artifact when compilation fails", async () => {
+    vi.mocked(compileLatex).mockResolvedValueOnce({
+      success: false,
+      sourcePath: "/workspace/paper.tex",
+      pdfPath: "/workspace/paper.pdf",
+      path: "/workspace/paper.pdf",
+      logPath: "/workspace/paper.log",
+      error: "No LaTeX engine found",
+      diagnostic: "No LaTeX engine found",
+    } as Any);
+    const registerArtifact = vi.fn();
+    const tools = new DocumentTools("/workspace", "task-1", registerArtifact);
+
+    const result = await tools.compileLatex({ sourcePath: "paper.tex" });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("No LaTeX engine");
+    expect(registerArtifact).not.toHaveBeenCalled();
   });
 
   // ── generatePresentation ──────────────────────────────────────

--- a/src/electron/agent/tools/document-tools.ts
+++ b/src/electron/agent/tools/document-tools.ts
@@ -16,6 +16,7 @@ import { generatePPTX } from "../../utils/document-generators/pptx-generator";
 import { generateXLSX } from "../../utils/document-generators/xlsx-generator";
 import { generateEPUB } from "../../utils/document-generators/epub-generator";
 import { generateLandingPage } from "../../utils/document-generators/html-page-generator";
+import { compileLatex } from "../../utils/document-generators/latex-compiler";
 import { getVoiceService } from "../../voice";
 
 function sanitizeFilename(raw: string, maxLen = 80): string {
@@ -27,7 +28,12 @@ export class DocumentTools {
   constructor(
     private workspacePath: string,
     private taskId: string,
-    private registerArtifact?: (taskId: string, filePath: string, mimeType: string) => void,
+    private registerArtifact?: (
+      taskId: string,
+      filePath: string,
+      mimeType: string,
+      metadata?: Record<string, unknown>,
+    ) => void,
   ) {}
 
   setWorkspace(workspace: { path: string }): void {
@@ -38,6 +44,32 @@ export class DocumentTools {
 
   static getToolDefinitions(): LLMTool[] {
     return [
+      {
+        name: "compile_latex",
+        description:
+          "Compile a workspace .tex file into a PDF using a system LaTeX engine. " +
+          "Use this after writing LaTeX/TikZ source when the user asks for a compiled paper or PDF. " +
+          "Uses tectonic, latexmk, xelatex, lualatex, or pdflatex when installed.",
+        input_schema: {
+          type: "object" as const,
+          properties: {
+            sourcePath: {
+              type: "string",
+              description: 'Workspace-relative or absolute path to the .tex file (e.g. "paper.tex")',
+            },
+            outputPath: {
+              type: "string",
+              description: 'Optional workspace-contained PDF path (e.g. "paper.pdf")',
+            },
+            engine: {
+              type: "string",
+              enum: ["auto", "tectonic", "latexmk", "xelatex", "lualatex", "pdflatex"],
+              description: "Optional compiler preference. Defaults to auto.",
+            },
+          },
+          required: ["sourcePath"],
+        },
+      },
       {
         name: "generate_document",
         description:
@@ -261,6 +293,40 @@ export class DocumentTools {
   }
 
   // ── Tool execution ──────────────────────────────────────────────
+
+  async compileLatex(input: Any): Promise<Any> {
+    const result = await compileLatex({
+      workspacePath: this.workspacePath,
+      sourcePath: input.sourcePath,
+      outputPath: input.outputPath,
+      engine: input.engine || "auto",
+    });
+
+    if (result.success && this.registerArtifact) {
+      this.registerArtifact(this.taskId, result.pdfPath, "application/pdf", {
+        sourcePath: result.sourcePath,
+        logPath: result.logPath,
+        engine: result.engine,
+        type: "latex_pdf",
+      });
+    }
+
+    return {
+      success: result.success,
+      sourcePath: result.sourcePath,
+      pdfPath: result.pdfPath,
+      path: result.pdfPath,
+      logPath: result.logPath,
+      engine: result.engine,
+      size: result.size,
+      error: result.error,
+      diagnostic: result.diagnostic,
+      mimeType: "application/pdf",
+      message: result.success
+        ? `LaTeX compiled: ${path.basename(result.pdfPath)} (${formatBytes(result.size || 0)})`
+        : `LaTeX compile failed: ${result.error || result.diagnostic}`,
+    };
+  }
 
   async generateDocument(input: Any): Promise<Any> {
     const filename = sanitizeFilename(input.filename || "document.pdf");

--- a/src/electron/ipc/__tests__/video-preview-transcode.test.ts
+++ b/src/electron/ipc/__tests__/video-preview-transcode.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { buildVideoPreviewTranscodeArgs } from "../video-preview-transcode";
+
+describe("buildVideoPreviewTranscodeArgs", () => {
+  it("builds a video-only ffmpeg command so silent mp4 previews still transcode", () => {
+    const args = buildVideoPreviewTranscodeArgs(
+      "/workspace/artifacts/demo.mp4",
+      "/tmp/demo-preview.webm",
+    );
+
+    expect(args).toEqual([
+      "-y",
+      "-i",
+      "/workspace/artifacts/demo.mp4",
+      "-map",
+      "0:v:0",
+      "-an",
+      "-c:v",
+      "libvpx",
+      "-deadline",
+      "realtime",
+      "-cpu-used",
+      "5",
+      "-crf",
+      "24",
+      "-b:v",
+      "1M",
+      "/tmp/demo-preview.webm",
+    ]);
+    expect(args).not.toContain("-c:a");
+    expect(args).not.toContain("-b:a");
+  });
+});

--- a/src/electron/ipc/video-preview-transcode.ts
+++ b/src/electron/ipc/video-preview-transcode.ts
@@ -1,0 +1,24 @@
+export function buildVideoPreviewTranscodeArgs(
+  inputPath: string,
+  outputPath: string,
+): string[] {
+  return [
+    "-y",
+    "-i",
+    inputPath,
+    "-map",
+    "0:v:0",
+    "-an",
+    "-c:v",
+    "libvpx",
+    "-deadline",
+    "realtime",
+    "-cpu-used",
+    "5",
+    "-crf",
+    "24",
+    "-b:v",
+    "1M",
+    outputPath,
+  ];
+}

--- a/src/electron/utils/PptxPreviewService.ts
+++ b/src/electron/utils/PptxPreviewService.ts
@@ -1,0 +1,292 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { createHash } from "crypto";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { getUserDataDir } from "./user-data-dir";
+import {
+  extractPptxStructuredContentFromFile,
+  type PptxExtractedSlide,
+  type PptxStructuredExtract,
+} from "./pptx-extractor";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_RENDER_TIMEOUT_MS = 45_000;
+const DEFAULT_MAX_RENDERED_SLIDES = 80;
+
+export type PptxPreviewRenderStatus = "rendered" | "text_only" | "failed";
+
+export interface PptxPreviewSlide {
+  index: number;
+  title?: string;
+  text: string;
+  notes?: string;
+  imageDataUrl?: string;
+}
+
+export interface PptxPresentationPreview {
+  slideCount: number;
+  title?: string;
+  slides: PptxPreviewSlide[];
+  renderStatus: PptxPreviewRenderStatus;
+  renderMessage?: string;
+}
+
+type CommandRunner = (
+  command: string,
+  args: string[],
+  options: { timeout: number; maxBuffer?: number },
+) => Promise<unknown>;
+
+interface PptxPreviewServiceOptions {
+  cacheRoot?: string;
+  commandRunner?: CommandRunner;
+  renderTimeoutMs?: number;
+  maxRenderedSlides?: number;
+}
+
+interface CachedRenderManifest {
+  sourcePath: string;
+  sourceSize: number;
+  sourceMtimeMs: number;
+  imageFiles: Array<{ index: number; fileName: string }>;
+}
+
+export class PptxPreviewService {
+  private readonly cacheRoot: string;
+  private readonly commandRunner: CommandRunner;
+  private readonly renderTimeoutMs: number;
+  private readonly maxRenderedSlides: number;
+
+  constructor(options: PptxPreviewServiceOptions = {}) {
+    this.cacheRoot =
+      options.cacheRoot ?? path.join(getUserDataDir(), "cache", "pptx-previews");
+    this.commandRunner =
+      options.commandRunner ??
+      ((command, args, execOptions) =>
+        execFileAsync(command, args, execOptions));
+    this.renderTimeoutMs = options.renderTimeoutMs ?? DEFAULT_RENDER_TIMEOUT_MS;
+    this.maxRenderedSlides =
+      options.maxRenderedSlides ?? DEFAULT_MAX_RENDERED_SLIDES;
+  }
+
+  async buildPreview(input: {
+    filePath: string;
+    workspaceRoot?: string;
+  }): Promise<PptxPresentationPreview> {
+    const resolvedPath = path.resolve(input.filePath);
+    if (input.workspaceRoot && !isPathInside(resolvedPath, input.workspaceRoot)) {
+      throw new Error("Access denied: PPTX preview path is outside the workspace");
+    }
+
+    const stats = await fs.stat(resolvedPath);
+    const structured = await extractPptxStructuredContentFromFile(resolvedPath);
+    const cacheDir = this.getCacheDir(resolvedPath, stats);
+    const cachedImages = await this.readCachedImages(cacheDir, resolvedPath, stats);
+    if (cachedImages.size > 0) {
+      return this.toPreview(structured, cachedImages, "rendered");
+    }
+
+    const renderResult = await this.renderSlideImages(resolvedPath, stats, cacheDir);
+    return this.toPreview(
+      structured,
+      renderResult.images,
+      renderResult.images.size > 0 ? "rendered" : "text_only",
+      renderResult.message,
+    );
+  }
+
+  private toPreview(
+    structured: PptxStructuredExtract,
+    images: Map<number, string>,
+    renderStatus: PptxPreviewRenderStatus,
+    renderMessage?: string,
+  ): PptxPresentationPreview {
+    const slides: PptxExtractedSlide[] =
+      structured.slides.length > 0
+        ? structured.slides
+        : Array.from({ length: structured.slideCount }, (_, index) => ({
+            index: index + 1,
+            text: "",
+          }));
+
+    return {
+      slideCount: structured.slideCount,
+      title: structured.title,
+      slides: slides.map((slide) => ({
+        index: slide.index,
+        title: slide.title,
+        text: slide.text,
+        notes: slide.notes,
+        imageDataUrl: images.get(slide.index),
+      })),
+      renderStatus,
+      renderMessage,
+    };
+  }
+
+  private getCacheDir(resolvedPath: string, stats: { size: number; mtimeMs: number }): string {
+    const key = createHash("sha256")
+      .update(`${resolvedPath}\n${stats.size}\n${Math.floor(stats.mtimeMs)}`)
+      .digest("hex")
+      .slice(0, 24);
+    return path.join(this.cacheRoot, key);
+  }
+
+  private async readCachedImages(
+    cacheDir: string,
+    resolvedPath: string,
+    stats: { size: number; mtimeMs: number },
+  ): Promise<Map<number, string>> {
+    try {
+      const manifestRaw = await fs.readFile(path.join(cacheDir, "manifest.json"), "utf-8");
+      const manifest = JSON.parse(manifestRaw) as CachedRenderManifest;
+      if (
+        manifest.sourcePath !== resolvedPath ||
+        manifest.sourceSize !== stats.size ||
+        Math.floor(manifest.sourceMtimeMs) !== Math.floor(stats.mtimeMs)
+      ) {
+        return new Map();
+      }
+
+      const images = new Map<number, string>();
+      for (const image of manifest.imageFiles) {
+        if (!Number.isFinite(image.index) || !image.fileName) continue;
+        const imagePath = path.join(cacheDir, image.fileName);
+        const dataUrl = await readPngDataUrl(imagePath);
+        if (dataUrl) images.set(image.index, dataUrl);
+      }
+      return images;
+    } catch {
+      return new Map();
+    }
+  }
+
+  private async renderSlideImages(
+    resolvedPath: string,
+    stats: { size: number; mtimeMs: number },
+    cacheDir: string,
+  ): Promise<{ images: Map<number, string>; message?: string }> {
+    let tempDir: string | undefined;
+    try {
+      await fs.mkdir(this.cacheRoot, { recursive: true });
+      tempDir = await fs.mkdtemp(path.join(this.cacheRoot, "convert-"));
+      await fs.mkdir(cacheDir, { recursive: true });
+
+      await this.commandRunner(
+        "soffice",
+        [
+          "--headless",
+          "--convert-to",
+          "pdf",
+          "--outdir",
+          tempDir,
+          resolvedPath,
+        ],
+        { timeout: this.renderTimeoutMs, maxBuffer: 8 * 1024 * 1024 },
+      );
+
+      const pdfPath = await findConvertedPdf(tempDir, resolvedPath);
+      if (!pdfPath) {
+        return {
+          images: new Map(),
+          message: "LibreOffice did not produce a PDF preview.",
+        };
+      }
+
+      const outputPrefix = path.join(cacheDir, "slide");
+      await this.commandRunner(
+        "pdftoppm",
+        [
+          "-png",
+          "-scale-to-x",
+          "1280",
+          "-scale-to-y",
+          "-1",
+          pdfPath,
+          outputPrefix,
+        ],
+        { timeout: this.renderTimeoutMs, maxBuffer: 8 * 1024 * 1024 },
+      );
+
+      const imageFiles = await listRenderedSlideFiles(cacheDir, this.maxRenderedSlides);
+      const manifest: CachedRenderManifest = {
+        sourcePath: resolvedPath,
+        sourceSize: stats.size,
+        sourceMtimeMs: stats.mtimeMs,
+        imageFiles: imageFiles.map((image) => ({
+          index: image.index,
+          fileName: path.basename(image.path),
+        })),
+      };
+      await fs.writeFile(path.join(cacheDir, "manifest.json"), JSON.stringify(manifest), "utf-8");
+
+      const images = new Map<number, string>();
+      for (const image of imageFiles) {
+        const dataUrl = await readPngDataUrl(image.path);
+        if (dataUrl) images.set(image.index, dataUrl);
+      }
+      return { images };
+    } catch (error) {
+      return {
+        images: new Map(),
+        message:
+          error instanceof Error
+            ? error.message
+            : "Presentation image preview could not be rendered.",
+      };
+    } finally {
+      if (tempDir) {
+        await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {
+          // Best-effort cleanup.
+        });
+      }
+    }
+  }
+}
+
+function isPathInside(targetPath: string, rootPath: string): boolean {
+  const normalizedRoot = path.resolve(rootPath);
+  const relative = path.relative(normalizedRoot, targetPath);
+  return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function findConvertedPdf(tempDir: string, sourcePath: string): Promise<string | null> {
+  const expected = path.join(tempDir, `${path.basename(sourcePath, path.extname(sourcePath))}.pdf`);
+  try {
+    await fs.access(expected);
+    return expected;
+  } catch {
+    const entries = await fs.readdir(tempDir);
+    const pdf = entries.find((entry) => entry.toLowerCase().endsWith(".pdf"));
+    return pdf ? path.join(tempDir, pdf) : null;
+  }
+}
+
+async function listRenderedSlideFiles(
+  cacheDir: string,
+  maxRenderedSlides: number,
+): Promise<Array<{ index: number; path: string }>> {
+  const entries = await fs.readdir(cacheDir);
+  return entries
+    .map((entry) => {
+      const match = entry.match(/^slide-(\d+)\.png$/i) || entry.match(/^slide\.png$/i);
+      if (!match) return null;
+      return {
+        index: match[1] ? Number(match[1]) : 1,
+        path: path.join(cacheDir, entry),
+      };
+    })
+    .filter((entry): entry is { index: number; path: string } => !!entry && entry.index > 0)
+    .sort((a, b) => a.index - b.index)
+    .slice(0, maxRenderedSlides);
+}
+
+async function readPngDataUrl(imagePath: string): Promise<string | null> {
+  try {
+    const bytes = await fs.readFile(imagePath);
+    return `data:image/png;base64,${bytes.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/electron/utils/__tests__/PptxPreviewService.test.ts
+++ b/src/electron/utils/__tests__/PptxPreviewService.test.ts
@@ -1,0 +1,150 @@
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PptxPreviewService } from "../PptxPreviewService";
+import { generatePPTX } from "../document-generators/pptx-generator";
+
+const PNG_BYTES = Buffer.from("presentation-preview");
+
+let tempRoot = "";
+
+beforeEach(async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-pptx-preview-test-"));
+});
+
+afterEach(async () => {
+  if (tempRoot) {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+async function createDeck(filePath: string): Promise<void> {
+  await generatePPTX(filePath, {
+    title: "Preview test deck",
+    slides: [
+      {
+        title: "Intro",
+        subtitle: "Opening slide",
+        layout: "title",
+        notes: "Presenter note A",
+      },
+      {
+        title: "Findings",
+        bullets: ["First point", "Second point"],
+        layout: "content",
+        notes: "Presenter note B",
+      },
+    ],
+  });
+}
+
+describe("PptxPreviewService", () => {
+  it("extracts structured slide text and speaker notes", async () => {
+    const workspace = path.join(tempRoot, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+    const deckPath = path.join(workspace, "deck.pptx");
+    await createDeck(deckPath);
+
+    const service = new PptxPreviewService({
+      cacheRoot: path.join(tempRoot, "cache"),
+      commandRunner: async () => {
+        throw new Error("converter unavailable");
+      },
+    });
+
+    const preview = await service.buildPreview({
+      filePath: deckPath,
+      workspaceRoot: workspace,
+    });
+
+    expect(preview.slideCount).toBe(2);
+    expect(preview.renderStatus).toBe("text_only");
+    expect(preview.slides[0].title).toContain("Intro");
+    expect(preview.slides[0].notes).toContain("Presenter note A");
+    expect(preview.slides[1].text).toContain("First point");
+  });
+
+  it("renders images once and reuses the preview cache", async () => {
+    const workspace = path.join(tempRoot, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+    const deckPath = path.join(workspace, "deck.pptx");
+    await createDeck(deckPath);
+    const calls: string[] = [];
+
+    const service = new PptxPreviewService({
+      cacheRoot: path.join(tempRoot, "cache"),
+      commandRunner: async (command, args) => {
+        calls.push(command);
+        if (command === "soffice") {
+          const outDir = String(args[args.indexOf("--outdir") + 1]);
+          await fs.writeFile(path.join(outDir, "deck.pdf"), "%PDF");
+          return;
+        }
+        if (command === "pdftoppm") {
+          const outputPrefix = String(args[args.length - 1]);
+          await fs.writeFile(`${outputPrefix}-1.png`, PNG_BYTES);
+          await fs.writeFile(`${outputPrefix}-2.png`, PNG_BYTES);
+          return;
+        }
+      },
+    });
+
+    const first = await service.buildPreview({
+      filePath: deckPath,
+      workspaceRoot: workspace,
+    });
+    const second = await service.buildPreview({
+      filePath: deckPath,
+      workspaceRoot: workspace,
+    });
+
+    expect(first.renderStatus).toBe("rendered");
+    expect(first.slides[0].imageDataUrl).toContain("data:image/png;base64,");
+    expect(second.renderStatus).toBe("rendered");
+    expect(calls).toEqual(["soffice", "pdftoppm"]);
+  });
+
+  it("falls back to text-only preview when converters fail", async () => {
+    const workspace = path.join(tempRoot, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+    const deckPath = path.join(workspace, "deck.pptx");
+    await createDeck(deckPath);
+
+    const service = new PptxPreviewService({
+      cacheRoot: path.join(tempRoot, "cache"),
+      commandRunner: async () => {
+        throw new Error("soffice missing");
+      },
+    });
+
+    const preview = await service.buildPreview({
+      filePath: deckPath,
+      workspaceRoot: workspace,
+    });
+
+    expect(preview.renderStatus).toBe("text_only");
+    expect(preview.renderMessage).toContain("soffice missing");
+    expect(preview.slides[0].text).toContain("Intro");
+  });
+
+  it("rejects files outside the workspace", async () => {
+    const workspace = path.join(tempRoot, "workspace");
+    const outside = path.join(tempRoot, "outside");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(outside, { recursive: true });
+    const deckPath = path.join(outside, "deck.pptx");
+    await createDeck(deckPath);
+
+    const service = new PptxPreviewService({
+      cacheRoot: path.join(tempRoot, "cache"),
+    });
+
+    await expect(
+      service.buildPreview({
+        filePath: deckPath,
+        workspaceRoot: workspace,
+      }),
+    ).rejects.toThrow(/outside the workspace/);
+  });
+});

--- a/src/electron/utils/__tests__/latex-compiler.test.ts
+++ b/src/electron/utils/__tests__/latex-compiler.test.ts
@@ -1,0 +1,92 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { compileLatex, findLatexEngine } from "../document-generators/latex-compiler";
+
+describe("latex compiler", () => {
+  async function makeWorkspace(): Promise<string> {
+    const workspace = path.join(os.tmpdir(), `cowork-latex-${randomUUID()}`);
+    await fs.mkdir(workspace, { recursive: true });
+    return workspace;
+  }
+
+  it("selects the first installed engine in priority order", async () => {
+    const execFileImpl = vi.fn(async (file: string, args: string[]) => {
+      if (file !== "which") throw new Error("unexpected command");
+      if (args[0] === "latexmk") return { stdout: "/usr/bin/latexmk\n", stderr: "" };
+      throw new Error("not found");
+    });
+
+    await expect(findLatexEngine("auto", execFileImpl)).resolves.toBe("latexmk");
+    expect(execFileImpl).toHaveBeenNthCalledWith(
+      1,
+      "which",
+      ["tectonic"],
+      expect.objectContaining({ timeout: 5000 }),
+    );
+    expect(execFileImpl).toHaveBeenNthCalledWith(
+      2,
+      "which",
+      ["latexmk"],
+      expect.objectContaining({ timeout: 5000 }),
+    );
+  });
+
+  it("returns a clear failure when no engine is installed", async () => {
+    const workspace = await makeWorkspace();
+    await fs.writeFile(path.join(workspace, "paper.tex"), "\\documentclass{article}\\begin{document}Hi\\end{document}");
+    const execFileImpl = vi.fn(async () => {
+      throw new Error("not found");
+    });
+
+    const result = await compileLatex({
+      workspacePath: workspace,
+      sourcePath: "paper.tex",
+      execFileImpl,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No LaTeX engine");
+    await expect(fs.access(path.join(workspace, "paper.pdf"))).rejects.toThrow();
+  });
+
+  it("runs a selected engine with bounded args and returns the generated PDF", async () => {
+    const workspace = await makeWorkspace();
+    const sourcePath = path.join(workspace, "paper.tex");
+    await fs.writeFile(sourcePath, "\\documentclass{article}\\begin{document}Hi\\end{document}");
+    const execFileImpl = vi.fn(async (file: string, args: string[]) => {
+      if (file === "which") return { stdout: "/usr/bin/pdflatex\n", stderr: "" };
+      expect(file).toBe("pdflatex");
+      expect(args).toContain("-interaction=nonstopmode");
+      expect(args).toContain("-halt-on-error");
+      await fs.writeFile(path.join(workspace, "paper.pdf"), "%PDF-1.4\n");
+      return { stdout: "ok", stderr: "" };
+    });
+
+    const result = await compileLatex({
+      workspacePath: workspace,
+      sourcePath: "paper.tex",
+      engine: "pdflatex",
+      execFileImpl,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.engine).toBe("pdflatex");
+    expect(result.pdfPath).toBe(path.join(workspace, "paper.pdf"));
+    expect(result.size).toBeGreaterThan(0);
+  });
+
+  it("rejects source paths outside the workspace", async () => {
+    const workspace = await makeWorkspace();
+    const result = await compileLatex({
+      workspacePath: workspace,
+      sourcePath: "../paper.tex",
+      execFileImpl: vi.fn(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("inside the workspace");
+  });
+});

--- a/src/electron/utils/__tests__/window-visibility.test.ts
+++ b/src/electron/utils/__tests__/window-visibility.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { revealWindow, type RevealableWindow } from "../window-visibility";
+
+function createWindowMock(overrides: Partial<RevealableWindow> = {}): RevealableWindow {
+  return {
+    isDestroyed: vi.fn(() => false),
+    isMinimized: vi.fn(() => false),
+    restore: vi.fn(),
+    isVisible: vi.fn(() => true),
+    show: vi.fn(),
+    focus: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("revealWindow", () => {
+  it("returns false for a missing window", () => {
+    expect(revealWindow(null)).toBe(false);
+  });
+
+  it("shows a hidden window before focusing it", () => {
+    const window = createWindowMock({
+      isVisible: vi.fn(() => false),
+    });
+
+    expect(revealWindow(window)).toBe(true);
+    expect(window.show).toHaveBeenCalledOnce();
+    expect(window.focus).toHaveBeenCalledOnce();
+  });
+
+  it("restores a minimized window before focusing it", () => {
+    const window = createWindowMock({
+      isMinimized: vi.fn(() => true),
+    });
+
+    expect(revealWindow(window)).toBe(true);
+    expect(window.restore).toHaveBeenCalledOnce();
+    expect(window.focus).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing for a destroyed window", () => {
+    const window = createWindowMock({
+      isDestroyed: vi.fn(() => true),
+    });
+
+    expect(revealWindow(window)).toBe(false);
+    expect(window.restore).not.toHaveBeenCalled();
+    expect(window.show).not.toHaveBeenCalled();
+    expect(window.focus).not.toHaveBeenCalled();
+  });
+});

--- a/src/electron/utils/document-generators/latex-compiler.ts
+++ b/src/electron/utils/document-generators/latex-compiler.ts
@@ -1,0 +1,229 @@
+import { execFile as execFileCallback } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+export type LatexEngine = "tectonic" | "latexmk" | "xelatex" | "lualatex" | "pdflatex";
+export type LatexEngineInput = "auto" | LatexEngine;
+
+type ExecFileLike = (
+  file: string,
+  args: string[],
+  options: { cwd?: string; timeout?: number; maxBuffer?: number },
+) => Promise<{ stdout?: string | Buffer; stderr?: string | Buffer }>;
+
+export type CompileLatexParams = {
+  workspacePath: string;
+  sourcePath: string;
+  outputPath?: string;
+  engine?: LatexEngineInput;
+  execFileImpl?: ExecFileLike;
+};
+
+export type CompileLatexResult = {
+  success: boolean;
+  sourcePath: string;
+  pdfPath: string;
+  logPath: string;
+  engine?: LatexEngine;
+  diagnostic: string;
+  size?: number;
+  error?: string;
+};
+
+const ENGINE_ORDER: LatexEngine[] = ["tectonic", "latexmk", "xelatex", "lualatex", "pdflatex"];
+const COMPILE_TIMEOUT_MS = 120_000;
+const COMPILE_MAX_BUFFER = 1024 * 1024;
+const MAX_DIAGNOSTIC_CHARS = 8_000;
+
+function isPathInsideWorkspace(targetPath: string, workspacePath: string): boolean {
+  const relative = path.relative(path.resolve(workspacePath), path.resolve(targetPath));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function resolveWorkspacePath(workspacePath: string, requestedPath: string, label: string): string {
+  const trimmed = String(requestedPath || "").trim();
+  if (!trimmed) {
+    throw new Error(`${label} is required`);
+  }
+  const resolved = path.isAbsolute(trimmed)
+    ? path.resolve(trimmed)
+    : path.resolve(workspacePath, trimmed);
+  if (!isPathInsideWorkspace(resolved, workspacePath)) {
+    throw new Error(`${label} must be inside the workspace`);
+  }
+  return resolved;
+}
+
+function stringifyOutput(value: unknown): string {
+  if (Buffer.isBuffer(value)) return value.toString("utf-8");
+  return typeof value === "string" ? value : "";
+}
+
+function trimDiagnostic(value: string): string {
+  const normalized = value.replace(/\r\n/g, "\n").trim();
+  if (normalized.length <= MAX_DIAGNOSTIC_CHARS) return normalized;
+  return normalized.slice(normalized.length - MAX_DIAGNOSTIC_CHARS).trimStart();
+}
+
+function createDiagnostic(stdout?: unknown, stderr?: unknown): string {
+  return trimDiagnostic([stringifyOutput(stdout), stringifyOutput(stderr)].filter(Boolean).join("\n"));
+}
+
+async function commandExists(command: string, execImpl: ExecFileLike): Promise<boolean> {
+  const locator = process.platform === "win32" ? "where" : "which";
+  try {
+    await execImpl(locator, [command], { timeout: 5_000, maxBuffer: 64 * 1024 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function findLatexEngine(
+  requested: LatexEngineInput | undefined,
+  execImpl: ExecFileLike = execFile,
+): Promise<LatexEngine | null> {
+  const candidates = requested && requested !== "auto" ? [requested] : ENGINE_ORDER;
+  for (const candidate of candidates) {
+    if (await commandExists(candidate, execImpl)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function buildLatexCommand(engine: LatexEngine, sourcePath: string, outputDir: string): string[] {
+  switch (engine) {
+    case "tectonic":
+      return ["--keep-logs", "--keep-intermediates", "--outdir", outputDir, sourcePath];
+    case "latexmk":
+      return [
+        "-pdf",
+        "-interaction=nonstopmode",
+        "-halt-on-error",
+        `-outdir=${outputDir}`,
+        sourcePath,
+      ];
+    case "xelatex":
+    case "lualatex":
+    case "pdflatex":
+      return [
+        "-interaction=nonstopmode",
+        "-halt-on-error",
+        "-file-line-error",
+        "-output-directory",
+        outputDir,
+        sourcePath,
+      ];
+  }
+}
+
+export async function compileLatex(params: CompileLatexParams): Promise<CompileLatexResult> {
+  const workspacePath = path.resolve(params.workspacePath);
+  const execImpl = params.execFileImpl || execFile;
+  let sourcePath = "";
+  let pdfPath = "";
+  let logPath = "";
+
+  try {
+    sourcePath = resolveWorkspacePath(workspacePath, params.sourcePath, "sourcePath");
+    if (path.extname(sourcePath).toLowerCase() !== ".tex") {
+      throw new Error("sourcePath must point to a .tex file");
+    }
+
+    const outputPath = params.outputPath
+      ? resolveWorkspacePath(workspacePath, params.outputPath, "outputPath")
+      : path.join(path.dirname(sourcePath), `${path.basename(sourcePath, path.extname(sourcePath))}.pdf`);
+    if (path.extname(outputPath).toLowerCase() !== ".pdf") {
+      throw new Error("outputPath must point to a .pdf file");
+    }
+
+    pdfPath = outputPath;
+    const outputDir = path.dirname(outputPath);
+    const sourceBase = path.basename(sourcePath, ".tex");
+    const compilerPdfPath = path.join(outputDir, `${sourceBase}.pdf`);
+    logPath = path.join(outputDir, `${sourceBase}.log`);
+
+    await fs.access(sourcePath);
+    await fs.mkdir(outputDir, { recursive: true });
+
+    const engine = await findLatexEngine(params.engine || "auto", execImpl);
+    if (!engine) {
+      const requested = params.engine && params.engine !== "auto" ? ` "${params.engine}"` : "";
+      const error =
+        `No LaTeX engine${requested} found. Install tectonic, latexmk, xelatex, lualatex, or pdflatex and retry.`;
+      return {
+        success: false,
+        sourcePath,
+        pdfPath,
+        logPath,
+        error,
+        diagnostic: error,
+      };
+    }
+
+    let diagnostic = "";
+    try {
+      const commandResult = await execImpl(engine, buildLatexCommand(engine, sourcePath, outputDir), {
+        cwd: path.dirname(sourcePath),
+        timeout: COMPILE_TIMEOUT_MS,
+        maxBuffer: COMPILE_MAX_BUFFER,
+      });
+      diagnostic = createDiagnostic(commandResult.stdout, commandResult.stderr);
+    } catch (compileError: unknown) {
+      const error = compileError as { stdout?: unknown; stderr?: unknown; message?: string };
+      diagnostic = createDiagnostic(error.stdout, error.stderr) || String(error.message || compileError);
+      return {
+        success: false,
+        sourcePath,
+        pdfPath,
+        logPath,
+        engine,
+        error: "LaTeX compilation failed",
+        diagnostic,
+      };
+    }
+
+    try {
+      await fs.access(compilerPdfPath);
+    } catch {
+      return {
+        success: false,
+        sourcePath,
+        pdfPath,
+        logPath,
+        engine,
+        error: "LaTeX compiler completed but did not produce a PDF",
+        diagnostic,
+      };
+    }
+
+    if (compilerPdfPath !== pdfPath) {
+      await fs.rename(compilerPdfPath, pdfPath);
+    }
+
+    const stats = await fs.stat(pdfPath);
+    return {
+      success: true,
+      sourcePath,
+      pdfPath,
+      logPath,
+      engine,
+      size: stats.size,
+      diagnostic,
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      sourcePath,
+      pdfPath,
+      logPath,
+      error: message,
+      diagnostic: message,
+    };
+  }
+}

--- a/src/electron/utils/document-generators/pdf-generator.ts
+++ b/src/electron/utils/document-generators/pdf-generator.ts
@@ -1,11 +1,12 @@
 /**
  * PDF Generator — converts markdown or structured sections into a styled PDF.
  *
- * Uses Puppeteer (already available for browser tools) to render HTML → PDF.
- * Falls back to a simple text-based PDF if Puppeteer is unavailable.
+ * Uses Playwright with a local Chromium-family browser to render HTML → PDF.
+ * Falls back to a styled HTML file if browser PDF rendering is unavailable.
  */
 
 import * as fs from "fs";
+import { execFileSync } from "node:child_process";
 
 interface PDFSection {
   heading?: string;
@@ -21,8 +22,82 @@ interface PDFOptions {
   landscape?: boolean;
 }
 
+function which(command: string): string | undefined {
+  try {
+    const output = execFileSync("which", [command], { encoding: "utf-8" }).trim();
+    return output || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveBrowserExecutable(): string | undefined {
+  const envCandidates = [
+    process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+    process.env.CHROME_PATH,
+    process.env.BRAVE_PATH,
+    process.env.PUPPETEER_EXECUTABLE_PATH,
+  ]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+
+  const platformCandidates =
+    process.platform === "darwin"
+      ? [
+          "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+          "/Applications/Chromium.app/Contents/MacOS/Chromium",
+          "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+          "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+        ]
+      : process.platform === "win32"
+        ? [
+            process.env.LOCALAPPDATA
+              ? `${process.env.LOCALAPPDATA}\\Google\\Chrome\\Application\\chrome.exe`
+              : "",
+            process.env.LOCALAPPDATA
+              ? `${process.env.LOCALAPPDATA}\\Chromium\\Application\\chrome.exe`
+              : "",
+            "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+            "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+            "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+            "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+            "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+            "C:\\Program Files (x86)\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+          ]
+        : [
+            "/usr/bin/google-chrome",
+            "/usr/bin/google-chrome-stable",
+            "/usr/bin/chromium",
+            "/usr/bin/chromium-browser",
+            "/usr/bin/microsoft-edge",
+            "/usr/bin/brave-browser",
+            "/snap/bin/chromium",
+            "/snap/bin/brave",
+          ];
+
+  const discovered =
+    process.platform === "win32"
+      ? []
+      : [
+          which("google-chrome"),
+          which("google-chrome-stable"),
+          which("chromium"),
+          which("chromium-browser"),
+          which("microsoft-edge"),
+          which("brave-browser"),
+        ].filter((value): value is string => Boolean(value));
+
+  for (const candidate of [...envCandidates, ...platformCandidates, ...discovered]) {
+    if (candidate && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
 /**
- * Render markdown/sections to a styled HTML string, then use Puppeteer to
+ * Render markdown/sections to a styled HTML string, then use Playwright to
  * produce a PDF file.
  */
 export async function generatePDF(
@@ -31,47 +106,28 @@ export async function generatePDF(
 ): Promise<{ success: boolean; path: string; size: number }> {
   const html = buildHTML(options);
 
-  // Try Puppeteer first (available if browser tools are installed)
+  // Try Playwright first (available if browser tools are installed)
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const puppeteer = require("puppeteer-core") as Any;
-    // Attempt to find an available Chromium executable
-    const execPaths = [
-      ...(process.platform === "win32"
-        ? [
-            "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
-            "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
-            process.env.LOCALAPPDATA
-              ? `${process.env.LOCALAPPDATA}\\Google\\Chrome\\Application\\chrome.exe`
-              : "",
-          ]
-        : [
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            "/Applications/Chromium.app/Contents/MacOS/Chromium",
-          ]),
-      process.env.PUPPETEER_EXECUTABLE_PATH,
-    ].filter(Boolean) as string[];
+    const playwrightModule = (await import("playwright")) as Any;
+    const chromium =
+      playwrightModule.chromium ||
+      playwrightModule.default?.chromium ||
+      playwrightModule.playwright?.chromium;
+    const executablePath = resolveBrowserExecutable();
 
-    let executablePath: string | undefined;
-    for (const p of execPaths) {
-      if (fs.existsSync(p)) {
-        executablePath = p;
-        break;
-      }
-    }
-
-    if (executablePath) {
-      const browser = await puppeteer.launch({
+    if (chromium && executablePath) {
+      const browser = await chromium.launch({
         headless: true,
         executablePath,
         args: ["--no-sandbox", "--disable-setuid-sandbox"],
       });
       try {
         const page = await browser.newPage();
-        await page.setContent(html, { waitUntil: "networkidle0" });
+        await page.setContent(html, { waitUntil: "networkidle" });
+        await page.emulateMedia({ media: "screen" });
         await page.pdf({
           path: outputPath,
-          format: (options.format || "A4") as Any,
+          format: options.format || "A4",
           landscape: options.landscape || false,
           printBackground: true,
           margin: { top: "1cm", right: "1.5cm", bottom: "1cm", left: "1.5cm" },
@@ -84,7 +140,7 @@ export async function generatePDF(
       return { success: true, path: outputPath, size: stat.size };
     }
   } catch {
-    // Puppeteer not available, fall through to HTML file
+    // Playwright or a local browser is unavailable; fall through to HTML file.
   }
 
   // Fallback: write styled HTML (can be opened in any browser and printed to PDF)

--- a/src/electron/utils/pptx-extractor.ts
+++ b/src/electron/utils/pptx-extractor.ts
@@ -7,6 +7,22 @@ type PptxRelationship = {
   target: string;
 };
 
+export interface PptxExtractedSlide {
+  index: number;
+  title?: string;
+  text: string;
+  notes?: string;
+}
+
+export interface PptxStructuredExtract {
+  title?: string;
+  slideCount: number;
+  processedSlideCount: number;
+  slides: PptxExtractedSlide[];
+  metadata: string[];
+  truncationNotices: string[];
+}
+
 export interface PptxExtractOptions {
   maxSlidesToProcess?: number;
   textCandidateLimit?: number;
@@ -22,6 +38,47 @@ export async function extractPptxContentFromFile(
   filePath: string,
   options: PptxExtractOptions = {},
 ): Promise<string> {
+  const structured = await extractPptxStructuredContentFromFile(filePath, options);
+  const slideText = structured.slides
+    .filter((slide) => slide.text || slide.notes)
+    .map((slide) => {
+      const blocks = [`Slide ${slide.index}:\n${slide.text}`];
+      if (slide.notes) {
+        blocks.push(`\n[Presenter notes]\n${slide.notes}`);
+      }
+      return blocks.join("\n");
+    });
+
+  let allText = slideText.join("\n\n");
+  if (!allText) {
+    allText = "[No extractable slide text found in this PPTX file.]";
+  }
+
+  const metadataText =
+    structured.metadata.length > 0
+      ? `[PPTX Metadata]\n${structured.metadata.join("\n")}\n\n`
+      : "";
+  const summaryLine = `[PPTX Slides: ${
+    structured.processedSlideCount === structured.slideCount
+      ? structured.slideCount
+      : `${structured.processedSlideCount}/${structured.slideCount}`
+  }]\n\n`;
+  let resultText = `${summaryLine}${metadataText}${allText}`;
+  if (structured.truncationNotices.length > 0) {
+    resultText = `${resultText}\n\n[${structured.truncationNotices.join(" ")}]`;
+  }
+
+  if (options.outputCharLimit && resultText.length > options.outputCharLimit) {
+    resultText = `${resultText.slice(0, options.outputCharLimit)}\n\n[... Content truncated. Showing first ${Math.round(options.outputCharLimit / 1024)}KB of extracted text ...]`;
+  }
+
+  return resultText;
+}
+
+export async function extractPptxStructuredContentFromFile(
+  filePath: string,
+  options: PptxExtractOptions = {},
+): Promise<PptxStructuredExtract> {
   const maxSlidesToProcess = Math.max(
     1,
     options.maxSlidesToProcess ?? DEFAULT_MAX_SLIDES_TO_PROCESS,
@@ -30,10 +87,6 @@ export async function extractPptxContentFromFile(
     1024,
     options.textCandidateLimit ?? DEFAULT_TEXT_CANDIDATE_LIMIT,
   );
-  const outputCharLimit =
-    typeof options.outputCharLimit === "number" && Number.isFinite(options.outputCharLimit)
-      ? Math.max(1, Math.floor(options.outputCharLimit))
-      : undefined;
   const maxFileSizeBytes = Math.max(
     1024,
     options.maxFileSizeBytes ?? DEFAULT_MAX_PPTX_FILE_SIZE_BYTES,
@@ -60,7 +113,7 @@ export async function extractPptxContentFromFile(
       return aIndex - bIndex;
     });
 
-  const slideText: string[] = [];
+  const slides: PptxExtractedSlide[] = [];
   const truncationNotices: string[] = [];
   const maxSlides = Math.min(slideEntries.length, maxSlidesToProcess);
   const slidesToProcess = slideEntries.slice(0, maxSlides);
@@ -73,20 +126,19 @@ export async function extractPptxContentFromFile(
     processedSlideCount += 1;
 
     const match = entryName.match(/slide(\d+)\.xml$/i);
-    const slideNumber = match ? Number(match[1]) : slideText.length + 1;
+    const slideNumber = match ? Number(match[1]) : slides.length + 1;
     const relationships = await extractPptxSlideRelationships(zip, entryName);
     const xml = await file.async("string");
     const extracted = extractPptxContentFromXml(xml, relationships);
-    if (!extracted) continue;
-
     const notes = await extractPptxNotesFromZip(zip, relationships, slideNumber);
-    const blocks = [`Slide ${slideNumber}:\n${extracted}`];
-    if (notes) {
-      blocks.push(`\n[Presenter notes]\n${notes}`);
-    }
-    const blockText = blocks.join("\n");
-    slideText.push(blockText);
-    accumulatedLength += blockText.length;
+
+    slides.push({
+      index: slideNumber,
+      title: derivePptxSlideTitle(extracted),
+      text: extracted,
+      notes: notes || undefined,
+    });
+    accumulatedLength += extracted.length + (notes?.length ?? 0);
 
     if (accumulatedLength > textCandidateLimit) {
       truncationNotices.push(
@@ -102,23 +154,14 @@ export async function extractPptxContentFromFile(
     );
   }
 
-  let allText = slideText.join("\n\n");
-  if (!allText) {
-    allText = "[No extractable slide text found in this PPTX file.]";
-  }
-
-  const metadataText = metadata.length > 0 ? `[PPTX Metadata]\n${metadata.join("\n")}\n\n` : "";
-  const summaryLine = `[PPTX Slides: ${processedSlideCount === slideEntries.length ? slideEntries.length : `${processedSlideCount}/${slideEntries.length}`}]\n\n`;
-  let resultText = `${summaryLine}${metadataText}${allText}`;
-  if (truncationNotices.length > 0) {
-    resultText = `${resultText}\n\n[${truncationNotices.join(" ")}]`;
-  }
-
-  if (outputCharLimit && resultText.length > outputCharLimit) {
-    resultText = `${resultText.slice(0, outputCharLimit)}\n\n[... Content truncated. Showing first ${Math.round(outputCharLimit / 1024)}KB of extracted text ...]`;
-  }
-
-  return resultText;
+  return {
+    title: metadata.title,
+    slideCount: slideEntries.length,
+    processedSlideCount,
+    slides,
+    metadata: metadata.entries,
+    truncationNotices,
+  };
 }
 
 function decodePptxXmlText(value: string): string {
@@ -156,8 +199,11 @@ function extractPptxXmlField(xml: string, tagCandidates: string[], isDate = fals
   return "";
 }
 
-async function extractPptxMetadataFromZip(zip: JSZip): Promise<string[]> {
+async function extractPptxMetadataFromZip(
+  zip: JSZip,
+): Promise<{ title?: string; entries: string[] }> {
   const metadata: string[] = [];
+  let deckTitle = "";
 
   const coreFile = zip.file("docProps/core.xml");
   if (coreFile) {
@@ -171,7 +217,10 @@ async function extractPptxMetadataFromZip(zip: JSZip): Promise<string[]> {
     const description = extractPptxXmlField(coreXml, ["description"]);
 
     const values: string[] = [];
-    if (title) values.push(`Title: ${title}`);
+    if (title) {
+      deckTitle = title;
+      values.push(`Title: ${title}`);
+    }
     if (subject) values.push(`Subject: ${subject}`);
     if (creator) values.push(`Author: ${creator}`);
     if (created) values.push(`Created: ${created}`);
@@ -195,7 +244,21 @@ async function extractPptxMetadataFromZip(zip: JSZip): Promise<string[]> {
     if (values.length > 0) metadata.push(values.join(" | "));
   }
 
-  return metadata;
+  return { title: deckTitle || undefined, entries: metadata };
+}
+
+function derivePptxSlideTitle(text: string): string | undefined {
+  const line = text
+    .split("\n")
+    .map((candidate) => candidate.trim())
+    .find(
+      (candidate) =>
+        candidate.length > 0 &&
+        !candidate.startsWith("|") &&
+        !candidate.startsWith("[") &&
+        !candidate.startsWith("..."),
+    );
+  return line ? line.slice(0, 120) : undefined;
 }
 
 function parsePptxRelationshipsFromXml(

--- a/src/electron/utils/validation.ts
+++ b/src/electron/utils/validation.ts
@@ -159,6 +159,7 @@ export const AgentConfigSchema = z
     retainMemory: z.boolean().optional(),
     bypassQueue: z.boolean().optional(),
     allowUserInput: z.boolean().optional(),
+    chronicleMode: z.enum(["inherit", "enabled", "disabled"]).optional(),
     shellAccess: z.boolean().optional(),
     requireWorktree: z.boolean().optional(),
     autoApproveTypes: z.array(z.string().min(1).max(200)).max(50).optional(),
@@ -794,7 +795,13 @@ export const LLMSettingsSchema = z.object({
   customProviders: CustomProvidersSchema,
   imageGeneration: z
     .object({
+      defaultProvider: z
+        .enum(["openai", "openai-codex", "azure", "openrouter", "gemini"])
+        .optional(),
       defaultModel: z.enum(["gpt-image-1.5", "nano-banana-2"]).optional(),
+      backupProvider: z
+        .enum(["openai", "openai-codex", "azure", "openrouter", "gemini"])
+        .optional(),
       backupModel: z.enum(["gpt-image-1.5", "nano-banana-2"]).optional(),
     })
     .optional(),
@@ -926,6 +933,15 @@ export const GoogleWorkspaceSettingsSchema = z.object({
   scopes: z.array(z.string().max(200)).optional(),
   timeoutMs: z.number().int().min(1000).max(120000).optional(),
   loginHint: z.string().email().max(254).optional(),
+});
+
+export const AgentMailSettingsSchema = z.object({
+  enabled: z.boolean().default(false),
+  apiKey: z.string().max(4000).optional(),
+  baseUrl: z.string().url().max(500).optional(),
+  websocketUrl: z.string().url().max(500).optional(),
+  timeoutMs: z.number().int().min(1000).max(120000).optional(),
+  realtimeEnabled: z.boolean().optional(),
 });
 
 // ============ Dropbox Settings Schema ============
@@ -2738,8 +2754,10 @@ export const HookMappingSchema = z.object({
     .object({
       path: z.string().max(500).optional(),
       source: z.string().max(100).optional(),
+      type: z.string().max(100).optional(),
     })
     .optional(),
+  token: z.string().max(200).optional(),
   action: z.enum(["wake", "agent"]).optional(),
   wakeMode: z.enum(["now", "next-heartbeat"]).optional(),
   name: z.string().max(200).optional(),
@@ -2749,6 +2767,7 @@ export const HookMappingSchema = z.object({
   deliver: z.boolean().optional(),
   channel: HookMappingChannelSchema.optional(),
   to: z.string().max(100).optional(),
+  workspaceId: z.string().max(200).optional(),
   model: z.string().max(100).optional(),
   thinking: z.string().max(50).optional(),
   timeoutSeconds: z.number().int().min(1).max(3600).optional(),

--- a/src/electron/utils/window-visibility.ts
+++ b/src/electron/utils/window-visibility.ts
@@ -1,0 +1,24 @@
+export interface RevealableWindow {
+  isDestroyed?: () => boolean;
+  isMinimized: () => boolean;
+  restore: () => void;
+  isVisible: () => boolean;
+  show: () => void;
+  focus: () => void;
+}
+
+export function revealWindow(window: RevealableWindow | null | undefined): boolean {
+  if (!window) return false;
+  if (typeof window.isDestroyed === "function" && window.isDestroyed()) {
+    return false;
+  }
+
+  if (window.isMinimized()) {
+    window.restore();
+  }
+  if (!window.isVisible()) {
+    window.show();
+  }
+  window.focus();
+  return true;
+}

--- a/src/renderer/components/AssistantMessageContent.tsx
+++ b/src/renderer/components/AssistantMessageContent.tsx
@@ -1,5 +1,6 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { InlineHtmlPreview } from "./InlineHtmlPreview";
 import { InlineVideoPreview } from "./InlineVideoPreview";
 import { normalizeInlineLists, unwrapMarkdownCodeBlocks } from "../utils/markdown-inline-lists";
 import { sanitizeToolCallTextFromAssistant } from "../../shared/tool-call-text-sanitizer";
@@ -19,12 +20,20 @@ type VideoDirective = {
   loop?: boolean;
 };
 
+type HtmlDirective = {
+  path: string;
+  title?: string;
+};
+
 type MessageSegment =
   | { type: "markdown"; content: string }
   | { type: "video"; directive: VideoDirective; raw: string }
-  | { type: "video_error"; raw: string; error: string };
+  | { type: "video_error"; raw: string; error: string }
+  | { type: "html"; directive: HtmlDirective; raw: string }
+  | { type: "html_error"; raw: string; error: string };
 
 const VIDEO_DIRECTIVE_LINE_REGEX = /^\s*::video\{(.+)\}\s*$/;
+const HTML_DIRECTIVE_LINE_REGEX = /^\s*::html\{(.+)\}\s*$/;
 const DIRECTIVE_ATTR_REGEX = /(\w+)\s*=\s*("(?:[^"\\]|\\.)*"|true|false)/g;
 
 function decodeQuotedValue(value: string): string {
@@ -87,6 +96,61 @@ function parseVideoDirective(line: string): MessageSegment {
   };
 }
 
+function parseHtmlDirective(line: string): MessageSegment {
+  const match = line.match(HTML_DIRECTIVE_LINE_REGEX);
+  if (!match) {
+    return { type: "markdown", content: line };
+  }
+
+  const attrs = match[1];
+  const parsed: Partial<HtmlDirective> = {};
+  const seenKeys = new Set<string>();
+  let attrMatch: RegExpExecArray | null;
+
+  DIRECTIVE_ATTR_REGEX.lastIndex = 0;
+  while ((attrMatch = DIRECTIVE_ATTR_REGEX.exec(attrs)) !== null) {
+    const key = attrMatch[1];
+    const rawValue = attrMatch[2];
+    seenKeys.add(key);
+
+    if (rawValue === "true" || rawValue === "false") {
+      return {
+        type: "html_error",
+        raw: line,
+        error: "HTML embed does not support boolean attributes",
+      };
+    }
+
+    (parsed as Record<string, unknown>)[key] = decodeQuotedValue(rawValue);
+  }
+
+  const unmatched = attrs.replace(DIRECTIVE_ATTR_REGEX, "").trim();
+  if (unmatched.length > 0) {
+    return {
+      type: "html_error",
+      raw: line,
+      error: "Invalid HTML directive syntax",
+    };
+  }
+
+  if (!seenKeys.has("path") || typeof parsed.path !== "string" || parsed.path.trim().length === 0) {
+    return {
+      type: "html_error",
+      raw: line,
+      error: "HTML embed requires a path",
+    };
+  }
+
+  return {
+    type: "html",
+    raw: line,
+    directive: {
+      path: parsed.path.trim(),
+      title: typeof parsed.title === "string" ? parsed.title.trim() : undefined,
+    },
+  };
+}
+
 export function parseAssistantMessageSegments(message: string): MessageSegment[] {
   const sanitized = sanitizeToolCallTextFromAssistant(String(message || "")).text;
   const lines = sanitized.split("\n");
@@ -103,6 +167,16 @@ export function parseAssistantMessageSegments(message: string): MessageSegment[]
     if (line.trimStart().startsWith("::video{")) {
       flushMarkdown();
       const parsed = parseVideoDirective(line);
+      if (parsed.type === "markdown") {
+        markdownBuffer.push(line);
+      } else {
+        segments.push(parsed);
+      }
+      continue;
+    }
+    if (line.trimStart().startsWith("::html{")) {
+      flushMarkdown();
+      const parsed = parseHtmlDirective(line);
       if (parsed.type === "markdown") {
         markdownBuffer.push(line);
       } else {
@@ -146,10 +220,37 @@ export function AssistantMessageContent({
           );
         }
 
+        if (segment.type === "html_error") {
+          return (
+            <div key={`html-error-${index}`} className="assistant-html-error">
+              {segment.error}
+            </div>
+          );
+        }
+
         if (!workspacePath) {
           return (
-            <div key={`video-missing-workspace-${index}`} className="assistant-video-error">
-              Video embeds require a workspace-backed file.
+            <div
+              key={`directive-missing-workspace-${index}`}
+              className={segment.type === "html" ? "assistant-html-error" : "assistant-video-error"}
+            >
+              {segment.type === "html"
+                ? "HTML embeds require a workspace-backed file."
+                : "Video embeds require a workspace-backed file."}
+            </div>
+          );
+        }
+
+        if (segment.type === "html") {
+          return (
+            <div key={`html-${index}`} className="assistant-html-embed">
+              <InlineHtmlPreview
+                filePath={segment.directive.path}
+                workspacePath={workspacePath}
+                title={segment.directive.title}
+                onOpenViewer={onOpenViewer}
+                className="inline-html-preview-embedded"
+              />
             </div>
           );
         }

--- a/src/renderer/components/FileViewer.tsx
+++ b/src/renderer/components/FileViewer.tsx
@@ -6,6 +6,7 @@ import { FileViewerResult } from "../../electron/preload";
 import { useAgentContext } from "../hooks/useAgentContext";
 import { createVideoObjectUrl } from "../utils/videoPlayback";
 import { PDFDocumentSurface } from "./PDFDocumentSurface";
+import { PresentationViewer } from "./PresentationViewer";
 import { ThemeIcon } from "./ThemeIcon";
 import {
   AlertTriangleIcon,
@@ -97,6 +98,14 @@ export function FileViewer({ filePath, workspacePath, onClose }: FileViewerProps
     }
   };
 
+  const handleShowInFinder = async () => {
+    try {
+      await window.electronAPI.showInFinder(filePath, workspacePath);
+    } catch (err) {
+      console.error("Failed to show file:", err);
+    }
+  };
+
   // Format file size
   const formatSize = (bytes: number): string => {
     if (bytes < 1024) return `${bytes} B`;
@@ -117,6 +126,8 @@ export function FileViewer({ filePath, workspacePath, onClose }: FileViewerProps
         return <ThemeIcon emoji="📘" icon={<FileTextIcon size={16} />} />;
       case "pdf":
         return <ThemeIcon emoji="📕" icon={<FileTextIcon size={16} />} />;
+      case "latex":
+        return <ThemeIcon emoji="📄" icon={<FileTextIcon size={16} />} />;
       case "image":
         return <ThemeIcon emoji="🖼️" icon={<ImageIcon size={16} />} />;
       case "video":
@@ -145,6 +156,7 @@ export function FileViewer({ filePath, workspacePath, onClose }: FileViewerProps
         );
 
       case "code":
+      case "latex":
       case "text":
         return <pre className="file-viewer-code">{fileData.content}</pre>;
 
@@ -252,6 +264,17 @@ export function FileViewer({ filePath, workspacePath, onClose }: FileViewerProps
         );
 
       case "pptx":
+        if (fileData.presentationPreview) {
+          return (
+            <PresentationViewer
+              fileName={fileData.fileName}
+              sizeLabel={formatSize(fileData.size)}
+              preview={fileData.presentationPreview}
+              onOpenExternal={handleOpenExternal}
+              onShowInFinder={handleShowInFinder}
+            />
+          );
+        }
         return (
           <div className="file-viewer-placeholder">
             <span className="file-viewer-placeholder-icon">
@@ -330,7 +353,10 @@ export function FileViewer({ filePath, workspacePath, onClose }: FileViewerProps
   // Use portal to render at document body level (escapes parent container constraints)
   return createPortal(
     <div className="file-viewer-overlay" onClick={onClose}>
-      <div className="file-viewer-modal" onClick={(e) => e.stopPropagation()}>
+      <div
+        className={`file-viewer-modal ${fileData?.fileType === "pptx" ? "file-viewer-modal-presentation" : ""}`}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="file-viewer-header">
           <div className="file-viewer-title">
             <span className="file-viewer-icon">{getFileIcon(fileData?.fileType)}</span>

--- a/src/renderer/components/InlineDocumentPreview.tsx
+++ b/src/renderer/components/InlineDocumentPreview.tsx
@@ -8,7 +8,7 @@ type InlineDocumentPreviewProps = {
   onOpenViewer?: (path: string) => void;
 };
 
-type SupportedDocumentType = "pdf" | "docx" | "markdown" | "text" | "code";
+type SupportedDocumentType = "pdf" | "docx" | "markdown" | "latex" | "text" | "code";
 
 const PREVIEW_MAX_CHARS = 1600;
 
@@ -30,7 +30,7 @@ function formatFileSize(bytes: number): string {
 }
 
 function isDocumentType(type: string): type is SupportedDocumentType {
-  return type === "pdf" || type === "docx" || type === "markdown" || type === "text" || type === "code";
+  return type === "pdf" || type === "docx" || type === "markdown" || type === "latex" || type === "text" || type === "code";
 }
 
 function htmlToText(html: string): string {
@@ -51,6 +51,8 @@ function getTypeLabel(type: SupportedDocumentType): string {
       return "Word";
     case "markdown":
       return "Markdown";
+    case "latex":
+      return "LaTeX";
     case "code":
       return "Code";
     case "text":

--- a/src/renderer/components/InlineHtmlPreview.tsx
+++ b/src/renderer/components/InlineHtmlPreview.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useState } from "react";
+import type { FileViewerResult } from "../../electron/preload";
+
+type InlineHtmlPreviewProps = {
+  filePath: string;
+  workspacePath: string;
+  title?: string;
+  className?: string;
+  onOpenViewer?: (path: string) => void;
+};
+
+const formatFileSize = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)} MB`;
+};
+
+export function InlineHtmlPreview({
+  filePath,
+  workspacePath,
+  title,
+  className = "",
+  onOpenViewer,
+}: InlineHtmlPreviewProps) {
+  const [loading, setLoading] = useState(true);
+  const [result, setResult] = useState<FileViewerResult["data"] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const subtitle = useMemo(() => {
+    if (!result) return "";
+    return ["HTML", formatFileSize(result.size)].filter(Boolean).join(" • ");
+  }, [result]);
+
+  const displayTitle = title || result?.fileName || filePath.split("/").pop() || filePath;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      setResult(null);
+
+      try {
+        const response = await window.electronAPI.readFileForViewer(filePath, workspacePath);
+        if (cancelled) return;
+        if (!response.success || !response.data) {
+          setError(response.error || "Failed to load HTML preview");
+          return;
+        }
+        if (response.data.fileType !== "html" || !response.data.htmlContent) {
+          setError("File is not a previewable HTML document.");
+          return;
+        }
+        setResult(response.data);
+      } catch (e: unknown) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to load HTML preview");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    if (filePath && workspacePath) {
+      void run();
+    } else {
+      setLoading(false);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filePath, workspacePath]);
+
+  const handleOpen = async () => {
+    if (onOpenViewer) {
+      onOpenViewer(filePath);
+      return;
+    }
+    try {
+      await window.electronAPI.openFile(filePath, workspacePath);
+    } catch (e) {
+      console.error("Failed to open HTML preview:", e);
+    }
+  };
+
+  return (
+    <div className={`inline-html-preview ${className}`.trim()}>
+      {loading && <div className="inline-html-loading">Loading HTML preview…</div>}
+
+      {!loading && error && <div className="inline-html-error">{error}</div>}
+
+      {!loading && !error && result?.htmlContent && (
+        <>
+          <div className="inline-html-header">
+            <div className="inline-html-header-left">
+              <div className="inline-html-icon">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                  <path d="M4 4h16v16H4z" stroke="currentColor" strokeWidth="2" />
+                  <path
+                    d="m9 10-2 2 2 2M15 10l2 2-2 2M13 8l-2 8"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <div className="inline-html-name-wrap">
+                <div className="inline-html-filename" title={displayTitle}>
+                  {displayTitle}
+                </div>
+                {subtitle && <div className="inline-html-subtitle">{subtitle}</div>}
+              </div>
+            </div>
+            <div className="inline-html-header-actions">
+              <button className="inline-html-action-btn" onClick={handleOpen} title="Open preview">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <polyline points="15 3 21 3 21 9" />
+                  <polyline points="9 21 3 21 3 15" />
+                  <line x1="21" y1="3" x2="14" y2="10" />
+                  <line x1="3" y1="21" x2="10" y2="14" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div className="inline-html-frame-wrap">
+            <iframe
+              className="inline-html-frame"
+              srcDoc={result.htmlContent}
+              sandbox=""
+              title={displayTitle}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/InlinePresentationPreview.tsx
+++ b/src/renderer/components/InlinePresentationPreview.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from "react";
+import { ExternalLink, Presentation } from "lucide-react";
+import type { FileViewerResult } from "../../electron/preload";
+
+type InlinePresentationPreviewProps = {
+  filePath: string;
+  workspacePath: string;
+  onOpenViewer?: (path: string) => void;
+};
+
+type PresentationPreview = NonNullable<
+  NonNullable<FileViewerResult["data"]>["presentationPreview"]
+>;
+
+const PREVIEW_TEXT_MAX = 420;
+
+function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  return `${(kb / 1024).toFixed(1)} MB`;
+}
+
+function getFirstMeaningfulSlide(preview: PresentationPreview | null) {
+  if (!preview) return null;
+  return (
+    preview.slides.find((slide) => slide.imageDataUrl) ||
+    preview.slides.find((slide) => slide.text.trim().length > 0) ||
+    preview.slides[0] ||
+    null
+  );
+}
+
+export function InlinePresentationPreview({
+  filePath,
+  workspacePath,
+  onOpenViewer,
+}: InlinePresentationPreviewProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [fileName, setFileName] = useState("");
+  const [size, setSize] = useState(0);
+  const [preview, setPreview] = useState<PresentationPreview | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      setFileName("");
+      setSize(0);
+      setPreview(null);
+
+      try {
+        const response = await window.electronAPI.readFileForViewer(filePath, workspacePath);
+        if (cancelled) return;
+        if (!response.success || !response.data) {
+          setError(response.error || "Failed to load presentation");
+          return;
+        }
+        if (response.data.fileType !== "pptx" || !response.data.presentationPreview) {
+          setError("Presentation preview is not available.");
+          return;
+        }
+        setFileName(response.data.fileName || filePath.split("/").pop() || filePath);
+        setSize(response.data.size);
+        setPreview(response.data.presentationPreview);
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load presentation");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    if (filePath && workspacePath) {
+      void run();
+    } else {
+      setLoading(false);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filePath, workspacePath]);
+
+  const firstSlide = useMemo(() => getFirstMeaningfulSlide(preview), [preview]);
+  const previewText = useMemo(() => {
+    const text = firstSlide?.text.trim() || "No extractable slide text.";
+    if (text.length <= PREVIEW_TEXT_MAX) return text;
+    return `${text.slice(0, PREVIEW_TEXT_MAX).trimEnd()}\n...`;
+  }, [firstSlide]);
+
+  const handleOpen = () => {
+    if (onOpenViewer) {
+      onOpenViewer(filePath);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="inline-presentation-preview">
+        <div className="inline-presentation-loading">Loading presentation...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="inline-presentation-preview">
+        <div className="inline-presentation-error">{error}</div>
+      </div>
+    );
+  }
+
+  if (!preview || !firstSlide) return null;
+
+  const subtitle = [
+    `${preview.slideCount} slide${preview.slideCount === 1 ? "" : "s"}`,
+    formatFileSize(size),
+    preview.renderStatus === "rendered" ? "Preview rendered" : "Text preview",
+  ]
+    .filter(Boolean)
+    .join(" • ");
+
+  return (
+    <div
+      className="inline-presentation-preview"
+      onClick={handleOpen}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          handleOpen();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      title="Open presentation preview"
+    >
+      <div className="inline-presentation-header">
+        <div className="inline-presentation-header-left">
+          <span className="inline-presentation-icon">
+            <Presentation size={16} />
+          </span>
+          <span className="inline-presentation-name-wrap">
+            <span className="inline-presentation-filename">{fileName}</span>
+            <span className="inline-presentation-subtitle">{subtitle}</span>
+          </span>
+        </div>
+        <ExternalLink size={16} />
+      </div>
+      <div className="inline-presentation-body">
+        {firstSlide.imageDataUrl ? (
+          <img src={firstSlide.imageDataUrl} alt={`Slide ${firstSlide.index}`} />
+        ) : (
+          <pre>{previewText}</pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/LatexArtifactWorkbench.tsx
+++ b/src/renderer/components/LatexArtifactWorkbench.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useMemo, useState } from "react";
+import type { FileViewerResult } from "../../electron/preload";
+import { PDFDocumentSurface } from "./PDFDocumentSurface";
+
+type LatexArtifactWorkbenchProps = {
+  sourcePath: string;
+  pdfPath: string;
+  workspacePath: string;
+  onOpenViewer?: (path: string) => void;
+};
+
+type ActiveTab = "summary" | "source" | "pdf";
+
+function fileName(filePath: string): string {
+  return filePath.split(/[\\/]/).pop() || filePath;
+}
+
+function formatFileSize(bytes: number | undefined): string {
+  if (!Number.isFinite(bytes) || !bytes || bytes <= 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  return `${(kb / 1024).toFixed(1)} MB`;
+}
+
+export function LatexArtifactWorkbench({
+  sourcePath,
+  pdfPath,
+  workspacePath,
+  onOpenViewer,
+}: LatexArtifactWorkbenchProps) {
+  const [activeTab, setActiveTab] = useState<ActiveTab>("summary");
+  const [sourceData, setSourceData] = useState<FileViewerResult["data"] | null>(null);
+  const [pdfData, setPdfData] = useState<FileViewerResult["data"] | null>(null);
+  const [sourceError, setSourceError] = useState<string | null>(null);
+  const [pdfError, setPdfError] = useState<string | null>(null);
+  const [loadingSource, setLoadingSource] = useState(false);
+  const [loadingPdf, setLoadingPdf] = useState(false);
+  const [pdfPageIndex, setPdfPageIndex] = useState(0);
+  const [pdfPageCount, setPdfPageCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      setLoadingSource(true);
+      setSourceError(null);
+      setSourceData(null);
+      try {
+        const response = await window.electronAPI.readFileForViewer(sourcePath, workspacePath);
+        if (cancelled) return;
+        if (!response.success || !response.data) {
+          setSourceError(response.error || "Failed to load LaTeX source");
+          return;
+        }
+        setSourceData(response.data);
+      } catch (error: unknown) {
+        if (!cancelled) {
+          setSourceError(error instanceof Error ? error.message : "Failed to load LaTeX source");
+        }
+      } finally {
+        if (!cancelled) setLoadingSource(false);
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [sourcePath, workspacePath]);
+
+  useEffect(() => {
+    if (activeTab !== "pdf" && activeTab !== "summary") return;
+    let cancelled = false;
+    const run = async () => {
+      setLoadingPdf(true);
+      setPdfError(null);
+      try {
+        const response = await window.electronAPI.readFileForViewer(pdfPath, workspacePath, {
+          includePdfBase64: true,
+        });
+        if (cancelled) return;
+        if (!response.success || !response.data) {
+          setPdfError(response.error || "Failed to load compiled PDF");
+          return;
+        }
+        if (response.data.fileType !== "pdf") {
+          setPdfError("Compiled output is not a previewable PDF.");
+          return;
+        }
+        setPdfData(response.data);
+        setPdfPageIndex(0);
+      } catch (error: unknown) {
+        if (!cancelled) {
+          setPdfError(error instanceof Error ? error.message : "Failed to load compiled PDF");
+        }
+      } finally {
+        if (!cancelled) setLoadingPdf(false);
+      }
+    };
+    if (!pdfData) void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, pdfData, pdfPath, workspacePath]);
+
+  const sourceLineCount = useMemo(() => {
+    const content = sourceData?.content || "";
+    return content ? content.split("\n").length : 0;
+  }, [sourceData?.content]);
+
+  const openPath = (targetPath: string) => {
+    if (onOpenViewer) {
+      onOpenViewer(targetPath);
+      return;
+    }
+    void window.electronAPI.openFile(targetPath, workspacePath);
+  };
+
+  const showPath = (targetPath: string) => {
+    void window.electronAPI.showInFinder(targetPath, workspacePath);
+  };
+
+  return (
+    <div className="latex-artifact-workbench">
+      <div className="latex-artifact-header">
+        <div className="latex-artifact-title-block">
+          <div className="latex-artifact-title">{fileName(pdfPath)}</div>
+          <div className="latex-artifact-subtitle">
+            {fileName(sourcePath)} {"->"} compiled PDF
+          </div>
+        </div>
+        <div className="latex-artifact-actions">
+          <button type="button" onClick={() => openPath(pdfPath)} className="latex-artifact-action">
+            Open PDF
+          </button>
+          <button type="button" onClick={() => showPath(pdfPath)} className="latex-artifact-action secondary">
+            Show
+          </button>
+        </div>
+      </div>
+
+      <div className="latex-artifact-tabs" role="tablist" aria-label="LaTeX artifact tabs">
+        {(["summary", "source", "pdf"] as ActiveTab[]).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab}
+            className={`latex-artifact-tab ${activeTab === tab ? "active" : ""}`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab === "summary" ? "Summary" : tab === "source" ? ".tex source" : "PDF"}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "summary" && (
+        <div className="latex-artifact-summary">
+          <div className="latex-artifact-summary-row">
+            <span>Source</span>
+            <button type="button" onClick={() => openPath(sourcePath)}>
+              {fileName(sourcePath)}
+            </button>
+          </div>
+          <div className="latex-artifact-summary-row">
+            <span>PDF</span>
+            <button type="button" onClick={() => openPath(pdfPath)}>
+              {fileName(pdfPath)}
+            </button>
+          </div>
+          <div className="latex-artifact-summary-row">
+            <span>Size</span>
+            <strong>{formatFileSize(pdfData?.size) || "Unknown"}</strong>
+          </div>
+          <div className="latex-artifact-summary-row">
+            <span>Source lines</span>
+            <strong>{sourceLineCount || "Unknown"}</strong>
+          </div>
+          {loadingPdf && <div className="latex-artifact-loading">Loading PDF metadata...</div>}
+          {pdfError && <div className="latex-artifact-error">{pdfError}</div>}
+        </div>
+      )}
+
+      {activeTab === "source" && (
+        <div className="latex-artifact-source">
+          {loadingSource && <div className="latex-artifact-loading">Loading LaTeX source...</div>}
+          {sourceError && <div className="latex-artifact-error">{sourceError}</div>}
+          {!loadingSource && !sourceError && (
+            <pre className="latex-artifact-source-code">{sourceData?.content || ""}</pre>
+          )}
+        </div>
+      )}
+
+      {activeTab === "pdf" && (
+        <div className="latex-artifact-pdf">
+          {loadingPdf && <div className="latex-artifact-loading">Rendering PDF...</div>}
+          {pdfError && <div className="latex-artifact-error">{pdfError}</div>}
+          {!loadingPdf && !pdfError && pdfData?.pdfDataBase64 && (
+            <>
+              <div className="latex-artifact-pdf-toolbar">
+                <button
+                  type="button"
+                  onClick={() => setPdfPageIndex((current) => Math.max(0, current - 1))}
+                  disabled={pdfPageIndex <= 0}
+                >
+                  Previous
+                </button>
+                <span>
+                  Page {pdfPageCount > 0 ? pdfPageIndex + 1 : "-"} / {pdfPageCount || "-"}
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setPdfPageIndex((current) =>
+                      pdfPageCount > 0 ? Math.min(pdfPageCount - 1, current + 1) : current,
+                    )
+                  }
+                  disabled={pdfPageCount <= 0 || pdfPageIndex >= pdfPageCount - 1}
+                >
+                  Next
+                </button>
+                <strong>Zoom to fit</strong>
+              </div>
+              <PDFDocumentSurface
+                fileName={pdfData.fileName}
+                pdfDataBase64={pdfData.pdfDataBase64}
+                selection={null}
+                onSelectionChange={() => {}}
+                readOnly
+                visiblePageIndex={pdfPageIndex}
+                onPageCountChange={setPdfPageCount}
+              />
+            </>
+          )}
+          {!loadingPdf && !pdfError && pdfData && !pdfData.pdfDataBase64 && (
+            <div className="latex-artifact-error">
+              PDF is too large for inline rendering. Open it externally to inspect the full document.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/PDFDocumentSurface.tsx
+++ b/src/renderer/components/PDFDocumentSurface.tsx
@@ -20,6 +20,8 @@ type PDFDocumentSurfaceProps = {
   selection: PdfRegionSelection | null;
   onSelectionChange: (selection: PdfRegionSelection | null) => void;
   readOnly?: boolean;
+  visiblePageIndex?: number | null;
+  onPageCountChange?: (pageCount: number) => void;
 };
 
 type DraftSelection = {
@@ -53,6 +55,8 @@ export function PDFDocumentSurface({
   selection,
   onSelectionChange,
   readOnly = false,
+  visiblePageIndex = null,
+  onPageCountChange,
 }: PDFDocumentSurfaceProps) {
   const pageCanvases = useRef<Array<HTMLCanvasElement | null>>([]);
   const pageLayers = useRef<Array<HTMLDivElement | null>>([]);
@@ -78,6 +82,9 @@ export function PDFDocumentSurface({
         ).toString();
         const loadingTask = pdfjs.getDocument({ data: base64ToUint8Array(pdfDataBase64) });
         const document = await loadingTask.promise;
+        if (!cancelled) {
+          onPageCountChange?.(document.numPages);
+        }
         cleanup = async () => {
           await loadingTask.destroy();
           if (typeof document.destroy === "function") {
@@ -150,7 +157,7 @@ export function PDFDocumentSurface({
       cancelled = true;
       if (cleanup) void cleanup();
     };
-  }, [pdfDataBase64]);
+  }, [onPageCountChange, pdfDataBase64]);
 
   const selectionStyle = useMemo(() => {
     const target = draftSelection || selection;
@@ -239,6 +246,7 @@ export function PDFDocumentSurface({
   return (
     <div className="pdf-document-surface">
       {pageRenders.map((page, pageIndex) => {
+        if (typeof visiblePageIndex === "number" && pageIndex !== visiblePageIndex) return null;
         const showSelection =
           (draftSelection && draftSelection.pageIndex === pageIndex) ||
           (selection && selection.pageIndex === pageIndex);

--- a/src/renderer/components/PresentationViewer.tsx
+++ b/src/renderer/components/PresentationViewer.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  FolderOpen,
+  ZoomIn,
+} from "lucide-react";
+import type { FileViewerResult } from "../../electron/preload";
+
+type PresentationPreview = NonNullable<
+  NonNullable<FileViewerResult["data"]>["presentationPreview"]
+>;
+
+type PresentationViewerProps = {
+  fileName: string;
+  sizeLabel?: string;
+  preview: PresentationPreview;
+  onOpenExternal: () => void;
+  onShowInFinder: () => void;
+};
+
+const ZOOM_LEVELS = [75, 100, 125, 150] as const;
+
+export function PresentationViewer({
+  fileName,
+  sizeLabel,
+  preview,
+  onOpenExternal,
+  onShowInFinder,
+}: PresentationViewerProps) {
+  const [activeSlideIndex, setActiveSlideIndex] = useState(0);
+  const [zoom, setZoom] = useState<(typeof ZOOM_LEVELS)[number]>(100);
+  const slides = preview.slides;
+  const activeSlide = slides[activeSlideIndex] || slides[0] || null;
+  const renderedCount = useMemo(
+    () => slides.filter((slide) => Boolean(slide.imageDataUrl)).length,
+    [slides],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft") {
+        setActiveSlideIndex((current) => Math.max(0, current - 1));
+      }
+      if (event.key === "ArrowRight") {
+        setActiveSlideIndex((current) => Math.min(slides.length - 1, current + 1));
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [slides.length]);
+
+  const canGoBack = activeSlideIndex > 0;
+  const canGoForward = activeSlideIndex < slides.length - 1;
+  const subtitle = [
+    `${preview.slideCount} slide${preview.slideCount === 1 ? "" : "s"}`,
+    sizeLabel,
+    preview.renderStatus === "rendered" ? `${renderedCount} rendered` : "Text preview",
+  ]
+    .filter(Boolean)
+    .join(" • ");
+
+  const goBack = () => setActiveSlideIndex((current) => Math.max(0, current - 1));
+  const goForward = () =>
+    setActiveSlideIndex((current) => Math.min(slides.length - 1, current + 1));
+
+  return (
+    <div className="presentation-viewer">
+      <aside className="presentation-viewer-sidebar" aria-label="Slides">
+        <div className="presentation-viewer-file">
+          <div className="presentation-viewer-file-name" title={fileName}>
+            {preview.title || fileName}
+          </div>
+          <div className="presentation-viewer-file-meta">{subtitle}</div>
+        </div>
+        <div className="presentation-viewer-thumbnails">
+          {slides.map((slide, index) => (
+            <button
+              key={slide.index}
+              type="button"
+              className={`presentation-viewer-thumb ${index === activeSlideIndex ? "active" : ""}`}
+              onClick={() => setActiveSlideIndex(index)}
+              title={`Slide ${slide.index}`}
+            >
+              <span className="presentation-viewer-thumb-number">{slide.index}</span>
+              {slide.imageDataUrl ? (
+                <img src={slide.imageDataUrl} alt={`Slide ${slide.index}`} />
+              ) : (
+                <span className="presentation-viewer-thumb-text">
+                  {slide.title || slide.text || "Blank slide"}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </aside>
+
+      <section className="presentation-viewer-main">
+        <div className="presentation-viewer-toolbar">
+          <div className="presentation-viewer-nav">
+            <button
+              type="button"
+              className="presentation-viewer-icon-btn"
+              onClick={goBack}
+              disabled={!canGoBack}
+              title="Previous slide"
+            >
+              <ChevronLeft size={16} />
+            </button>
+            <span className="presentation-viewer-counter">
+              {activeSlide ? activeSlideIndex + 1 : 0}/{slides.length}
+            </span>
+            <button
+              type="button"
+              className="presentation-viewer-icon-btn"
+              onClick={goForward}
+              disabled={!canGoForward}
+              title="Next slide"
+            >
+              <ChevronRight size={16} />
+            </button>
+          </div>
+
+          <div className="presentation-viewer-actions">
+            <label className="presentation-viewer-zoom" title="Zoom">
+              <ZoomIn size={15} />
+              <select
+                value={zoom}
+                onChange={(event) =>
+                  setZoom(Number(event.target.value) as (typeof ZOOM_LEVELS)[number])
+                }
+              >
+                {ZOOM_LEVELS.map((level) => (
+                  <option key={level} value={level}>
+                    {level}%
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              className="presentation-viewer-icon-btn"
+              onClick={onShowInFinder}
+              title="Show in Finder"
+            >
+              <FolderOpen size={16} />
+            </button>
+            <button
+              type="button"
+              className="presentation-viewer-icon-btn"
+              onClick={onOpenExternal}
+              title="Open in external app"
+            >
+              <ExternalLink size={16} />
+            </button>
+          </div>
+        </div>
+
+        <div className="presentation-viewer-slide-stage">
+          {activeSlide?.imageDataUrl ? (
+            <img
+              src={activeSlide.imageDataUrl}
+              alt={`Slide ${activeSlide.index}`}
+              className="presentation-viewer-slide-image"
+              style={{ width: `${zoom}%` }}
+            />
+          ) : (
+            <div className="presentation-viewer-slide-text" style={{ width: `${zoom}%` }}>
+              <div className="presentation-viewer-slide-text-kicker">
+                Slide {activeSlide?.index ?? 0}
+              </div>
+              <h3>{activeSlide?.title || "Untitled slide"}</h3>
+              <pre>{activeSlide?.text || "No extractable slide text."}</pre>
+            </div>
+          )}
+        </div>
+
+        <div className="presentation-viewer-notes">
+          <div className="presentation-viewer-notes-title">Speaker notes</div>
+          <pre>{activeSlide?.notes || "No speaker notes"}</pre>
+        </div>
+
+        {preview.renderStatus !== "rendered" && preview.renderMessage ? (
+          <div className="presentation-viewer-render-note">{preview.renderMessage}</div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/src/renderer/utils/__tests__/latex-artifacts.test.ts
+++ b/src/renderer/utils/__tests__/latex-artifacts.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { TaskEvent, TaskOutputSummary } from "../../../shared/types";
+import { findLatexPdfPair } from "../latex-artifacts";
+
+function event(type: TaskEvent["type"], payload: Record<string, unknown>): TaskEvent {
+  return {
+    id: `${type}-1`,
+    taskId: "task-1",
+    type,
+    timestamp: Date.now(),
+    payload,
+  } as TaskEvent;
+}
+
+describe("latex artifact pairing", () => {
+  it("pairs compiled PDFs with sourcePath metadata from artifact events", () => {
+    const pair = findLatexPdfPair([
+      event("artifact_created", {
+        path: "paper.pdf",
+        sourcePath: "paper.tex",
+        mimeType: "application/pdf",
+      }),
+    ]);
+
+    expect(pair).toEqual({ sourcePath: "paper.tex", pdfPath: "paper.pdf" });
+  });
+
+  it("falls back to matching same-folder basenames in output summaries", () => {
+    const outputSummary: TaskOutputSummary = {
+      created: ["docs/paper.tex", "docs/paper.pdf"],
+      primaryOutputPath: "docs/paper.pdf",
+      outputCount: 2,
+      folders: ["docs"],
+    };
+
+    expect(findLatexPdfPair([], outputSummary)).toEqual({
+      sourcePath: "docs/paper.tex",
+      pdfPath: "docs/paper.pdf",
+    });
+  });
+
+  it("does not pair unrelated TeX and PDF files", () => {
+    const outputSummary: TaskOutputSummary = {
+      created: ["paper.tex", "slides.pdf"],
+      primaryOutputPath: "slides.pdf",
+      outputCount: 2,
+      folders: ["."],
+    };
+
+    expect(findLatexPdfPair([], outputSummary)).toBeNull();
+  });
+});

--- a/src/renderer/utils/__tests__/step-document-preview.test.ts
+++ b/src/renderer/utils/__tests__/step-document-preview.test.ts
@@ -41,6 +41,11 @@ describe("step document preview helpers", () => {
     expect(extractDocumentPathFromText(text)).toBe("docs/spec.docx");
   });
 
+  it("extracts LaTeX source paths", () => {
+    const text = "Wrote `papers/codex-app-server-paper.tex` and compiled the PDF.";
+    expect(extractDocumentPathFromText(text)).toBe("papers/codex-app-server-paper.tex");
+  });
+
   it("trims trailing punctuation", () => {
     expect(extractDocumentPathFromText("Saved report.pdf, ready to share.")).toBe("report.pdf");
     expect(extractDocumentPathFromText("Saved report.docx.")).toBe("report.docx");

--- a/src/renderer/utils/__tests__/task-outputs.test.ts
+++ b/src/renderer/utils/__tests__/task-outputs.test.ts
@@ -96,6 +96,26 @@ describe("task output summary utilities", () => {
     expect(getPrimaryOutputFileName(summary)).toBe("final-report.pdf");
   });
 
+  it("derives output evidence from assistant media directives when file events are missing", () => {
+    const events: TaskEvent[] = [
+      makeEvent(
+        "timeline_step_updated",
+        {
+          legacyType: "assistant_message",
+          internal: true,
+          message:
+            'Rendered the clip.\n\n::video{path="artifacts/hyperframes-demo.mp4" title="HyperFrames Demo" muted=true loop=true}',
+        },
+        56,
+      ),
+    ];
+
+    const summary = deriveTaskOutputSummaryFromEvents(events);
+    expect(summary).not.toBeNull();
+    expect(summary?.created).toEqual(["artifacts/hyperframes-demo.mp4"]);
+    expect(summary?.primaryOutputPath).toBe("artifacts/hyperframes-demo.mp4");
+  });
+
   it("formats filename-only labels and output folder context", () => {
     expect(getFileName("artifacts/legal/negotiation-analysis")).toBe("negotiation-analysis");
     const nestedSummary = sanitizeTaskOutputSummary({

--- a/src/renderer/utils/assistant-media-directives.ts
+++ b/src/renderer/utils/assistant-media-directives.ts
@@ -1,0 +1,71 @@
+export type AssistantMediaDirective = {
+  type: "video" | "html";
+  path: string;
+};
+
+const VIDEO_DIRECTIVE_LINE_REGEX = /^\s*::video\{(.+)\}\s*$/;
+const HTML_DIRECTIVE_LINE_REGEX = /^\s*::html\{(.+)\}\s*$/;
+const DIRECTIVE_ATTR_REGEX = /(\w+)\s*=\s*("(?:[^"\\]|\\.)*"|true|false)/g;
+
+function decodeQuotedValue(value: string): string {
+  if (!value.startsWith("\"") || !value.endsWith("\"")) return value;
+  return value.slice(1, -1).replace(/\\"/g, "\"").replace(/\\\\/g, "\\");
+}
+
+function parseDirectiveLine(
+  line: string,
+  type: AssistantMediaDirective["type"],
+): AssistantMediaDirective | null {
+  const matcher = type === "video" ? VIDEO_DIRECTIVE_LINE_REGEX : HTML_DIRECTIVE_LINE_REGEX;
+  const match = line.match(matcher);
+  if (!match) return null;
+
+  const attrs = match[1];
+  const parsed: Record<string, unknown> = {};
+  let attrMatch: RegExpExecArray | null;
+
+  DIRECTIVE_ATTR_REGEX.lastIndex = 0;
+  while ((attrMatch = DIRECTIVE_ATTR_REGEX.exec(attrs)) !== null) {
+    const key = attrMatch[1];
+    const rawValue = attrMatch[2];
+    parsed[key] =
+      rawValue === "true" || rawValue === "false"
+        ? rawValue === "true"
+        : decodeQuotedValue(rawValue);
+  }
+
+  const unmatched = attrs.replace(DIRECTIVE_ATTR_REGEX, "").trim();
+  if (unmatched.length > 0) return null;
+
+  if (typeof parsed.path !== "string" || parsed.path.trim().length === 0) {
+    return null;
+  }
+
+  return {
+    type,
+    path: parsed.path.trim(),
+  };
+}
+
+export function extractAssistantMediaDirectives(message: string): AssistantMediaDirective[] {
+  const directives: AssistantMediaDirective[] = [];
+  const lines = String(message || "").split("\n");
+
+  for (const line of lines) {
+    if (line.trimStart().startsWith("::video{")) {
+      const parsed = parseDirectiveLine(line, "video");
+      if (parsed) directives.push(parsed);
+      continue;
+    }
+    if (line.trimStart().startsWith("::html{")) {
+      const parsed = parseDirectiveLine(line, "html");
+      if (parsed) directives.push(parsed);
+    }
+  }
+
+  return directives;
+}
+
+export function hasAssistantMediaDirective(message: string): boolean {
+  return extractAssistantMediaDirectives(message).length > 0;
+}

--- a/src/renderer/utils/latex-artifacts.ts
+++ b/src/renderer/utils/latex-artifacts.ts
@@ -1,0 +1,95 @@
+import type { TaskEvent, TaskOutputSummary } from "../../shared/types";
+import { getEffectiveTaskEventType } from "./task-event-compat";
+
+export type LatexPdfPair = {
+  sourcePath: string;
+  pdfPath: string;
+};
+
+const TEX_EXT_RE = /\.tex$/i;
+const PDF_EXT_RE = /\.pdf$/i;
+
+function normalizePath(raw: unknown): string {
+  return typeof raw === "string" ? raw.trim().replace(/\\/g, "/") : "";
+}
+
+function dirname(filePath: string): string {
+  const idx = filePath.lastIndexOf("/");
+  return idx >= 0 ? filePath.slice(0, idx) : ".";
+}
+
+function basenameWithoutExt(filePath: string): string {
+  const name = filePath.split("/").pop() || filePath;
+  const idx = name.lastIndexOf(".");
+  return idx >= 0 ? name.slice(0, idx).toLowerCase() : name.toLowerCase();
+}
+
+function sameStemAndFolder(left: string, right: string): boolean {
+  return dirname(left) === dirname(right) && basenameWithoutExt(left) === basenameWithoutExt(right);
+}
+
+export function findLatexPdfPair(
+  events: TaskEvent[] | undefined,
+  outputSummary?: TaskOutputSummary | null,
+): LatexPdfPair | null {
+  const texPaths = new Set<string>();
+  const pdfPaths = new Set<string>();
+  const orderedPdfPaths: string[] = [];
+
+  const addPath = (rawPath: unknown) => {
+    const filePath = normalizePath(rawPath);
+    if (!filePath) return;
+    if (TEX_EXT_RE.test(filePath)) {
+      texPaths.add(filePath);
+      return;
+    }
+    if (PDF_EXT_RE.test(filePath)) {
+      pdfPaths.add(filePath);
+      orderedPdfPaths.push(filePath);
+    }
+  };
+
+  for (const filePath of [
+    ...(outputSummary?.created || []),
+    ...(outputSummary?.modifiedFallback || []),
+    outputSummary?.primaryOutputPath,
+  ]) {
+    addPath(filePath);
+  }
+
+  for (const event of events || []) {
+    const effectiveType = getEffectiveTaskEventType(event);
+    if (
+      effectiveType !== "artifact_created" &&
+      effectiveType !== "file_created" &&
+      effectiveType !== "file_modified"
+    ) {
+      continue;
+    }
+    const eventPath = normalizePath(event.payload?.path || event.payload?.to || event.payload?.from);
+    const sourcePath = normalizePath(event.payload?.sourcePath);
+    addPath(eventPath);
+    addPath(sourcePath);
+    if (PDF_EXT_RE.test(eventPath) && TEX_EXT_RE.test(sourcePath)) {
+      return { sourcePath, pdfPath: eventPath };
+    }
+  }
+
+  for (const pdfPath of orderedPdfPaths) {
+    for (const sourcePath of texPaths) {
+      if (sameStemAndFolder(sourcePath, pdfPath)) {
+        return { sourcePath, pdfPath };
+      }
+    }
+  }
+
+  for (const pdfPath of pdfPaths) {
+    for (const sourcePath of texPaths) {
+      if (sameStemAndFolder(sourcePath, pdfPath)) {
+        return { sourcePath, pdfPath };
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/renderer/utils/step-document-preview.ts
+++ b/src/renderer/utils/step-document-preview.ts
@@ -5,7 +5,7 @@ const CREATION_STEP_PATTERN =
   /\b(create_document|create|created|generate|generated|write|wrote|produce|produced|export|exported|save|saved)\b/i;
 
 const DOCUMENT_PATH_PATTERN =
-  /(["'`])([^"'`\n]*?\.(?:docx|pdf))\1|((?:[A-Za-z]:[\\/])?[~./\\\w@%+-]+?\.(?:docx|pdf)\b)/gi;
+  /(["'`])([^"'`\n]*?\.(?:docx|pdf|tex))\1|((?:[A-Za-z]:[\\/])?[~./\\\w@%+-]+?\.(?:docx|pdf|tex)\b)/gi;
 
 function normalizeDocumentCandidate(candidate: string): string | null {
   const trimmed = candidate.trim();
@@ -13,7 +13,7 @@ function normalizeDocumentCandidate(candidate: string): string | null {
 
   const withoutLeadingWrapper = trimmed.replace(/^[([{]+/, "");
   const withoutTrailingPunctuation = withoutLeadingWrapper.replace(/[)\]}.;,!?]+$/g, "");
-  if (!/\.(docx|pdf)$/i.test(withoutTrailingPunctuation)) {
+  if (!/\.(docx|pdf|tex)$/i.test(withoutTrailingPunctuation)) {
     return null;
   }
   return withoutTrailingPunctuation;

--- a/src/renderer/utils/task-outputs.ts
+++ b/src/renderer/utils/task-outputs.ts
@@ -1,4 +1,6 @@
 import { Task, TaskEvent, TaskOutputSummary } from "../../shared/types";
+import { getEffectiveTaskEventType } from "./task-event-compat";
+import { extractAssistantMediaDirectives } from "./assistant-media-directives";
 
 function normalizePath(raw: string): string {
   return raw.trim().replace(/\\/g, "/");
@@ -147,7 +149,8 @@ export function deriveTaskOutputSummaryFromEvents(events: TaskEvent[]): TaskOutp
   const modified = new Map<string, number>();
 
   for (const event of events) {
-    if (event.type === "file_created") {
+    const effectiveType = getEffectiveTaskEventType(event);
+    if (effectiveType === "file_created") {
       const path = event.payload?.path;
       if (!isNonEmptyString(path)) continue;
       if (event.payload?.type === "directory") continue;
@@ -155,7 +158,7 @@ export function deriveTaskOutputSummaryFromEvents(events: TaskEvent[]): TaskOutp
       continue;
     }
 
-    if (event.type === "artifact_created") {
+    if (effectiveType === "artifact_created") {
       const path = event.payload?.path;
       if (!isNonEmptyString(path)) continue;
       created.set(normalizePath(path), event.timestamp || Date.now());
@@ -169,10 +172,35 @@ export function deriveTaskOutputSummaryFromEvents(events: TaskEvent[]): TaskOutp
       continue;
     }
 
-    if (event.type === "file_modified") {
+    if (effectiveType === "file_modified") {
       const path = event.payload?.path || event.payload?.to || event.payload?.from;
       if (!isNonEmptyString(path)) continue;
       modified.set(normalizePath(path), event.timestamp || Date.now());
+      continue;
+    }
+
+    if (effectiveType === "assistant_message") {
+      const message = typeof event.payload?.message === "string" ? event.payload.message : "";
+      for (const directive of extractAssistantMediaDirectives(message)) {
+        created.set(normalizePath(directive.path), event.timestamp || Date.now());
+      }
+      continue;
+    }
+
+    if (effectiveType === "task_completed") {
+      const candidateTexts = [
+        event.payload?.resultSummary,
+        event.payload?.semanticSummary,
+        event.payload?.message,
+        event.payload?.bestKnownOutcome?.resultSummary,
+        event.payload?.bestKnownOutcome?.semanticSummary,
+      ];
+      for (const text of candidateTexts) {
+        if (typeof text !== "string" || text.trim().length === 0) continue;
+        for (const directive of extractAssistantMediaDirectives(text)) {
+          created.set(normalizePath(directive.path), event.timestamp || Date.now());
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds PPTX preview generation, in-app presentation viewing, and inline presentation cards.
- Adds source-first LaTeX compilation support with paired source/PDF artifact rendering.
- Adds HTML/media directive rendering helpers and preview utilities for task artifact surfaces.

## Validation
- npm run type-check
- npx vitest run src/electron/utils/__tests__/PptxPreviewService.test.ts src/electron/utils/__tests__/latex-compiler.test.ts src/electron/utils/__tests__/window-visibility.test.ts src/electron/ipc/__tests__/video-preview-transcode.test.ts src/renderer/utils/__tests__/latex-artifacts.test.ts src/renderer/utils/__tests__/step-document-preview.test.ts src/renderer/utils/__tests__/task-outputs.test.ts src/electron/agent/tools/__tests__/document-tools.test.ts

## Notes
This is the next stack layer after merged PR #77.