### PR TITLE
feat(mailbox): add AgentMail and forwarding support

### DIFF
--- a/docs/inbox-agent.md
+++ b/docs/inbox-agent.md
@@ -81,7 +81,34 @@ The main advantage of Inbox Agent is speed without losing context:
 - **Refresh intel** - re-runs the thread analysis and contact intelligence for the selected conversation
 - **Remind later** - snoozes a thread by creating a timed follow-up task
 - **Automation rule / schedule** - create inbox-native rules or patrol schedules from a thread or filter
+- **Auto-forward** - create a Gmail forwarding automation from the selected thread to route matching attachments to another mailbox
 - **Bulk archive / trash / mark read** - clears multiple threads at once
+
+## Gmail Forwarding Automations
+
+Inbox Agent can create native Gmail forwarding automations from the selected thread with `Auto-forward…`.
+
+What the flow does:
+
+- creates a mailbox automation with sender/domain filters, optional subject keywords, attachment extension filters, and a target recipient
+- stores the selected Gmail `providerThreadId` so thread-created automations stay scoped to that Gmail conversation instead of widening to the whole mailbox
+- supports `dry-run` mode first so you can label and audit candidate messages before enabling real sends
+- reconstructs and sends a new MIME email with the matched attachments instead of relying on Google Apps Script forwarding
+
+Current behavior:
+
+- **Gmail only** - the forwarding automation currently depends on Gmail API search, label mutation, attachment fetch, and send flows
+- **Attachment-driven** - the built-in thread action currently defaults to PDF forwarding, but the underlying automation supports configurable attachment extension and filename keyword filters
+- **Persistent scan watermark** - recurring runs track the last successful scan time and search with overlap, so a short app restart, laptop sleep, or delayed timer does not permanently drop matching mail
+- **Per-message dedupe** - already-sent messages are tracked in the local database by automation id and Gmail message id, so later mail in the same thread can still be evaluated independently
+- **Thread labels are status cues, not hard suppression** - candidate / rejected / forwarded Gmail labels are still applied for operator visibility, but they are not used as permanent search exclusions because later messages in the same thread may still qualify
+
+Operational notes:
+
+- `Run now` evaluates the automation immediately and then recomputes the next scheduled run from the current time
+- a successful non-dry-run execution advances the stored scan watermark; dry-run keeps the watermark unchanged so you can repeatedly inspect the same candidate set
+- thread-created automations keep the CoWork `threadId` for UI association and the Gmail `providerThreadId` for execution scoping
+- Gmail modify scope is required because the automation creates labels, updates thread labels, fetches attachments, and sends mail
 
 ## Event Pipeline
 

--- a/src/electron/agentmail/AgentMailAdminService.ts
+++ b/src/electron/agentmail/AgentMailAdminService.ts
@@ -1,0 +1,820 @@
+import Database from "better-sqlite3";
+import {
+  AgentMailApiKeySummary,
+  AgentMailConnectionTestResult,
+  AgentMailDomain,
+  AgentMailInbox,
+  AgentMailListEntry,
+  AgentMailPod,
+  AgentMailSettingsData,
+  AgentMailStatus,
+  AgentMailWorkspaceBinding,
+} from "../../shared/types";
+import { AgentMailSettingsManager } from "../settings/agentmail-manager";
+import { AgentMailClient } from "./AgentMailClient";
+
+type AgentMailRealtimeStatusProvider = () => Pick<
+  AgentMailStatus,
+  "realtimeConnected" | "connectionState" | "lastEventAt" | "error"
+>;
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function parseJson<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function listEntryId(workspaceId: string, inboxId: string | undefined, direction: string, listType: string, entry: string): string {
+  return [workspaceId, inboxId || "org", direction, listType, entry.toLowerCase()].join(":");
+}
+
+function mapPod(payload: unknown): AgentMailPod {
+  const record = asObject(payload) || {};
+  return {
+    podId: asString(record.pod_id) || "",
+    name: asString(record.name),
+    clientId: asString(record.client_id),
+    createdAt: parseTimestamp(record.created_at),
+    updatedAt: parseTimestamp(record.updated_at),
+  };
+}
+
+function mapInbox(payload: unknown, workspaceId?: string): AgentMailInbox {
+  const record = asObject(payload) || {};
+  return {
+    podId: asString(record.pod_id) || "",
+    inboxId: asString(record.inbox_id) || "",
+    email: asString(record.email) || asString(record.inbox_id),
+    displayName: asString(record.display_name),
+    clientId: asString(record.client_id),
+    workspaceId,
+    createdAt: parseTimestamp(record.created_at),
+    updatedAt: parseTimestamp(record.updated_at),
+  };
+}
+
+function mapDomain(payload: unknown, workspaceId?: string): AgentMailDomain {
+  const record = asObject(payload) || {};
+  const records = Array.isArray(record.records)
+    ? record.records
+        .map((item) => {
+          const entry = asObject(item);
+          if (!entry) return null;
+          const type = asString(entry.type);
+          const name = asString(entry.name);
+          const value = asString(entry.value);
+          if (!type || !name || !value) return null;
+          return {
+            type,
+            name,
+            value,
+            status: asString(entry.status),
+            priority: asNumber(entry.priority),
+          };
+        })
+        .filter((item): item is NonNullable<typeof item> => Boolean(item))
+    : [];
+
+  return {
+    domainId: asString(record.domain_id) || "",
+    domain: asString(record.domain),
+    status: asString(record.status),
+    feedbackEnabled: Boolean(record.feedback_enabled),
+    records,
+    podId: asString(record.pod_id) || "",
+    clientId: asString(record.client_id),
+    workspaceId,
+    createdAt: parseTimestamp(record.created_at),
+    updatedAt: parseTimestamp(record.updated_at),
+  };
+}
+
+function mapListEntry(payload: unknown, fallback: Partial<AgentMailListEntry> = {}): AgentMailListEntry | null {
+  const record = asObject(payload) || {};
+  const direction = (asString(record.direction) || fallback.direction) as AgentMailListEntry["direction"] | undefined;
+  const listType = (asString(record.type) || fallback.listType) as AgentMailListEntry["listType"] | undefined;
+  const entry = asString(record.entry);
+  if (!direction || !listType || !entry) return null;
+  return {
+    direction,
+    listType,
+    entry,
+    entryType: (asString(record.entry_type) as AgentMailListEntry["entryType"] | undefined) || fallback.entryType,
+    reason: asString(record.reason),
+    organizationId: asString(record.organization_id),
+    podId: asString(record.pod_id) || fallback.podId,
+    inboxId: asString(record.inbox_id) || fallback.inboxId,
+    createdAt: parseTimestamp(record.created_at),
+  };
+}
+
+function mapApiKey(payload: unknown): AgentMailApiKeySummary {
+  const record = asObject(payload) || {};
+  return {
+    apiKeyId: asString(record.api_key_id) || "",
+    prefix: asString(record.prefix) || "",
+    name: asString(record.name),
+    podId: asString(record.pod_id),
+    inboxId: asString(record.inbox_id),
+    createdAt: parseTimestamp(record.created_at),
+    permissions: asObject(record.permissions) as Record<string, boolean> | undefined,
+  };
+}
+
+export class AgentMailAdminService {
+  constructor(
+    private readonly db: Database.Database,
+    private readonly getRealtimeStatus?: AgentMailRealtimeStatusProvider,
+  ) {}
+
+  getSettings(): AgentMailSettingsData {
+    return AgentMailSettingsManager.loadSettings();
+  }
+
+  saveSettings(settings: AgentMailSettingsData): void {
+    AgentMailSettingsManager.saveSettings(settings);
+    AgentMailSettingsManager.clearCache();
+  }
+
+  private getClient(): AgentMailClient {
+    return new AgentMailClient(AgentMailSettingsManager.loadSettings());
+  }
+
+  private getWorkspaceBindingRow(workspaceId: string) {
+    return this.db
+      .prepare(
+        `SELECT workspace_id, pod_id, pod_name, created_at, updated_at
+         FROM agentmail_workspace_pods
+         WHERE workspace_id = ?`,
+      )
+      .get(workspaceId) as
+      | {
+          workspace_id: string;
+          pod_id: string;
+          pod_name: string | null;
+          created_at: number;
+          updated_at: number;
+        }
+      | undefined;
+  }
+
+  private ensureWorkspaceBinding(workspaceId: string): AgentMailWorkspaceBinding {
+    const row = this.getWorkspaceBindingRow(workspaceId);
+    if (!row) {
+      throw new Error("This workspace is not bound to an AgentMail pod yet.");
+    }
+    return {
+      workspaceId: row.workspace_id,
+      podId: row.pod_id,
+      podName: row.pod_name || undefined,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private persistWorkspaceBinding(binding: AgentMailWorkspaceBinding): void {
+    this.db
+      .prepare(
+        `INSERT INTO agentmail_workspace_pods
+          (workspace_id, pod_id, pod_name, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(workspace_id) DO UPDATE SET
+           pod_id = excluded.pod_id,
+           pod_name = excluded.pod_name,
+           updated_at = excluded.updated_at`,
+      )
+      .run(
+        binding.workspaceId,
+        binding.podId,
+        binding.podName || null,
+        binding.createdAt,
+        binding.updatedAt,
+      );
+  }
+
+  private persistInboxes(workspaceId: string, podId: string, inboxes: AgentMailInbox[]): void {
+    const now = Date.now();
+    const existingIds = new Set(inboxes.map((inbox) => inbox.inboxId));
+    const deleteStatement = this.db.prepare(
+      `DELETE FROM agentmail_inboxes WHERE workspace_id = ? AND pod_id = ? AND inbox_id = ?`,
+    );
+    const upsertStatement = this.db.prepare(
+      `INSERT INTO agentmail_inboxes
+        (workspace_id, pod_id, inbox_id, email, display_name, client_id, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(pod_id, inbox_id) DO UPDATE SET
+         workspace_id = excluded.workspace_id,
+         email = excluded.email,
+         display_name = excluded.display_name,
+         client_id = excluded.client_id,
+         metadata_json = excluded.metadata_json,
+         updated_at = excluded.updated_at`,
+    );
+    const currentRows = this.db
+      .prepare("SELECT inbox_id FROM agentmail_inboxes WHERE workspace_id = ? AND pod_id = ?")
+      .all(workspaceId, podId) as Array<{ inbox_id: string }>;
+
+    for (const row of currentRows) {
+      if (!existingIds.has(row.inbox_id)) {
+        deleteStatement.run(workspaceId, podId, row.inbox_id);
+      }
+    }
+
+    for (const inbox of inboxes) {
+      upsertStatement.run(
+        workspaceId,
+        podId,
+        inbox.inboxId,
+        inbox.email || null,
+        inbox.displayName || null,
+        inbox.clientId || null,
+        JSON.stringify(inbox),
+        inbox.createdAt || now,
+        inbox.updatedAt || now,
+      );
+    }
+  }
+
+  private persistDomains(workspaceId: string, podId: string, domains: AgentMailDomain[]): void {
+    const now = Date.now();
+    const existingIds = new Set(domains.map((domain) => domain.domainId));
+    const currentRows = this.db
+      .prepare("SELECT domain_id FROM agentmail_domains WHERE workspace_id = ? AND pod_id = ?")
+      .all(workspaceId, podId) as Array<{ domain_id: string }>;
+
+    for (const row of currentRows) {
+      if (!existingIds.has(row.domain_id)) {
+        this.db.prepare("DELETE FROM agentmail_domains WHERE domain_id = ?").run(row.domain_id);
+      }
+    }
+
+    const upsert = this.db.prepare(
+      `INSERT INTO agentmail_domains
+        (domain_id, workspace_id, pod_id, domain, status, feedback_enabled, records_json, client_id, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(domain_id) DO UPDATE SET
+         workspace_id = excluded.workspace_id,
+         pod_id = excluded.pod_id,
+         domain = excluded.domain,
+         status = excluded.status,
+         feedback_enabled = excluded.feedback_enabled,
+         records_json = excluded.records_json,
+         client_id = excluded.client_id,
+         metadata_json = excluded.metadata_json,
+         updated_at = excluded.updated_at`,
+    );
+
+    for (const domain of domains) {
+      upsert.run(
+        domain.domainId,
+        workspaceId,
+        podId,
+        domain.domain || null,
+        domain.status || null,
+        domain.feedbackEnabled ? 1 : 0,
+        JSON.stringify(domain.records),
+        domain.clientId || null,
+        JSON.stringify(domain),
+        domain.createdAt || now,
+        domain.updatedAt || now,
+      );
+    }
+  }
+
+  private persistListEntries(workspaceId: string, entries: AgentMailListEntry[]): void {
+    for (const entry of entries) {
+      const id = listEntryId(workspaceId, entry.inboxId, entry.direction, entry.listType, entry.entry);
+      this.db
+        .prepare(
+          `INSERT INTO agentmail_lists
+            (id, workspace_id, pod_id, inbox_id, direction, list_type, entry_value, entry_type, reason, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             pod_id = excluded.pod_id,
+             inbox_id = excluded.inbox_id,
+             entry_type = excluded.entry_type,
+             reason = excluded.reason,
+             updated_at = excluded.updated_at`,
+        )
+        .run(
+          id,
+          workspaceId,
+          entry.podId || null,
+          entry.inboxId || null,
+          entry.direction,
+          entry.listType,
+          entry.entry,
+          entry.entryType || null,
+          entry.reason || null,
+          entry.createdAt || Date.now(),
+          Date.now(),
+        );
+    }
+  }
+
+  private deleteListEntryRecord(
+    workspaceId: string,
+    inboxId: string | undefined,
+    direction: AgentMailListEntry["direction"],
+    listType: AgentMailListEntry["listType"],
+    entry: string,
+  ): void {
+    this.db
+      .prepare("DELETE FROM agentmail_lists WHERE id = ?")
+      .run(listEntryId(workspaceId, inboxId, direction, listType, entry));
+  }
+
+  private persistApiKeys(workspaceId: string, inboxId: string, apiKeys: AgentMailApiKeySummary[]): void {
+    const seen = new Set(apiKeys.map((item) => item.apiKeyId));
+    const currentRows = this.db
+      .prepare("SELECT api_key_id FROM agentmail_api_keys WHERE workspace_id = ? AND inbox_id = ?")
+      .all(workspaceId, inboxId) as Array<{ api_key_id: string }>;
+
+    for (const row of currentRows) {
+      if (!seen.has(row.api_key_id)) {
+        this.db.prepare("DELETE FROM agentmail_api_keys WHERE api_key_id = ?").run(row.api_key_id);
+      }
+    }
+
+    for (const apiKey of apiKeys) {
+      this.db
+        .prepare(
+          `INSERT INTO agentmail_api_keys
+            (api_key_id, workspace_id, pod_id, inbox_id, name, prefix, permissions_json, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(api_key_id) DO UPDATE SET
+             workspace_id = excluded.workspace_id,
+             pod_id = excluded.pod_id,
+             inbox_id = excluded.inbox_id,
+             name = excluded.name,
+             prefix = excluded.prefix,
+             permissions_json = excluded.permissions_json,
+             updated_at = excluded.updated_at`,
+        )
+        .run(
+          apiKey.apiKeyId,
+          workspaceId,
+          apiKey.podId || null,
+          apiKey.inboxId || inboxId,
+          apiKey.name || null,
+          apiKey.prefix,
+          JSON.stringify(apiKey.permissions || {}),
+          apiKey.createdAt || Date.now(),
+          Date.now(),
+        );
+    }
+  }
+
+  async testConnection(): Promise<AgentMailConnectionTestResult> {
+    const settings = AgentMailSettingsManager.loadSettings();
+    if (!settings.apiKey) {
+      return {
+        success: false,
+        error: "AgentMail API key is missing.",
+        baseUrl: settings.baseUrl,
+      };
+    }
+
+    try {
+      const client = new AgentMailClient(settings);
+      const podsResponse = await client.listPods(25);
+      const pods = Array.isArray(podsResponse.pods) ? podsResponse.pods : [];
+      let inboxCount = 0;
+
+      for (const pod of pods.slice(0, 5)) {
+        const podId = asString(asObject(pod)?.pod_id);
+        if (!podId) continue;
+        const inboxResponse = await client.listPodInboxes(podId, 100);
+        inboxCount += Array.isArray(inboxResponse.inboxes) ? inboxResponse.inboxes.length : 0;
+      }
+
+      return {
+        success: true,
+        podCount: pods.length,
+        inboxCount,
+        baseUrl: client.baseUrl,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        baseUrl: settings.baseUrl,
+      };
+    }
+  }
+
+  async getStatus(): Promise<AgentMailStatus> {
+    const settings = AgentMailSettingsManager.loadSettings();
+    const realtime = this.getRealtimeStatus?.() || {
+      realtimeConnected: false,
+      connectionState: "disconnected" as const,
+      lastEventAt: undefined,
+      error: undefined,
+    };
+
+    if (!settings.apiKey) {
+      return {
+        configured: false,
+        connected: false,
+        realtimeConnected: realtime.realtimeConnected,
+        connectionState: realtime.connectionState,
+        baseUrl: settings.baseUrl,
+        websocketUrl: settings.websocketUrl,
+        lastEventAt: realtime.lastEventAt,
+        error: realtime.error,
+      };
+    }
+
+    const domainCountRow = this.db
+      .prepare("SELECT COUNT(*) AS count FROM agentmail_domains")
+      .get() as { count: number };
+    const inboxCountRow = this.db
+      .prepare("SELECT COUNT(*) AS count FROM agentmail_inboxes")
+      .get() as { count: number };
+    const podCountRow = this.db
+      .prepare("SELECT COUNT(*) AS count FROM agentmail_workspace_pods")
+      .get() as { count: number };
+
+    try {
+      const result = await this.testConnection();
+      return {
+        configured: true,
+        connected: result.success,
+        realtimeConnected: realtime.realtimeConnected,
+        connectionState: realtime.connectionState,
+        baseUrl: settings.baseUrl,
+        websocketUrl: settings.websocketUrl,
+        podCount: result.podCount ?? podCountRow.count,
+        inboxCount: result.inboxCount ?? inboxCountRow.count,
+        domainCount: domainCountRow.count,
+        lastEventAt: realtime.lastEventAt,
+        error: result.success ? realtime.error : result.error || realtime.error,
+      };
+    } catch (error) {
+      return {
+        configured: true,
+        connected: false,
+        realtimeConnected: realtime.realtimeConnected,
+        connectionState: realtime.connectionState,
+        baseUrl: settings.baseUrl,
+        websocketUrl: settings.websocketUrl,
+        podCount: podCountRow.count,
+        inboxCount: inboxCountRow.count,
+        domainCount: domainCountRow.count,
+        lastEventAt: realtime.lastEventAt,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async listPods(): Promise<AgentMailPod[]> {
+    const response = await this.getClient().listPods(100);
+    return (Array.isArray(response.pods) ? response.pods : [])
+      .map((pod) => mapPod(pod))
+      .filter((pod) => pod.podId);
+  }
+
+  getWorkspaceBinding(workspaceId: string): AgentMailWorkspaceBinding | null {
+    const row = this.getWorkspaceBindingRow(workspaceId);
+    if (!row) return null;
+    return {
+      workspaceId: row.workspace_id,
+      podId: row.pod_id,
+      podName: row.pod_name || undefined,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  async bindWorkspacePod(workspaceId: string, podId: string): Promise<AgentMailWorkspaceBinding> {
+    const pod = mapPod(await this.getClient().getPod(podId));
+    const now = Date.now();
+    const binding: AgentMailWorkspaceBinding = {
+      workspaceId,
+      podId: pod.podId,
+      podName: pod.name,
+      createdAt: this.getWorkspaceBindingRow(workspaceId)?.created_at || now,
+      updatedAt: now,
+    };
+    this.persistWorkspaceBinding(binding);
+    await this.refreshWorkspace(workspaceId);
+    return binding;
+  }
+
+  async createWorkspacePod(workspaceId: string, podName?: string): Promise<AgentMailWorkspaceBinding> {
+    const pod = mapPod(
+      await this.getClient().createPod({
+        name: podName,
+        clientId: workspaceId,
+      }),
+    );
+    const binding: AgentMailWorkspaceBinding = {
+      workspaceId,
+      podId: pod.podId,
+      podName: pod.name,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    this.persistWorkspaceBinding(binding);
+    await this.refreshWorkspace(workspaceId);
+    return binding;
+  }
+
+  async refreshWorkspace(workspaceId: string): Promise<{
+    binding: AgentMailWorkspaceBinding;
+    inboxes: AgentMailInbox[];
+    domains: AgentMailDomain[];
+  }> {
+    const binding = this.ensureWorkspaceBinding(workspaceId);
+    const client = this.getClient();
+    const [inboxResponse, domainResponse, podResponse] = await Promise.all([
+      client.listPodInboxes(binding.podId, 100),
+      client.listPodDomains(binding.podId, 100),
+      client.getPod(binding.podId),
+    ]);
+    const pod = mapPod(podResponse);
+    const nextBinding: AgentMailWorkspaceBinding = {
+      ...binding,
+      podName: pod.name || binding.podName,
+      updatedAt: Date.now(),
+    };
+    this.persistWorkspaceBinding(nextBinding);
+
+    const inboxes = (Array.isArray(inboxResponse.inboxes) ? inboxResponse.inboxes : [])
+      .map((inbox) => mapInbox(inbox, workspaceId))
+      .filter((inbox) => inbox.inboxId);
+    const domains = (Array.isArray(domainResponse.domains) ? domainResponse.domains : [])
+      .map((domain) => mapDomain(domain, workspaceId))
+      .filter((domain) => domain.domainId);
+
+    this.persistInboxes(workspaceId, binding.podId, inboxes);
+    this.persistDomains(workspaceId, binding.podId, domains);
+
+    return {
+      binding: nextBinding,
+      inboxes,
+      domains,
+    };
+  }
+
+  listInboxes(workspaceId: string): AgentMailInbox[] {
+    const rows = this.db
+      .prepare(
+        `SELECT pod_id, inbox_id, email, display_name, client_id, created_at, updated_at
+         FROM agentmail_inboxes
+         WHERE workspace_id = ?
+         ORDER BY email COLLATE NOCASE ASC`,
+      )
+      .all(workspaceId) as Array<{
+      pod_id: string;
+      inbox_id: string;
+      email: string | null;
+      display_name: string | null;
+      client_id: string | null;
+      created_at: number;
+      updated_at: number;
+    }>;
+
+    return rows.map((row) => ({
+      podId: row.pod_id,
+      inboxId: row.inbox_id,
+      email: row.email || undefined,
+      displayName: row.display_name || undefined,
+      clientId: row.client_id || undefined,
+      workspaceId,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  async createInbox(
+    workspaceId: string,
+    input: { username?: string; domain?: string; displayName?: string; clientId?: string },
+  ): Promise<AgentMailInbox> {
+    const binding = this.ensureWorkspaceBinding(workspaceId);
+    const inbox = mapInbox(await this.getClient().createPodInbox(binding.podId, input), workspaceId);
+    this.persistInboxes(workspaceId, binding.podId, [...this.listInboxes(workspaceId), inbox]);
+    return inbox;
+  }
+
+  async updateInbox(
+    workspaceId: string,
+    inboxId: string,
+    input: { displayName: string },
+  ): Promise<AgentMailInbox> {
+    this.ensureWorkspaceBinding(workspaceId);
+    const inbox = mapInbox(await this.getClient().updateInbox(inboxId, input), workspaceId);
+    await this.refreshWorkspace(workspaceId);
+    return inbox;
+  }
+
+  async deleteInbox(workspaceId: string, inboxId: string): Promise<{ success: boolean }> {
+    await this.getClient().deleteInbox(inboxId);
+    this.db.prepare("DELETE FROM agentmail_inboxes WHERE workspace_id = ? AND inbox_id = ?").run(workspaceId, inboxId);
+    return { success: true };
+  }
+
+  listDomains(workspaceId: string): AgentMailDomain[] {
+    const rows = this.db
+      .prepare(
+        `SELECT domain_id, workspace_id, pod_id, domain, status, feedback_enabled, records_json, client_id, created_at, updated_at
+         FROM agentmail_domains
+         WHERE workspace_id = ?
+         ORDER BY domain COLLATE NOCASE ASC`,
+      )
+      .all(workspaceId) as Array<{
+      domain_id: string;
+      workspace_id: string;
+      pod_id: string;
+      domain: string | null;
+      status: string | null;
+      feedback_enabled: number;
+      records_json: string | null;
+      client_id: string | null;
+      created_at: number;
+      updated_at: number;
+    }>;
+
+    return rows.map((row) => ({
+      domainId: row.domain_id,
+      domain: row.domain || undefined,
+      status: row.status || undefined,
+      feedbackEnabled: Boolean(row.feedback_enabled),
+      records: parseJson(row.records_json, []),
+      podId: row.pod_id,
+      clientId: row.client_id || undefined,
+      workspaceId: row.workspace_id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  async createDomain(
+    workspaceId: string,
+    input: { domain: string; feedbackEnabled?: boolean },
+  ): Promise<AgentMailDomain> {
+    const binding = this.ensureWorkspaceBinding(workspaceId);
+    const domain = mapDomain(
+      await this.getClient().createPodDomain(binding.podId, {
+        domain: input.domain,
+        feedbackEnabled: input.feedbackEnabled ?? true,
+      }),
+      workspaceId,
+    );
+    await this.refreshWorkspace(workspaceId);
+    return domain;
+  }
+
+  async verifyDomain(workspaceId: string, domainId: string): Promise<AgentMailDomain | null> {
+    const binding = this.ensureWorkspaceBinding(workspaceId);
+    await this.getClient().verifyPodDomain(binding.podId, domainId);
+    const refreshed = await this.refreshWorkspace(workspaceId);
+    return refreshed.domains.find((domain) => domain.domainId === domainId) || null;
+  }
+
+  async deleteDomain(workspaceId: string, domainId: string): Promise<{ success: boolean }> {
+    const binding = this.ensureWorkspaceBinding(workspaceId);
+    await this.getClient().deletePodDomain(binding.podId, domainId);
+    this.db.prepare("DELETE FROM agentmail_domains WHERE domain_id = ?").run(domainId);
+    return { success: true };
+  }
+
+  async listListEntries(
+    workspaceId: string,
+    options: { inboxId?: string; direction?: AgentMailListEntry["direction"]; listType?: AgentMailListEntry["listType"] } = {},
+  ): Promise<AgentMailListEntry[]> {
+    const directions = options.direction ? [options.direction] : (["receive", "reply"] as AgentMailListEntry["direction"][]);
+    const listTypes = options.listType ? [options.listType] : (["allow", "block"] as AgentMailListEntry["listType"][]);
+    const client = this.getClient();
+    const entries: AgentMailListEntry[] = [];
+
+    for (const direction of directions) {
+      for (const listType of listTypes) {
+        const response = options.inboxId
+          ? await client.listInboxLists(options.inboxId, direction, listType, 100)
+          : await client.listLists(direction, listType, 100);
+        const mapped = (Array.isArray(response.entries) ? response.entries : [])
+          .map((entry) =>
+            mapListEntry(entry, {
+              direction,
+              listType,
+              inboxId: options.inboxId,
+            }),
+          )
+          .filter((entry): entry is AgentMailListEntry => Boolean(entry));
+        entries.push(...mapped);
+      }
+    }
+
+    if (entries.length > 0) {
+      this.persistListEntries(workspaceId, entries);
+    }
+
+    return entries.sort((a, b) => a.entry.localeCompare(b.entry));
+  }
+
+  async createListEntry(
+    workspaceId: string,
+    input: {
+      inboxId?: string;
+      direction: AgentMailListEntry["direction"];
+      listType: AgentMailListEntry["listType"];
+      entry: string;
+      reason?: string;
+    },
+  ): Promise<AgentMailListEntry> {
+    const payload = input.inboxId
+      ? await this.getClient().createInboxListEntry(input.inboxId, input.direction, input.listType, {
+          entry: input.entry,
+          reason: input.reason,
+        })
+      : await this.getClient().createListEntry(input.direction, input.listType, {
+          entry: input.entry,
+          reason: input.reason,
+        });
+
+    const entry = mapListEntry(payload, input);
+    if (!entry) {
+      throw new Error("AgentMail returned an invalid list entry payload.");
+    }
+    this.persistListEntries(workspaceId, [entry]);
+    return entry;
+  }
+
+  async deleteListEntry(
+    workspaceId: string,
+    input: {
+      inboxId?: string;
+      direction: AgentMailListEntry["direction"];
+      listType: AgentMailListEntry["listType"];
+      entry: string;
+    },
+  ): Promise<{ success: boolean }> {
+    if (input.inboxId) {
+      await this.getClient().deleteInboxListEntry(input.inboxId, input.direction, input.listType, input.entry);
+    } else {
+      await this.getClient().deleteListEntry(input.direction, input.listType, input.entry);
+    }
+    this.deleteListEntryRecord(workspaceId, input.inboxId, input.direction, input.listType, input.entry);
+    return { success: true };
+  }
+
+  async listInboxApiKeys(workspaceId: string, inboxId: string): Promise<AgentMailApiKeySummary[]> {
+    const response = await this.getClient().listInboxApiKeys(inboxId);
+    const keys = (Array.isArray(response.api_keys) ? response.api_keys : [])
+      .map((item) => mapApiKey(item))
+      .filter((item) => item.apiKeyId);
+    this.persistApiKeys(workspaceId, inboxId, keys);
+    return keys;
+  }
+
+  async createInboxApiKey(
+    workspaceId: string,
+    inboxId: string,
+    input: { name?: string; permissions?: Record<string, boolean> },
+  ): Promise<AgentMailApiKeySummary & { apiKey?: string }> {
+    const response = await this.getClient().createInboxApiKey(inboxId, input);
+    const summary = mapApiKey(response);
+    this.persistApiKeys(workspaceId, inboxId, [summary]);
+    return {
+      ...summary,
+      apiKey: asString(asObject(response)?.api_key),
+    };
+  }
+
+  async deleteInboxApiKey(
+    _workspaceId: string,
+    inboxId: string,
+    apiKeyId: string,
+  ): Promise<{ success: boolean }> {
+    await this.getClient().deleteInboxApiKey(inboxId, apiKeyId);
+    this.db.prepare("DELETE FROM agentmail_api_keys WHERE api_key_id = ?").run(apiKeyId);
+    return { success: true };
+  }
+}

--- a/src/electron/agentmail/AgentMailClient.ts
+++ b/src/electron/agentmail/AgentMailClient.ts
@@ -1,0 +1,386 @@
+import { AgentMailSettingsData } from "../../shared/types";
+
+type AgentMailRequestOptions = {
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  query?: Record<string, string | number | boolean | null | undefined>;
+  body?: unknown;
+};
+
+const DEFAULT_TIMEOUT_MS = 20000;
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export class AgentMailClient {
+  readonly baseUrl: string;
+  readonly websocketUrl: string;
+  readonly timeoutMs: number;
+
+  constructor(private readonly settings: AgentMailSettingsData) {
+    this.baseUrl = stripTrailingSlash(settings.baseUrl || "https://api.agentmail.to/v0");
+    this.websocketUrl = settings.websocketUrl || "wss://api.agentmail.to/v0/websocket";
+    this.timeoutMs = settings.timeoutMs || DEFAULT_TIMEOUT_MS;
+  }
+
+  get apiKey(): string | undefined {
+    return this.settings.apiKey;
+  }
+
+  private buildUrl(pathname: string, query?: AgentMailRequestOptions["query"]): string {
+    const url = new URL(`${this.baseUrl}${pathname.startsWith("/") ? pathname : `/${pathname}`}`);
+    for (const [key, value] of Object.entries(query || {})) {
+      if (value === null || value === undefined || value === "") continue;
+      url.searchParams.set(key, String(value));
+    }
+    return url.toString();
+  }
+
+  async request<T>(pathname: string, options: AgentMailRequestOptions = {}): Promise<T> {
+    if (!this.settings.apiKey) {
+      throw new Error("AgentMail API key is not configured");
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(this.buildUrl(pathname, options.query), {
+        method: options.method || "GET",
+        headers: {
+          Authorization: `Bearer ${this.settings.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: options.body === undefined ? undefined : JSON.stringify(options.body),
+        signal: controller.signal,
+      });
+
+      const raw = await response.text();
+      const payload = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+
+      if (!response.ok) {
+        const message =
+          (payload && typeof payload.error === "string" && payload.error) ||
+          (payload && typeof payload.message === "string" && payload.message) ||
+          `${response.status} ${response.statusText}`;
+        throw new Error(`AgentMail request failed: ${message}`);
+      }
+
+      return (payload || {}) as T;
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`AgentMail request timed out after ${this.timeoutMs}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  listPods(limit = 100, pageToken?: string) {
+    return this.request<{ pods?: unknown[]; count?: number; next_page_token?: string }>("/pods", {
+      query: {
+        limit,
+        page_token: pageToken,
+      },
+    });
+  }
+
+  getPod(podId: string) {
+    return this.request<Record<string, unknown>>(`/pods/${encodeURIComponent(podId)}`);
+  }
+
+  createPod(input: { name?: string; clientId?: string }) {
+    return this.request<Record<string, unknown>>("/pods", {
+      method: "POST",
+      body: {
+        name: input.name,
+        client_id: input.clientId,
+      },
+    });
+  }
+
+  deletePod(podId: string) {
+    return this.request<Record<string, unknown>>(`/pods/${encodeURIComponent(podId)}`, {
+      method: "DELETE",
+    });
+  }
+
+  listPodInboxes(podId: string, limit = 100, pageToken?: string) {
+    return this.request<{ inboxes?: unknown[]; count?: number; next_page_token?: string }>(
+      `/pods/${encodeURIComponent(podId)}/inboxes`,
+      {
+        query: {
+          limit,
+          page_token: pageToken,
+        },
+      },
+    );
+  }
+
+  createPodInbox(
+    podId: string,
+    input: { username?: string; domain?: string; displayName?: string; clientId?: string },
+  ) {
+    return this.request<Record<string, unknown>>(`/pods/${encodeURIComponent(podId)}/inboxes`, {
+      method: "POST",
+      body: {
+        username: input.username,
+        domain: input.domain,
+        display_name: input.displayName,
+        client_id: input.clientId,
+      },
+    });
+  }
+
+  updateInbox(inboxId: string, input: { displayName: string }) {
+    return this.request<Record<string, unknown>>(`/inboxes/${encodeURIComponent(inboxId)}`, {
+      method: "PATCH",
+      body: {
+        display_name: input.displayName,
+      },
+    });
+  }
+
+  deleteInbox(inboxId: string) {
+    return this.request<Record<string, unknown>>(`/inboxes/${encodeURIComponent(inboxId)}`, {
+      method: "DELETE",
+    });
+  }
+
+  listPodDomains(podId: string, limit = 100, pageToken?: string) {
+    return this.request<{ domains?: unknown[]; count?: number; next_page_token?: string }>(
+      `/pods/${encodeURIComponent(podId)}/domains`,
+      {
+        query: {
+          limit,
+          page_token: pageToken,
+        },
+      },
+    );
+  }
+
+  createPodDomain(podId: string, input: { domain: string; feedbackEnabled: boolean }) {
+    return this.request<Record<string, unknown>>(`/pods/${encodeURIComponent(podId)}/domains`, {
+      method: "POST",
+      body: {
+        domain: input.domain,
+        feedback_enabled: input.feedbackEnabled,
+      },
+    });
+  }
+
+  verifyPodDomain(podId: string, domainId: string) {
+    return this.request<Record<string, unknown>>(
+      `/pods/${encodeURIComponent(podId)}/domains/${encodeURIComponent(domainId)}/verify`,
+      {
+        method: "POST",
+      },
+    );
+  }
+
+  deletePodDomain(podId: string, domainId: string) {
+    return this.request<Record<string, unknown>>(
+      `/pods/${encodeURIComponent(podId)}/domains/${encodeURIComponent(domainId)}`,
+      {
+        method: "DELETE",
+      },
+    );
+  }
+
+  listPodThreads(
+    podId: string,
+    input: {
+      limit?: number;
+      pageToken?: string;
+      after?: string;
+      includeSpam?: boolean;
+      includeBlocked?: boolean;
+      includeTrash?: boolean;
+    } = {},
+  ) {
+    return this.request<{ threads?: unknown[]; count?: number; next_page_token?: string }>(
+      `/pods/${encodeURIComponent(podId)}/threads`,
+      {
+        query: {
+          limit: input.limit ?? 50,
+          page_token: input.pageToken,
+          after: input.after,
+          include_spam: input.includeSpam,
+          include_blocked: input.includeBlocked,
+          include_trash: input.includeTrash,
+        },
+      },
+    );
+  }
+
+  getPodThread(podId: string, threadId: string) {
+    return this.request<Record<string, unknown>>(
+      `/pods/${encodeURIComponent(podId)}/threads/${encodeURIComponent(threadId)}`,
+    );
+  }
+
+  getAttachment(inboxId: string, messageId: string, attachmentId: string) {
+    return this.request<Record<string, unknown>>(
+      `/inboxes/${encodeURIComponent(inboxId)}/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}`,
+    );
+  }
+
+  updateMessage(
+    inboxId: string,
+    messageId: string,
+    input: { addLabels?: string[]; removeLabels?: string[] },
+  ) {
+    return this.request<Record<string, unknown>>(
+      `/inboxes/${encodeURIComponent(inboxId)}/messages/${encodeURIComponent(messageId)}`,
+      {
+        method: "PATCH",
+        body: {
+          add_labels: input.addLabels,
+          remove_labels: input.removeLabels,
+        },
+      },
+    );
+  }
+
+  replyAllMessage(
+    inboxId: string,
+    messageId: string,
+    input: { text?: string; html?: string; subject?: string; labels?: string[] },
+  ) {
+    return this.request<Record<string, unknown>>(
+      `/inboxes/${encodeURIComponent(inboxId)}/messages/${encodeURIComponent(messageId)}/reply-all`,
+      {
+        method: "POST",
+        body: {
+          text: input.text,
+          html: input.html,
+          subject: input.subject,
+          reply_all: true,
+          labels: input.labels,
+        },
+      },
+    );
+  }
+
+  listLists(
+    direction: "send" | "receive" | "reply",
+    listType: "allow" | "block",
+    limit = 100,
+  ) {
+    return this.request<{ entries?: unknown[]; count?: number }>(
+      `/lists/${direction}/${listType}`,
+      {
+        query: {
+          limit,
+        },
+      },
+    );
+  }
+
+  createListEntry(
+    direction: "send" | "receive" | "reply",
+    listType: "allow" | "block",
+    input: { entry: string; reason?: string },
+  ) {
+    return this.request<Record<string, unknown>>(`/lists/${direction}/${listType}`, {
+      method: "POST",
+      body: {
+        entry: input.entry,
+        reason: input.reason,
+      },
+    });
+  }
+
+  deleteListEntry(
+    direction: "send" | "receive" | "reply",
+    listType: "allow" | "block",
+    entry: string,
+  ) {
+    return this.request<Record<string, unknown>>(`/lists/${direction}/${listType}`, {
+      method: "DELETE",
+      body: {
+        entry,
+      },
+    });
+  }
+
+  listInboxLists(
+    inboxId: string,
+    direction: "send" | "receive" | "reply",
+    listType: "allow" | "block",
+    limit = 100,
+  ) {
+    return this.request<{ entries?: unknown[]; count?: number }>(
+      `/inboxes/${encodeURIComponent(inboxId)}/lists/${direction}/${listType}`,
+      {
+        query: {
+          limit,
+        },
+      },
+    );
+  }
+
+  createInboxListEntry(
+    inboxId: string,
+    direction: "send" | "receive" | "reply",
+    listType: "allow" | "block",
+    input: { entry: string; reason?: string },
+  ) {
+    return this.request<Record<string, unknown>>(
+      `/inboxes/${encodeURIComponent(inboxId)}/lists/${direction}/${listType}`,
+      {
+        method: "POST",
+        body: {
+          entry: input.entry,
+          reason: input.reason,
+        },
+      },
+    );
+  }
+
+  deleteInboxListEntry(
+    inboxId: string,
+    direction: "send" | "receive" | "reply",
+    listType: "allow" | "block",
+    entry: string,
+  ) {
+    return this.request<Record<string, unknown>>(
+      `/inboxes/${encodeURIComponent(inboxId)}/lists/${direction}/${listType}`,
+      {
+        method: "DELETE",
+        body: {
+          entry,
+        },
+      },
+    );
+  }
+
+  listInboxApiKeys(inboxId: string) {
+    return this.request<{ api_keys?: unknown[]; count?: number }>(
+      `/inboxes/${encodeURIComponent(inboxId)}/api-keys`,
+    );
+  }
+
+  createInboxApiKey(
+    inboxId: string,
+    input: { name?: string; permissions?: Record<string, boolean> },
+  ) {
+    return this.request<Record<string, unknown>>(`/inboxes/${encodeURIComponent(inboxId)}/api-keys`, {
+      method: "POST",
+      body: {
+        name: input.name,
+        permissions: input.permissions,
+      },
+    });
+  }
+
+  deleteInboxApiKey(inboxId: string, apiKeyId: string) {
+    return this.request<Record<string, unknown>>(
+      `/inboxes/${encodeURIComponent(inboxId)}/api-keys/${encodeURIComponent(apiKeyId)}`,
+      {
+        method: "DELETE",
+      },
+    );
+  }
+}

--- a/src/electron/agentmail/AgentMailRealtimeService.ts
+++ b/src/electron/agentmail/AgentMailRealtimeService.ts
@@ -1,0 +1,331 @@
+import Database from "better-sqlite3";
+import WebSocket from "ws";
+import { createLogger } from "../utils/logger";
+import { AgentMailStatus } from "../../shared/types";
+import { AgentMailSettingsManager } from "../settings/agentmail-manager";
+import { AgentMailClient } from "./AgentMailClient";
+import type { MailboxService } from "../mailbox/MailboxService";
+
+const logger = createLogger("AgentMailRealtimeService");
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+type RuntimeState = Pick<
+  AgentMailStatus,
+  "realtimeConnected" | "connectionState" | "lastEventAt" | "error"
+>;
+
+export class AgentMailRealtimeService {
+  private socket: WebSocket | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private stopped = false;
+  private subscribedInboxIds = new Set<string>();
+  private runtimeState: RuntimeState = {
+    realtimeConnected: false,
+    connectionState: "disconnected",
+    lastEventAt: undefined,
+    error: undefined,
+  };
+
+  constructor(
+    private readonly db: Database.Database,
+    private readonly mailboxService: MailboxService,
+  ) {}
+
+  getRuntimeStatus(): RuntimeState {
+    const row = this.db
+      .prepare(
+        `SELECT connection_state, last_event_at, last_error
+         FROM agentmail_realtime_state
+         WHERE id = 'global'`,
+      )
+      .get() as
+      | {
+          connection_state: AgentMailStatus["connectionState"];
+          last_event_at: number | null;
+          last_error: string | null;
+        }
+      | undefined;
+
+    if (!row) {
+      return this.runtimeState;
+    }
+
+    return {
+      realtimeConnected: row.connection_state === "connected",
+      connectionState: row.connection_state,
+      lastEventAt: row.last_event_at || undefined,
+      error: row.last_error || undefined,
+    };
+  }
+
+  private persistRuntimeState(next: RuntimeState): void {
+    this.runtimeState = next;
+    this.db
+      .prepare(
+        `INSERT INTO agentmail_realtime_state
+          (id, connection_state, last_event_at, last_error, subscribed_inboxes_json, updated_at)
+         VALUES ('global', ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           connection_state = excluded.connection_state,
+           last_event_at = excluded.last_event_at,
+           last_error = excluded.last_error,
+           subscribed_inboxes_json = excluded.subscribed_inboxes_json,
+           updated_at = excluded.updated_at`,
+      )
+      .run(
+        next.connectionState,
+        next.lastEventAt || null,
+        next.error || null,
+        JSON.stringify(Array.from(this.subscribedInboxIds)),
+        Date.now(),
+      );
+  }
+
+  private loadSubscribedInboxIds(): string[] {
+    const rows = this.db
+      .prepare("SELECT inbox_id FROM agentmail_inboxes ORDER BY inbox_id")
+      .all() as Array<{ inbox_id: string }>;
+    return rows.map((row) => row.inbox_id);
+  }
+
+  start(): void {
+    this.stopped = false;
+    const settings = AgentMailSettingsManager.loadSettings();
+    if (!settings.enabled || !settings.apiKey || !settings.realtimeEnabled) {
+      this.stop();
+      return;
+    }
+    this.connect();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.socket) {
+      try {
+        this.socket.close();
+      } catch {
+        // Best effort only.
+      }
+      this.socket = null;
+    }
+    this.subscribedInboxIds = new Set();
+    this.persistRuntimeState({
+      realtimeConnected: false,
+      connectionState: "disconnected",
+      lastEventAt: this.runtimeState.lastEventAt,
+      error: undefined,
+    });
+  }
+
+  refreshSubscriptions(): void {
+    const settings = AgentMailSettingsManager.loadSettings();
+    if (!settings.enabled || !settings.apiKey || !settings.realtimeEnabled) {
+      this.stop();
+      return;
+    }
+
+    const nextIds = this.loadSubscribedInboxIds();
+    this.subscribedInboxIds = new Set(nextIds);
+
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      this.sendSubscription(nextIds);
+      return;
+    }
+
+    this.start();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.stopped) {
+        this.connect();
+      }
+    }, 5000);
+  }
+
+  private connect(): void {
+    const settings = AgentMailSettingsManager.loadSettings();
+    if (!settings.enabled || !settings.apiKey || !settings.realtimeEnabled) {
+      this.stop();
+      return;
+    }
+
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      return;
+    }
+
+    this.subscribedInboxIds = new Set(this.loadSubscribedInboxIds());
+    this.persistRuntimeState({
+      realtimeConnected: false,
+      connectionState: "connecting",
+      lastEventAt: this.runtimeState.lastEventAt,
+      error: undefined,
+    });
+
+    this.socket = new WebSocket(settings.websocketUrl || "wss://api.agentmail.to/v0/websocket", {
+      headers: {
+        Authorization: `Bearer ${settings.apiKey}`,
+      },
+    });
+
+    this.socket.on("open", () => {
+      this.persistRuntimeState({
+        realtimeConnected: true,
+        connectionState: "connected",
+        lastEventAt: this.runtimeState.lastEventAt,
+        error: undefined,
+      });
+      this.sendSubscription(Array.from(this.subscribedInboxIds));
+    });
+
+    this.socket.on("message", (raw) => {
+      void this.handleMessage(raw.toString("utf8"));
+    });
+
+    this.socket.on("close", () => {
+      this.socket = null;
+      this.persistRuntimeState({
+        realtimeConnected: false,
+        connectionState: this.stopped ? "disconnected" : "error",
+        lastEventAt: this.runtimeState.lastEventAt,
+        error: this.stopped ? undefined : "AgentMail realtime connection closed.",
+      });
+      if (!this.stopped) {
+        this.scheduleReconnect();
+      }
+    });
+
+    this.socket.on("error", (error) => {
+      logger.warn("AgentMail realtime socket error", error);
+      this.persistRuntimeState({
+        realtimeConnected: false,
+        connectionState: "error",
+        lastEventAt: this.runtimeState.lastEventAt,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  private sendSubscription(inboxIds: string[]): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    this.socket.send(
+      JSON.stringify({
+        type: "subscribe",
+        inboxIds,
+        eventTypes: [
+          "message.received",
+          "message.received.spam",
+          "message.received.blocked",
+          "message.sent",
+          "message.delivered",
+          "message.bounced",
+          "message.complained",
+          "message.rejected",
+        ],
+      }),
+    );
+  }
+
+  private async handleMessage(raw: string): Promise<void> {
+    let payload: Record<string, unknown> | null = null;
+    try {
+      payload = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      logger.warn("Ignoring malformed AgentMail realtime payload");
+      return;
+    }
+
+    const type = asString(payload.type) || asString(payload.event_type) || asString(payload.event);
+    if (!type) {
+      return;
+    }
+
+    if (type === "subscribed") {
+      this.persistRuntimeState({
+        realtimeConnected: true,
+        connectionState: "connected",
+        lastEventAt: this.runtimeState.lastEventAt,
+        error: undefined,
+      });
+      return;
+    }
+
+    if (
+      ![
+        "message.received",
+        "message.received.spam",
+        "message.received.blocked",
+        "message.sent",
+        "message.delivered",
+        "message.bounced",
+        "message.complained",
+        "message.rejected",
+        "message_received",
+        "message_received_spam",
+        "message_received_blocked",
+        "message_sent",
+        "message_delivered",
+        "message_bounced",
+        "message_complained",
+        "message_rejected",
+      ].includes(type)
+    ) {
+      return;
+    }
+
+    const event = asObject(payload.data) || payload;
+    const inboxId = asString(event.inbox_id);
+    const threadId = asString(event.thread_id);
+
+    if (!inboxId || !threadId) {
+      return;
+    }
+
+    const inboxRow = this.db
+      .prepare(
+        `SELECT workspace_id, pod_id
+         FROM agentmail_inboxes
+         WHERE inbox_id = ?
+         LIMIT 1`,
+      )
+      .get(inboxId) as { workspace_id: string; pod_id: string } | undefined;
+    if (!inboxRow) {
+      return;
+    }
+
+    try {
+      const client = new AgentMailClient(AgentMailSettingsManager.loadSettings());
+      const thread = await client.getPodThread(inboxRow.pod_id, threadId);
+      await this.mailboxService.ingestAgentMailThread(inboxRow.workspace_id, inboxRow.pod_id, thread);
+      this.persistRuntimeState({
+        realtimeConnected: true,
+        connectionState: "connected",
+        lastEventAt: Date.now(),
+        error: undefined,
+      });
+    } catch (error) {
+      logger.warn("Failed to hydrate AgentMail realtime event", error);
+      this.persistRuntimeState({
+        realtimeConnected: false,
+        connectionState: "error",
+        lastEventAt: this.runtimeState.lastEventAt,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/src/electron/database/SecureSettingsRepository.ts
+++ b/src/electron/database/SecureSettingsRepository.ts
@@ -40,6 +40,7 @@ export type SettingsCategory =
   | "acp"
   | "voice"
   | "memory"
+  | "chronicle"
   | "llm"
   | "search"
   | "appearance"

--- a/src/electron/database/repositories.ts
+++ b/src/electron/database/repositories.ts
@@ -516,16 +516,40 @@ export class TaskRepository {
     return this.findById(id);
   }
 
+  touch(id: string, timestamp = Date.now()): Task | undefined {
+    const before = this.findById(id);
+    const result = this.db
+      .prepare("UPDATE tasks SET updated_at = ? WHERE id = ?")
+      .run(timestamp, id);
+
+    if (result.changes === 0) {
+      return undefined;
+    }
+
+    const after = this.findById(id);
+    UsageInsightsProjector.getIfInitialized()?.enqueueTaskUpdate(before, after);
+    return after;
+  }
+
   findById(id: string): Task | undefined {
     const stmt = this.db.prepare("SELECT * FROM tasks WHERE id = ?");
     const row = stmt.get(id) as Any;
     return row ? this.mapRowToTask(row) : undefined;
   }
 
-  findAll(limit = 100, offset = 0): Task[] {
+  findAll(limit = 100, offset = 0, options?: { prioritizeSidebar?: boolean }): Task[] {
+    const orderBy = options?.prioritizeSidebar
+      ? `
+      ORDER BY
+        CASE WHEN COALESCE(is_pinned, 0) = 1 THEN 0 ELSE 1 END,
+        CASE WHEN status IN ('executing', 'planning', 'interrupted', 'paused', 'blocked') THEN 0 ELSE 1 END,
+        COALESCE(updated_at, created_at) DESC,
+        created_at DESC
+      `
+      : "ORDER BY COALESCE(updated_at, created_at) DESC, created_at DESC";
     const stmt = this.db.prepare(`
       SELECT * FROM tasks
-      ORDER BY created_at DESC
+      ${orderBy}
       LIMIT ? OFFSET ?
     `);
     const rows = stmt.all(limit, offset) as Any[];
@@ -3407,6 +3431,7 @@ export type MemoryType =
   | "decision"
   | "error"
   | "insight"
+  | "screen_context"
   | "summary"
   | "preference"
   | "constraint"
@@ -4055,6 +4080,12 @@ export class MemoryRepository {
   deleteByWorkspace(workspaceId: string): number {
     const stmt = this.db.prepare("DELETE FROM memories WHERE workspace_id = ?");
     const result = stmt.run(workspaceId);
+    return result.changes;
+  }
+
+  deleteByWorkspaceAndId(workspaceId: string, memoryId: string): number {
+    const stmt = this.db.prepare("DELETE FROM memories WHERE workspace_id = ? AND id = ?");
+    const result = stmt.run(workspaceId, memoryId);
     return result.changes;
   }
 

--- a/src/electron/database/schema.ts
+++ b/src/electron/database/schema.ts
@@ -1268,6 +1268,81 @@ export class DatabaseManager {
         last_seen_at INTEGER NOT NULL
       );
 
+      CREATE TABLE IF NOT EXISTS agentmail_workspace_pods (
+        workspace_id TEXT PRIMARY KEY,
+        pod_id TEXT NOT NULL UNIQUE,
+        pod_name TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS agentmail_inboxes (
+        workspace_id TEXT NOT NULL,
+        pod_id TEXT NOT NULL,
+        inbox_id TEXT NOT NULL,
+        email TEXT,
+        display_name TEXT,
+        client_id TEXT,
+        metadata_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (pod_id, inbox_id),
+        FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS agentmail_domains (
+        domain_id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        pod_id TEXT NOT NULL,
+        domain TEXT NOT NULL,
+        status TEXT,
+        feedback_enabled INTEGER NOT NULL DEFAULT 0,
+        records_json TEXT,
+        client_id TEXT,
+        metadata_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS agentmail_lists (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        pod_id TEXT,
+        inbox_id TEXT,
+        direction TEXT NOT NULL,
+        list_type TEXT NOT NULL,
+        entry_value TEXT NOT NULL,
+        entry_type TEXT,
+        reason TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS agentmail_api_keys (
+        api_key_id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        pod_id TEXT,
+        inbox_id TEXT,
+        name TEXT,
+        prefix TEXT NOT NULL,
+        permissions_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS agentmail_realtime_state (
+        id TEXT PRIMARY KEY,
+        connection_state TEXT NOT NULL,
+        last_event_at INTEGER,
+        last_error TEXT,
+        subscribed_inboxes_json TEXT,
+        updated_at INTEGER NOT NULL
+      );
+
       CREATE TABLE IF NOT EXISTS contact_identities (
         id TEXT PRIMARY KEY,
         workspace_id TEXT NOT NULL,
@@ -1434,6 +1509,10 @@ export class DatabaseManager {
       CREATE INDEX IF NOT EXISTS idx_mailbox_contacts_email ON mailbox_contacts(email);
       CREATE INDEX IF NOT EXISTS idx_mailbox_events_workspace ON mailbox_events(workspace_id, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_mailbox_events_thread ON mailbox_events(thread_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_agentmail_inboxes_workspace ON agentmail_inboxes(workspace_id, pod_id);
+      CREATE INDEX IF NOT EXISTS idx_agentmail_domains_workspace ON agentmail_domains(workspace_id, pod_id);
+      CREATE INDEX IF NOT EXISTS idx_agentmail_lists_workspace ON agentmail_lists(workspace_id, inbox_id, direction, list_type);
+      CREATE INDEX IF NOT EXISTS idx_agentmail_api_keys_workspace ON agentmail_api_keys(workspace_id, inbox_id);
       CREATE INDEX IF NOT EXISTS idx_contact_identities_workspace ON contact_identities(workspace_id, updated_at DESC);
       CREATE INDEX IF NOT EXISTS idx_contact_identities_email ON contact_identities(primary_email);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_contact_identity_handles_unique

--- a/src/electron/mailbox/MailboxAutomationRegistry.ts
+++ b/src/electron/mailbox/MailboxAutomationRegistry.ts
@@ -1,11 +1,13 @@
 import type Database from "better-sqlite3";
 import { randomUUID } from "crypto";
 import { getCronService } from "../cron";
+import { computeNextRunAtMs } from "../cron/schedule";
 import type { CronEvent, CronJobCreate, CronJobPatch } from "../cron/types";
 import type { EventTriggerService } from "../triggers/EventTriggerService";
 import type { EventTrigger, TriggerCondition, TriggerEvent, TriggerHistoryEntry } from "../triggers/types";
 import type {
   MailboxAutomationRecord,
+  MailboxForwardRecipe,
   MailboxAutomationStatus,
   MailboxRuleRecipe,
   MailboxScheduleRecipe,
@@ -20,13 +22,16 @@ type MailboxAutomationAuditEvent =
   | "cron_updated"
   | "cron_started"
   | "cron_finished"
-  | "cron_removed";
+  | "cron_removed"
+  | "forward_run_started"
+  | "forward_run_finished";
 
 type MailboxAutomationRegistryDeps = {
   db: Database.Database;
   triggerService?: EventTriggerService | null;
   resolveDefaultWorkspaceId: () => string | undefined;
   log?: (...args: unknown[]) => void;
+  onMutation?: () => void;
 };
 
 type MailboxAutomationRow = {
@@ -84,6 +89,19 @@ function ruleTriggerName(recipe: MailboxRuleRecipe): string {
 
 function scheduleJobName(recipe: MailboxScheduleRecipe): string {
   return recipe.name.trim();
+}
+
+function forwardingJobName(recipe: MailboxForwardRecipe): string {
+  return recipe.name.trim();
+}
+
+function normalizeStringArray(values: unknown, lowercase = true): string[] {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map((value) => normalizeString(value))
+    .filter((value): value is string => Boolean(value))
+    .map((value) => (lowercase ? value.toLowerCase() : value))
+    .filter((value, index, array) => array.indexOf(value) === index);
 }
 
 export class MailboxAutomationRegistry {
@@ -294,6 +312,7 @@ export class MailboxAutomationRegistry {
         automationId,
       );
     this.appendAudit(automationId, record.workspaceId, "updated", { patch });
+    deps.onMutation?.();
     return this.listAutomations({ workspaceId: record.workspaceId }).find((item) => item.id === automationId) ?? null;
   }
 
@@ -306,6 +325,165 @@ export class MailboxAutomationRegistry {
       deps.triggerService.removeTrigger(record.backingTriggerId);
     }
     this.markDeleted(record.id, record.workspaceId, { backingTriggerId: record.backingTriggerId });
+    return true;
+  }
+
+  static createForward(recipe: MailboxForwardRecipe): MailboxAutomationRecord {
+    const deps = this.getDeps();
+    const workspaceId = recipe.workspaceId?.trim() || deps.resolveDefaultWorkspaceId();
+    if (!workspaceId) {
+      throw new Error("No default workspace available for mailbox automation");
+    }
+    if (!normalizeString(recipe.targetEmail)) {
+      throw new Error("Target email is required for forwarding automation");
+    }
+    const allowedSenders = normalizeStringArray(recipe.allowedSenders);
+    const allowedDomains = normalizeStringArray(recipe.allowedDomains);
+    if (allowedSenders.length === 0 && allowedDomains.length === 0) {
+      throw new Error("At least one allowed sender or domain is required");
+    }
+
+    const automationId = randomUUID();
+    const now = Date.now();
+    const normalizedRecipe: MailboxForwardRecipe = {
+      ...recipe,
+      workspaceId,
+      name: forwardingJobName(recipe),
+      targetEmail: recipe.targetEmail.trim(),
+      providerThreadId: normalizeString(recipe.providerThreadId),
+      allowedSenders,
+      allowedDomains,
+      excludedSenders: normalizeStringArray(recipe.excludedSenders),
+      excludedDomains: normalizeStringArray(recipe.excludedDomains),
+      subjectKeywords: normalizeStringArray(recipe.subjectKeywords),
+      attachmentKeywords: normalizeStringArray(recipe.attachmentKeywords),
+      attachmentExtensions: normalizeStringArray(recipe.attachmentExtensions),
+      dryRun: recipe.dryRun ?? true,
+      maxMessagesPerRun: Math.max(1, Math.min(500, Number(recipe.maxMessagesPerRun || 100))),
+      backfillDays: Math.max(1, Math.min(3650, Number(recipe.backfillDays || 30))),
+      lookbackMinutes: Math.max(1, Math.min(7 * 24 * 60, Number(recipe.lookbackMinutes || 20))),
+      forwardedLabelName: normalizeString(recipe.forwardedLabelName) || "cowork/forwarded",
+      rejectedLabelName: normalizeString(recipe.rejectedLabelName) || "cowork/rejected",
+      candidateLabelName: normalizeString(recipe.candidateLabelName) || "cowork/candidate",
+      gmailQuery: normalizeString(recipe.gmailQuery),
+      enabled: recipe.enabled ?? true,
+    };
+
+    const record: MailboxAutomationRecord = {
+      id: automationId,
+      workspaceId,
+      kind: "forward",
+      status: normalizedRecipe.enabled === false ? "paused" : "active",
+      name: normalizedRecipe.name,
+      description: normalizedRecipe.description,
+      threadId: normalizedRecipe.threadId,
+      source: "cron",
+      forward: normalizedRecipe,
+      nextRunAt: normalizedRecipe.enabled === false ? undefined : computeNextRunAtMs(normalizedRecipe.schedule, now),
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.insertRecord(record, {
+      automationId,
+      workspaceId,
+      eventType: "created",
+      detail: { kind: "forward" },
+    });
+    const created = this.fetchRow(automationId);
+    if (!created) {
+      throw new Error("Failed to persist forwarding automation");
+    }
+    return this.enrichRecord(created);
+  }
+
+  static updateForward(
+    automationId: string,
+    patch: Partial<MailboxForwardRecipe> & { status?: MailboxAutomationStatus },
+  ): MailboxAutomationRecord | null {
+    const deps = this.getDeps();
+    const row = this.fetchRow(automationId);
+    if (!row || row.kind !== "forward") return null;
+
+    const record = this.enrichRecord(row);
+    const nextForward: MailboxForwardRecipe = {
+      ...(record.forward || {
+        name: record.name,
+        schedule: { kind: "every", everyMs: 15 * 60 * 1000 },
+        targetEmail: "",
+        allowedSenders: [],
+        allowedDomains: [],
+      }),
+      ...patch,
+      workspaceId: record.workspaceId,
+      allowedSenders: normalizeStringArray(patch.allowedSenders ?? record.forward?.allowedSenders ?? []),
+      allowedDomains: normalizeStringArray(patch.allowedDomains ?? record.forward?.allowedDomains ?? []),
+      excludedSenders: normalizeStringArray(patch.excludedSenders ?? record.forward?.excludedSenders ?? []),
+      excludedDomains: normalizeStringArray(patch.excludedDomains ?? record.forward?.excludedDomains ?? []),
+      subjectKeywords: normalizeStringArray(patch.subjectKeywords ?? record.forward?.subjectKeywords ?? []),
+      attachmentKeywords: normalizeStringArray(patch.attachmentKeywords ?? record.forward?.attachmentKeywords ?? []),
+      attachmentExtensions: normalizeStringArray(patch.attachmentExtensions ?? record.forward?.attachmentExtensions ?? []),
+      targetEmail: normalizeString(patch.targetEmail ?? record.forward?.targetEmail) || "",
+      providerThreadId: normalizeString(patch.providerThreadId ?? record.forward?.providerThreadId),
+      forwardedLabelName:
+        normalizeString(patch.forwardedLabelName ?? record.forward?.forwardedLabelName) || "cowork/forwarded",
+      rejectedLabelName:
+        normalizeString(patch.rejectedLabelName ?? record.forward?.rejectedLabelName) || "cowork/rejected",
+      candidateLabelName:
+        normalizeString(patch.candidateLabelName ?? record.forward?.candidateLabelName) || "cowork/candidate",
+      gmailQuery: normalizeString(patch.gmailQuery ?? record.forward?.gmailQuery),
+      maxMessagesPerRun: Math.max(
+        1,
+        Math.min(500, Number(patch.maxMessagesPerRun ?? record.forward?.maxMessagesPerRun ?? 100)),
+      ),
+      backfillDays: Math.max(1, Math.min(3650, Number(patch.backfillDays ?? record.forward?.backfillDays ?? 30))),
+      lookbackMinutes: Math.max(
+        1,
+        Math.min(7 * 24 * 60, Number(patch.lookbackMinutes ?? record.forward?.lookbackMinutes ?? 20)),
+      ),
+      dryRun: patch.dryRun ?? record.forward?.dryRun ?? true,
+      enabled: patch.enabled ?? record.forward?.enabled ?? true,
+      name: normalizeString(patch.name ?? record.name) || record.name,
+    };
+
+    if (!nextForward.targetEmail) {
+      throw new Error("Target email is required for forwarding automation");
+    }
+    if (nextForward.allowedSenders.length === 0 && nextForward.allowedDomains.length === 0) {
+      throw new Error("At least one allowed sender or domain is required");
+    }
+
+    const nextStatus =
+      patch.status ??
+      (nextForward.enabled === false ? "paused" : record.status === "deleted" ? "deleted" : "active");
+    const nextRunAt =
+      nextStatus === "active" ? computeNextRunAtMs(nextForward.schedule, Date.now()) : null;
+    const now = Date.now();
+    deps.db
+      .prepare(
+        `UPDATE mailbox_automations
+         SET name = ?, description = ?, status = ?, thread_id = ?, recipe_json = ?, next_run_at = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(
+        nextForward.name,
+        nextForward.description || null,
+        nextStatus,
+        nextForward.threadId || null,
+        stringifyJson(nextForward),
+        nextRunAt ?? null,
+        now,
+        automationId,
+      );
+    this.appendAudit(automationId, record.workspaceId, "updated", { patch });
+    deps.onMutation?.();
+    return this.listAutomations({ workspaceId: record.workspaceId }).find((item) => item.id === automationId) ?? null;
+  }
+
+  static deleteForward(automationId: string): boolean {
+    const row = this.fetchRow(automationId);
+    if (!row || row.kind !== "forward") return false;
+    this.markDeleted(row.id, row.workspace_id, {});
     return true;
   }
 
@@ -412,6 +590,7 @@ export class MailboxAutomationRegistry {
         automationId,
       );
     this.appendAudit(automationId, record.workspaceId, "updated", { patch });
+    deps.onMutation?.();
     return this.listAutomations({ workspaceId: record.workspaceId }).find((item) => item.id === automationId) ?? null;
   }
 
@@ -596,7 +775,7 @@ export class MailboxAutomationRegistry {
   }
 
   private static enrichRecord(row: MailboxAutomationRow): MailboxAutomationRecord {
-    const recipe = parseJson<MailboxRuleRecipe | MailboxScheduleRecipe | Record<string, unknown>>(
+    const recipe = parseJson<MailboxRuleRecipe | MailboxScheduleRecipe | MailboxForwardRecipe | Record<string, unknown>>(
       row.recipe_json,
       {},
     );
@@ -623,6 +802,10 @@ export class MailboxAutomationRegistry {
       schedule:
         row.kind === "schedule" || row.kind === "reminder"
           ? (recipe as MailboxScheduleRecipe)
+          : undefined,
+      forward:
+        row.kind === "forward"
+          ? (recipe as MailboxForwardRecipe)
           : undefined,
       backingTriggerId: row.backing_trigger_id || undefined,
       backingCronJobId: row.backing_cron_job_id || undefined,
@@ -656,7 +839,13 @@ export class MailboxAutomationRegistry {
         record.description || null,
         record.threadId || null,
         record.source,
-        stringifyJson(record.kind === "rule" ? record.rule || {} : record.schedule || {}),
+        stringifyJson(
+          record.kind === "rule"
+            ? record.rule || {}
+            : record.kind === "forward"
+              ? record.forward || {}
+              : record.schedule || {},
+        ),
         record.backingTriggerId || null,
         record.backingCronJobId || null,
         record.latestOutcome || null,
@@ -668,6 +857,7 @@ export class MailboxAutomationRegistry {
         record.updatedAt,
       );
     this.appendAudit(audit.automationId, audit.workspaceId, audit.eventType, audit.detail);
+    deps.onMutation?.();
   }
 
   private static insertScheduleRecord(input: {
@@ -737,5 +927,70 @@ export class MailboxAutomationRegistry {
       )
       .run(Date.now(), automationId);
     this.appendAudit(automationId, workspaceId, "deleted", detail);
+    deps.onMutation?.();
+  }
+
+  static markForwardRunStarted(automationId: string, runAtMs: number): void {
+    const deps = this.getDeps();
+    deps.db
+      .prepare(
+        `UPDATE mailbox_automations
+         SET latest_run_at = ?, latest_error = NULL, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(runAtMs, Date.now(), automationId);
+    const row = this.fetchRow(automationId);
+    if (row) {
+      this.appendAudit(automationId, row.workspace_id, "forward_run_started", { runAtMs });
+    }
+  }
+
+  static markForwardRunFinished(
+    automationId: string,
+    input: {
+      status: MailboxAutomationStatus;
+      latestOutcome?: string;
+      latestError?: string | null;
+      latestFireAt?: number;
+      nextRunAt?: number | null;
+    },
+  ): void {
+    const deps = this.getDeps();
+    deps.db
+      .prepare(
+        `UPDATE mailbox_automations
+         SET status = ?, latest_outcome = ?, latest_error = ?, latest_fire_at = ?, next_run_at = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(
+        input.status,
+        input.latestOutcome || null,
+        input.latestError || null,
+        input.latestFireAt || null,
+        input.nextRunAt ?? null,
+        Date.now(),
+        automationId,
+      );
+    const row = this.fetchRow(automationId);
+    if (row) {
+      this.appendAudit(automationId, row.workspace_id, "forward_run_finished", {
+        status: input.status,
+        latestOutcome: input.latestOutcome,
+        latestError: input.latestError,
+        latestFireAt: input.latestFireAt,
+        nextRunAt: input.nextRunAt,
+      });
+    }
+  }
+
+  static setForwardNextRun(automationId: string, nextRunAt?: number): void {
+    const deps = this.getDeps();
+    deps.db
+      .prepare(
+        `UPDATE mailbox_automations
+         SET next_run_at = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(nextRunAt ?? null, Date.now(), automationId);
   }
 }

--- a/src/electron/mailbox/MailboxForwardingService.ts
+++ b/src/electron/mailbox/MailboxForwardingService.ts
@@ -1,0 +1,870 @@
+import type Database from "better-sqlite3";
+import { randomUUID } from "crypto";
+import { computeNextRunAtMs } from "../cron/schedule";
+import { MailboxAutomationRegistry } from "./MailboxAutomationRegistry";
+import { GoogleWorkspaceSettingsManager } from "../settings/google-workspace-manager";
+import { gmailRequest } from "../utils/gmail-api";
+import { createLogger } from "../utils/logger";
+import { GOOGLE_SCOPE_GMAIL_MODIFY, hasScope } from "../../shared/google-workspace";
+import type { GmailRequestResult } from "../utils/gmail-api";
+import type { MailboxAutomationRecord, MailboxForwardRecipe } from "../../shared/mailbox";
+
+const logger = createLogger("MailboxForwardingService");
+const MAX_GMAIL_LIST_RESULTS = 500;
+const MAX_MESSAGE_BODY_CHARS = 120_000;
+const TIMER_FALLBACK_MS = 60_000;
+const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
+const SEARCH_WATERMARK_OVERLAP_MS = 5 * MINUTE_MS;
+
+type MailboxForwardingServiceDeps = {
+  db: Database.Database;
+  log?: (...args: unknown[]) => void;
+};
+
+type ForwardingAttachment = {
+  filename: string;
+  mimeType: string;
+  attachmentId?: string;
+  inlineData?: string;
+};
+
+type ForwardingMessage = {
+  id: string;
+  threadId: string;
+  subject: string;
+  fromRaw?: string;
+  fromEmail?: string;
+  internalDate: number;
+  textBody: string;
+  htmlBody?: string;
+  attachments: ForwardingAttachment[];
+  labelIds: string[];
+};
+
+type MessageForwardOutcome =
+  | { status: "sent" | "already_sent" | "dry_run"; messageId: string }
+  | { status: "failed"; messageId: string; error: string };
+
+type ThreadEvaluation = {
+  threadId: string;
+  targets: ForwardingMessage[];
+};
+
+type RunSummary = {
+  matchedThreads: number;
+  matchedMessages: number;
+  sentMessages: number;
+  alreadySentMessages: number;
+  rejectedThreads: number;
+  failedMessages: number;
+  dryRun: boolean;
+  summary: string;
+};
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function normalizeEmail(value: unknown): string | undefined {
+  const raw = normalizeString(value);
+  if (!raw) return undefined;
+  const match = raw.match(/<([^>]+)>/);
+  return (match?.[1] || raw).trim().toLowerCase();
+}
+
+function normalizeDomain(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const atIndex = value.lastIndexOf("@");
+  return atIndex === -1 ? undefined : value.slice(atIndex + 1).trim().toLowerCase() || undefined;
+}
+
+function formatGmailAfterDate(timestampMs: number): string {
+  const date = new Date(timestampMs);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}/${month}/${day}`;
+}
+
+function base64UrlDecode(data: string): string {
+  const normalized = data.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4 === 0 ? 0 : 4 - (normalized.length % 4);
+  return Buffer.from(normalized + "=".repeat(padding), "base64").toString("utf8");
+}
+
+function encodeBase64Lines(data: Uint8Array): string {
+  return Buffer.from(data)
+    .toString("base64")
+    .replace(/(.{76})/g, "$1\r\n");
+}
+
+function encodeMessage(raw: string): string {
+  return Buffer.from(raw)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function escapeHeader(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+function extractPlainText(payload: Any): string {
+  const mimeType = normalizeString(payload?.mimeType) || "";
+  if (payload?.body?.data && mimeType === "text/plain") {
+    return base64UrlDecode(payload.body.data).slice(0, MAX_MESSAGE_BODY_CHARS);
+  }
+
+  const parts = Array.isArray(payload?.parts) ? payload.parts : [];
+  for (const part of parts) {
+    const text = extractPlainText(part);
+    if (text) return text;
+  }
+
+  if (payload?.body?.data && mimeType === "text/html") {
+    return base64UrlDecode(payload.body.data)
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, MAX_MESSAGE_BODY_CHARS);
+  }
+
+  return "";
+}
+
+function extractHtml(payload: Any): string | undefined {
+  const mimeType = normalizeString(payload?.mimeType) || "";
+  if (payload?.body?.data && mimeType === "text/html") {
+    return base64UrlDecode(payload.body.data);
+  }
+
+  const parts = Array.isArray(payload?.parts) ? payload.parts : [];
+  for (const part of parts) {
+    const html = extractHtml(part);
+    if (html) return html;
+  }
+
+  return undefined;
+}
+
+function collectAttachments(payload: Any): ForwardingAttachment[] {
+  const parts = Array.isArray(payload?.parts) ? payload.parts : [];
+  const attachments: ForwardingAttachment[] = [];
+
+  for (const part of parts) {
+    const filename = normalizeString(part?.filename);
+    const body = part?.body;
+    if (filename && (normalizeString(body?.attachmentId) || normalizeString(body?.data))) {
+      attachments.push({
+        filename,
+        mimeType: normalizeString(part?.mimeType) || "application/octet-stream",
+        attachmentId: normalizeString(body?.attachmentId),
+        inlineData: normalizeString(body?.data),
+      });
+    }
+    attachments.push(...collectAttachments(part));
+  }
+
+  return attachments;
+}
+
+function extractHeaders(headers: Any[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const header of headers) {
+    const name = normalizeString(header?.name)?.toLowerCase();
+    const value = normalizeString(header?.value);
+    if (!name || !value) continue;
+    if (!(name in result)) {
+      result[name] = value;
+    }
+  }
+  return result;
+}
+
+function matchesAnyKeyword(text: string, keywords: string[] | undefined): boolean {
+  if (!keywords?.length) return false;
+  const lower = text.toLowerCase();
+  return keywords.some((keyword) => lower.includes(keyword.toLowerCase()));
+}
+
+function matchesAttachmentKeywords(
+  attachments: ForwardingAttachment[],
+  keywords: string[] | undefined,
+): boolean {
+  if (!keywords?.length) return false;
+  return attachments.some((attachment) => matchesAnyKeyword(attachment.filename, keywords));
+}
+
+function attachmentMatchesExtensions(
+  attachment: ForwardingAttachment,
+  allowedExtensions: string[] | undefined,
+): boolean {
+  if (!allowedExtensions?.length) return true;
+  const lower = attachment.filename.toLowerCase();
+  return allowedExtensions.some((ext) => lower.endsWith(`.${ext.toLowerCase()}`));
+}
+
+function attachmentListMatches(
+  attachments: ForwardingAttachment[],
+  recipe: MailboxForwardRecipe,
+): ForwardingAttachment[] {
+  return attachments.filter((attachment) => {
+    if (!attachmentMatchesExtensions(attachment, recipe.attachmentExtensions)) {
+      return false;
+    }
+    if (recipe.attachmentKeywords?.length) {
+      return matchesAnyKeyword(attachment.filename, recipe.attachmentKeywords);
+    }
+    return true;
+  });
+}
+
+function buildForwardedMime(params: {
+  to: string;
+  subject: string;
+  body: string;
+  originalFrom?: string;
+  originalSubject?: string;
+  originalDate?: number;
+  originalMessageId: string;
+  attachments: Array<{ filename: string; mimeType: string; data: Uint8Array }>;
+}): string {
+  const boundary = `cowork-forward-${randomUUID()}`;
+  const headers = [
+    `To: ${escapeHeader(params.to)}`,
+    `Subject: ${escapeHeader(params.subject)}`,
+    "MIME-Version: 1.0",
+    `X-CoWork-Original-Message-Id: ${escapeHeader(params.originalMessageId)}`,
+    `Content-Type: multipart/mixed; boundary="${boundary}"`,
+    "",
+    `--${boundary}`,
+    'Content-Type: text/plain; charset="UTF-8"',
+    "Content-Transfer-Encoding: 7bit",
+    "",
+    [
+      "Forwarded by CoWork OS",
+      params.originalFrom ? `From: ${params.originalFrom}` : null,
+      params.originalSubject ? `Original subject: ${params.originalSubject}` : null,
+      params.originalDate ? `Original date: ${new Date(params.originalDate).toUTCString()}` : null,
+      "",
+      params.body,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join("\r\n"),
+  ];
+
+  const parts = [...headers];
+  for (const attachment of params.attachments) {
+    parts.push(
+      `--${boundary}`,
+      `Content-Type: ${attachment.mimeType}; name="${escapeHeader(attachment.filename)}"`,
+      `Content-Disposition: attachment; filename="${escapeHeader(attachment.filename)}"`,
+      "Content-Transfer-Encoding: base64",
+      "",
+      encodeBase64Lines(attachment.data),
+    );
+  }
+  parts.push(`--${boundary}--`, "");
+  return parts.join("\r\n");
+}
+
+export class MailboxForwardingService {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private started = false;
+  private runningAutomationIds = new Set<string>();
+
+  constructor(private deps: MailboxForwardingServiceDeps) {
+    this.ensureSchema();
+  }
+
+  start(): void {
+    this.started = true;
+    void this.refresh();
+  }
+
+  stop(): void {
+    this.started = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.started) return;
+    this.armTimer();
+  }
+
+  async runNow(automationId: string): Promise<string> {
+    const automation = MailboxAutomationRegistry.listAutomations().find(
+      (item) => item.id === automationId && item.kind === "forward",
+    );
+    if (!automation?.forward) {
+      throw new Error("Forwarding automation not found");
+    }
+    const summary = await this.runAutomation(automation, true);
+    await this.refresh();
+    return summary.summary;
+  }
+
+  private ensureSchema(): void {
+    this.deps.db.exec(`
+      CREATE TABLE IF NOT EXISTS mailbox_forwarding_message_runs (
+        automation_id TEXT NOT NULL,
+        message_id TEXT NOT NULL,
+        thread_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        error TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (automation_id, message_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_mailbox_forwarding_message_runs_thread
+        ON mailbox_forwarding_message_runs(thread_id, updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS mailbox_forwarding_run_state (
+        automation_id TEXT PRIMARY KEY,
+        last_successful_scan_at INTEGER,
+        updated_at INTEGER NOT NULL
+      );
+    `);
+  }
+
+  private armTimer(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (!this.started) return;
+
+    const now = Date.now();
+    const automations = MailboxAutomationRegistry.listAutomations().filter(
+      (item) => item.kind === "forward" && item.status === "active" && item.forward,
+    );
+
+    let earliest: number | undefined;
+    for (const automation of automations) {
+      const nextRunAt =
+        automation.nextRunAt ??
+        computeNextRunAtMs(automation.forward!.schedule, now);
+      if (nextRunAt !== automation.nextRunAt) {
+        MailboxAutomationRegistry.setForwardNextRun(automation.id, nextRunAt);
+      }
+      if (nextRunAt !== undefined && (earliest === undefined || nextRunAt < earliest)) {
+        earliest = nextRunAt;
+      }
+    }
+
+    const delayMs =
+      earliest === undefined
+        ? TIMER_FALLBACK_MS
+        : Math.max(0, Math.min(TIMER_FALLBACK_MS, earliest - now));
+    this.timer = setTimeout(() => {
+      void this.processDueAutomations();
+    }, delayMs);
+  }
+
+  private async processDueAutomations(): Promise<void> {
+    if (!this.started) return;
+    const now = Date.now();
+    const automations = MailboxAutomationRegistry.listAutomations().filter(
+      (item) =>
+        item.kind === "forward" &&
+        item.status === "active" &&
+        item.forward &&
+        typeof item.nextRunAt === "number" &&
+        item.nextRunAt <= now,
+    );
+
+    for (const automation of automations) {
+      try {
+        await this.runAutomation(automation, false);
+      } catch (error) {
+        logger.error("Forwarding automation failed", {
+          automationId: automation.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    await this.refresh();
+  }
+
+  private async runAutomation(
+    automation: MailboxAutomationRecord,
+    manual: boolean,
+  ): Promise<RunSummary> {
+    if (!automation.forward) {
+      throw new Error("Forwarding automation is missing recipe data");
+    }
+    if (this.runningAutomationIds.has(automation.id)) {
+      throw new Error("Forwarding automation is already running");
+    }
+
+    this.runningAutomationIds.add(automation.id);
+    const runAtMs = Date.now();
+    MailboxAutomationRegistry.markForwardRunStarted(automation.id, runAtMs);
+
+    try {
+      const summary = await this.executeForwardingRun(automation);
+      const shouldRemainActive = automation.status === "active";
+      const nextRunAt = shouldRemainActive
+        ? computeNextRunAtMs(automation.forward.schedule, Date.now())
+        : automation.nextRunAt;
+      const nextStatus = shouldRemainActive
+        ? nextRunAt === undefined && automation.forward.schedule.kind === "at"
+          ? "paused"
+          : "active"
+        : automation.status;
+      MailboxAutomationRegistry.markForwardRunFinished(automation.id, {
+        status: nextStatus,
+        latestOutcome: summary.summary,
+        latestFireAt: runAtMs,
+        nextRunAt,
+      });
+      return summary;
+    } catch (error) {
+      const shouldRemainActive = automation.status === "active";
+      const nextRunAt = shouldRemainActive
+        ? computeNextRunAtMs(automation.forward.schedule, Date.now())
+        : automation.nextRunAt;
+      MailboxAutomationRegistry.markForwardRunFinished(automation.id, {
+        status: shouldRemainActive ? (nextRunAt === undefined ? "paused" : "error") : automation.status,
+        latestOutcome: "Forwarding run failed",
+        latestError: error instanceof Error ? error.message : String(error),
+        latestFireAt: runAtMs,
+        nextRunAt,
+      });
+      throw error;
+    } finally {
+      this.runningAutomationIds.delete(automation.id);
+    }
+  }
+
+  private async executeForwardingRun(automation: MailboxAutomationRecord): Promise<RunSummary> {
+    if (!automation.forward) {
+      throw new Error("Forwarding automation is missing recipe data");
+    }
+    const automationId = automation.id;
+    const recipe = automation.forward;
+    const settings = GoogleWorkspaceSettingsManager.loadSettings();
+    if (!settings.enabled) {
+      throw new Error("Google Workspace integration is disabled");
+    }
+    if (settings.scopes && !hasScope(settings.scopes, GOOGLE_SCOPE_GMAIL_MODIFY)) {
+      throw new Error(
+        "Google Workspace Gmail modify scope is required. Reconnect in Settings > Integrations > Google Workspace.",
+      );
+    }
+
+    const labelMap = await this.getOrCreateLabels(settings, recipe);
+    const lastSuccessfulScanAt = this.getLastSuccessfulScanAt(automationId);
+    const earliestTimestamp = this.computeEarliestTimestamp(automation, lastSuccessfulScanAt);
+    const threadIds = await this.listCandidateThreadIds(settings, recipe, earliestTimestamp);
+
+    let matchedThreads = 0;
+    let matchedMessages = 0;
+    let sentMessages = 0;
+    let alreadySentMessages = 0;
+    let rejectedThreads = 0;
+    let failedMessages = 0;
+
+    for (const threadId of threadIds) {
+      const threadResult = await gmailRequest(settings, {
+        method: "GET",
+        path: `/users/me/threads/${encodeURIComponent(threadId)}`,
+        query: { format: "full" },
+      });
+      const evaluation = this.evaluateThread(threadResult, recipe, earliestTimestamp);
+      if (!evaluation) {
+        continue;
+      }
+
+      const targetOutcomes: MessageForwardOutcome[] = [];
+      if (evaluation.targets.length === 0) {
+        await this.applyThreadLabels(settings, threadId, {
+          add: [labelMap.rejected],
+          remove: [labelMap.candidate, labelMap.forwarded],
+        });
+        rejectedThreads += 1;
+        continue;
+      }
+
+      matchedThreads += 1;
+      matchedMessages += evaluation.targets.length;
+
+      for (const message of evaluation.targets) {
+        const outcome = await this.forwardMessage(settings, automationId, recipe, message);
+        targetOutcomes.push(outcome);
+        if (outcome.status === "sent") {
+          sentMessages += 1;
+        } else if (outcome.status === "already_sent") {
+          alreadySentMessages += 1;
+        } else if (outcome.status === "failed") {
+        failedMessages += 1;
+        }
+      }
+
+      const hasFailures = targetOutcomes.some((outcome) => outcome.status === "failed");
+      if (recipe.dryRun) {
+        await this.applyThreadLabels(settings, threadId, {
+          add: [labelMap.candidate],
+          remove: [labelMap.rejected, labelMap.forwarded],
+        });
+      } else if (hasFailures) {
+        await this.applyThreadLabels(settings, threadId, {
+          add: [labelMap.candidate],
+          remove: [labelMap.rejected, labelMap.forwarded],
+        });
+      } else {
+        await this.applyThreadLabels(settings, threadId, {
+          add: [labelMap.forwarded],
+          remove: [labelMap.candidate, labelMap.rejected],
+        });
+      }
+    }
+
+    if (!recipe.dryRun && failedMessages === 0) {
+      this.setLastSuccessfulScanAt(automationId, Date.now());
+    }
+
+    const summary = recipe.dryRun
+      ? `Dry run matched ${matchedMessages} message${matchedMessages === 1 ? "" : "s"} across ${matchedThreads} thread${matchedThreads === 1 ? "" : "s"}`
+      : `Forwarded ${sentMessages + alreadySentMessages} message${sentMessages + alreadySentMessages === 1 ? "" : "s"} across ${matchedThreads} thread${matchedThreads === 1 ? "" : "s"}`;
+    return {
+      matchedThreads,
+      matchedMessages,
+      sentMessages,
+      alreadySentMessages,
+      rejectedThreads,
+      failedMessages,
+      dryRun: Boolean(recipe.dryRun),
+      summary:
+        failedMessages > 0
+          ? `${summary} with ${failedMessages} failure${failedMessages === 1 ? "" : "s"}`
+          : summary,
+    };
+  }
+
+  private computeEarliestTimestamp(
+    automation: MailboxAutomationRecord,
+    lastSuccessfulScanAt?: number,
+  ): number {
+    const recipe = automation.forward!;
+    const now = Date.now();
+    const backfillStart = now - recipe.backfillDays! * DAY_MS;
+    if (recipe.schedule.kind === "at") {
+      return backfillStart;
+    }
+
+    if (typeof lastSuccessfulScanAt === "number" && Number.isFinite(lastSuccessfulScanAt)) {
+      return Math.max(backfillStart, lastSuccessfulScanAt - SEARCH_WATERMARK_OVERLAP_MS);
+    }
+
+    return backfillStart;
+  }
+
+  private async listCandidateThreadIds(
+    settings: Any,
+    recipe: MailboxForwardRecipe,
+    earliestTimestamp: number,
+  ): Promise<string[]> {
+    if (recipe.providerThreadId) {
+      return [recipe.providerThreadId];
+    }
+
+    const queryParts = [
+      recipe.gmailQuery,
+      "-in:sent",
+      "-in:drafts",
+      "has:attachment",
+      `after:${formatGmailAfterDate(earliestTimestamp)}`,
+    ].filter((value): value is string => Boolean(value));
+
+    const result = await gmailRequest(settings, {
+      method: "GET",
+      path: "/users/me/messages",
+      query: {
+        q: queryParts.join(" "),
+        maxResults: Math.min(MAX_GMAIL_LIST_RESULTS, Math.max(25, recipe.maxMessagesPerRun! * 3)),
+      },
+    });
+
+    const refs = Array.isArray(result.data?.messages) ? result.data.messages : [];
+    const threadIds: string[] = [];
+    const seen = new Set<string>();
+    for (const ref of refs) {
+      const threadId = normalizeString((ref as Any)?.threadId);
+      if (!threadId || seen.has(threadId)) continue;
+      seen.add(threadId);
+      threadIds.push(threadId);
+      if (threadIds.length >= recipe.maxMessagesPerRun!) {
+        break;
+      }
+    }
+    return threadIds;
+  }
+
+  private getLastSuccessfulScanAt(automationId: string): number | undefined {
+    const row = this.deps.db
+      .prepare(
+        `SELECT last_successful_scan_at
+         FROM mailbox_forwarding_run_state
+         WHERE automation_id = ?`,
+      )
+      .get(automationId) as { last_successful_scan_at: number | null } | undefined;
+    const timestamp = row?.last_successful_scan_at;
+    return typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : undefined;
+  }
+
+  private setLastSuccessfulScanAt(automationId: string, timestamp: number): void {
+    this.deps.db
+      .prepare(
+        `INSERT INTO mailbox_forwarding_run_state
+           (automation_id, last_successful_scan_at, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(automation_id) DO UPDATE SET
+           last_successful_scan_at = excluded.last_successful_scan_at,
+           updated_at = excluded.updated_at`,
+      )
+      .run(automationId, timestamp, Date.now());
+  }
+
+  private evaluateThread(
+    threadResult: GmailRequestResult,
+    recipe: MailboxForwardRecipe,
+    earliestTimestamp: number,
+  ): ThreadEvaluation | null {
+    const data = threadResult.data;
+    const threadId = normalizeString(data?.id);
+    const messages = Array.isArray(data?.messages) ? data.messages : [];
+    if (!threadId || messages.length === 0) {
+      return null;
+    }
+
+    const targets: ForwardingMessage[] = [];
+    for (const rawMessage of messages) {
+      const message = this.normalizeForwardingMessage(rawMessage);
+      if (!message) continue;
+      if (message.internalDate < earliestTimestamp) continue;
+      const senderEmail = message.fromEmail;
+      const senderDomain = normalizeDomain(senderEmail);
+      const allowed =
+        (senderEmail && recipe.allowedSenders.includes(senderEmail)) ||
+        (senderDomain && recipe.allowedDomains.includes(senderDomain));
+      if (!allowed) continue;
+      if (senderEmail && recipe.excludedSenders?.includes(senderEmail)) continue;
+      if (senderDomain && recipe.excludedDomains?.includes(senderDomain)) continue;
+
+      const allowedAttachments = attachmentListMatches(message.attachments, recipe);
+      if (allowedAttachments.length === 0) continue;
+
+      const keywordMatched =
+        (!recipe.subjectKeywords?.length && !recipe.attachmentKeywords?.length) ||
+        matchesAnyKeyword(message.subject, recipe.subjectKeywords) ||
+        matchesAttachmentKeywords(allowedAttachments, recipe.attachmentKeywords);
+      if (!keywordMatched) continue;
+
+      targets.push({
+        ...message,
+        attachments: allowedAttachments,
+      });
+    }
+
+    return { threadId, targets };
+  }
+
+  private normalizeForwardingMessage(rawMessage: Any): ForwardingMessage | null {
+    const id = normalizeString(rawMessage?.id);
+    const threadId = normalizeString(rawMessage?.threadId);
+    if (!id || !threadId) return null;
+    const payload = rawMessage?.payload || {};
+    const headers = extractHeaders(Array.isArray(payload.headers) ? payload.headers : []);
+    const attachments = collectAttachments(payload);
+    const labelIds = Array.isArray(rawMessage?.labelIds)
+      ? rawMessage.labelIds
+          .map((label: unknown) => normalizeString(label))
+          .filter((label: string): label is string => Boolean(label))
+      : [];
+    return {
+      id,
+      threadId,
+      subject: headers.subject || "(No subject)",
+      fromRaw: headers.from,
+      fromEmail: normalizeEmail(headers.from),
+      internalDate: Number(rawMessage?.internalDate || Date.now()),
+      textBody: extractPlainText(payload),
+      htmlBody: extractHtml(payload),
+      attachments,
+      labelIds,
+    };
+  }
+
+  private async getOrCreateLabels(settings: Any, recipe: MailboxForwardRecipe): Promise<{
+    forwarded: string;
+    rejected: string;
+    candidate: string;
+  }> {
+    const result = await gmailRequest(settings, {
+      method: "GET",
+      path: "/users/me/labels",
+    });
+    const labels = Array.isArray(result.data?.labels) ? result.data.labels : [];
+    const byName = new Map<string, string>();
+    for (const label of labels) {
+      const name = normalizeString((label as Any)?.name);
+      const id = normalizeString((label as Any)?.id);
+      if (name && id) {
+        byName.set(name, id);
+      }
+    }
+
+    const ensure = async (name: string): Promise<string> => {
+      const existing = byName.get(name);
+      if (existing) return existing;
+      const created = await gmailRequest(settings, {
+        method: "POST",
+        path: "/users/me/labels",
+        body: {
+          name,
+          labelListVisibility: "labelShow",
+          messageListVisibility: "show",
+        },
+      });
+      const id = normalizeString(created.data?.id);
+      if (!id) {
+        throw new Error(`Failed to create Gmail label: ${name}`);
+      }
+      byName.set(name, id);
+      return id;
+    };
+
+    return {
+      forwarded: await ensure(recipe.forwardedLabelName || "cowork/forwarded"),
+      rejected: await ensure(recipe.rejectedLabelName || "cowork/rejected"),
+      candidate: await ensure(recipe.candidateLabelName || "cowork/candidate"),
+    };
+  }
+
+  private async applyThreadLabels(
+    settings: Any,
+    threadId: string,
+    input: { add?: string[]; remove?: string[] },
+  ): Promise<void> {
+    const add = (input.add || []).filter(Boolean);
+    const remove = (input.remove || []).filter(Boolean);
+    if (add.length === 0 && remove.length === 0) return;
+    await gmailRequest(settings, {
+      method: "POST",
+      path: `/users/me/threads/${encodeURIComponent(threadId)}/modify`,
+      body: {
+        addLabelIds: add.length ? Array.from(new Set(add)) : undefined,
+        removeLabelIds: remove.length ? Array.from(new Set(remove)) : undefined,
+      },
+    });
+  }
+
+  private async forwardMessage(
+    settings: Any,
+    automationId: string,
+    recipe: MailboxForwardRecipe,
+    message: ForwardingMessage,
+  ): Promise<MessageForwardOutcome> {
+    const alreadyForwarded = this.deps.db
+      .prepare(
+        `SELECT status FROM mailbox_forwarding_message_runs WHERE automation_id = ? AND message_id = ?`,
+      )
+      .get(automationId, message.id) as { status: string } | undefined;
+    if (alreadyForwarded?.status === "sent") {
+      return { status: "already_sent", messageId: message.id };
+    }
+
+    if (recipe.dryRun) {
+      return { status: "dry_run", messageId: message.id };
+    }
+
+    try {
+      const attachments: Array<{ filename: string; mimeType: string; data: Uint8Array }> = [];
+      for (const attachment of message.attachments) {
+        let data: Uint8Array | null = null;
+        if (attachment.inlineData) {
+          const normalized = attachment.inlineData.replace(/-/g, "+").replace(/_/g, "/");
+          const padding = normalized.length % 4 === 0 ? 0 : 4 - (normalized.length % 4);
+          data = Buffer.from(normalized + "=".repeat(padding), "base64");
+        } else if (attachment.attachmentId) {
+          const attachmentResult = await gmailRequest(settings, {
+            method: "GET",
+            path: `/users/me/messages/${encodeURIComponent(message.id)}/attachments/${encodeURIComponent(attachment.attachmentId)}`,
+          });
+          const attachmentData = normalizeString(attachmentResult.data?.data);
+          if (attachmentData) {
+            const normalized = attachmentData.replace(/-/g, "+").replace(/_/g, "/");
+            const padding = normalized.length % 4 === 0 ? 0 : 4 - (normalized.length % 4);
+            data = Buffer.from(normalized + "=".repeat(padding), "base64");
+          }
+        }
+        if (!data) {
+          throw new Error(`Missing attachment data for ${attachment.filename}`);
+        }
+        attachments.push({
+          filename: attachment.filename,
+          mimeType: attachment.mimeType,
+          data,
+        });
+      }
+
+      const raw = buildForwardedMime({
+        to: recipe.targetEmail,
+        subject: message.subject.startsWith("Fwd:") ? message.subject : `Fwd: ${message.subject}`,
+        body: message.textBody || "(No plain text body available)",
+        originalFrom: message.fromRaw,
+        originalSubject: message.subject,
+        originalDate: message.internalDate,
+        originalMessageId: message.id,
+        attachments,
+      });
+      await gmailRequest(settings, {
+        method: "POST",
+        path: "/users/me/messages/send",
+        body: {
+          raw: encodeMessage(raw),
+        },
+      });
+
+      const now = Date.now();
+      this.deps.db
+        .prepare(
+          `INSERT INTO mailbox_forwarding_message_runs
+             (automation_id, message_id, thread_id, status, error, created_at, updated_at)
+           VALUES (?, ?, ?, 'sent', NULL, ?, ?)
+           ON CONFLICT(automation_id, message_id) DO UPDATE SET
+             status = 'sent',
+             error = NULL,
+             thread_id = excluded.thread_id,
+             updated_at = excluded.updated_at`,
+        )
+        .run(automationId, message.id, message.threadId, now, now);
+      return { status: "sent", messageId: message.id };
+    } catch (error) {
+      const now = Date.now();
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.deps.db
+        .prepare(
+          `INSERT INTO mailbox_forwarding_message_runs
+             (automation_id, message_id, thread_id, status, error, created_at, updated_at)
+           VALUES (?, ?, ?, 'error', ?, ?, ?)
+           ON CONFLICT(automation_id, message_id) DO UPDATE SET
+             status = 'error',
+             error = excluded.error,
+             thread_id = excluded.thread_id,
+             updated_at = excluded.updated_at`,
+        )
+        .run(automationId, message.id, message.threadId, errorMessage, now, now);
+      return { status: "failed", messageId: message.id, error: errorMessage };
+    }
+  }
+}

--- a/src/electron/mailbox/MailboxService.ts
+++ b/src/electron/mailbox/MailboxService.ts
@@ -10,9 +10,10 @@ import { LLMProviderFactory } from "../agent/llm/provider-factory";
 import { recordLlmCallError, recordLlmCallSuccess } from "../agent/llm/usage-telemetry";
 import type { LLMMessage } from "../agent/llm/types";
 import { GoogleWorkspaceSettingsManager } from "../settings/google-workspace-manager";
+import { AgentMailSettingsManager } from "../settings/agentmail-manager";
 import { gmailRequest } from "../utils/gmail-api";
 import { googleCalendarRequest } from "../utils/google-calendar-api";
-import { EmailClient } from "../gateway/channels/email-client";
+import { EmailClient, type EmailMessage } from "../gateway/channels/email-client";
 import { LoomEmailClient } from "../gateway/channels/loom-client";
 import { assertSafeLoomMailboxFolder } from "../utils/loom";
 import { refreshMicrosoftEmailAccessToken } from "../utils/microsoft-email-oauth";
@@ -26,7 +27,10 @@ import { ControlPlaneCoreService } from "../control-plane/ControlPlaneCoreServic
 import { ContactIdentityService } from "../identity/ContactIdentityService";
 import { MailboxAutomationHub } from "./MailboxAutomationHub";
 import { MailboxAutomationRegistry } from "./MailboxAutomationRegistry";
+import { AgentMailClient } from "../agentmail/AgentMailClient";
+import { AgentMailAdminService } from "../agentmail/AgentMailAdminService";
 import { mailboxLlmQuickReplies, mailboxLlmSimilarThreadIds } from "./mailbox-inbox-product-llm";
+import { getMailboxForwardingServiceInstance } from "./mailbox-forwarding-singleton";
 import {
   ChannelPreferenceSummary,
   ContactIdentity,
@@ -52,6 +56,7 @@ import {
   MailboxEvent,
   MailboxEventType,
   MailboxAutomationRecord,
+  MailboxForwardRecipe,
   MailboxCompanyCandidate,
   MailboxMissionControlHandoffPreview,
   MailboxMissionControlHandoffRecord,
@@ -151,6 +156,12 @@ type MailboxMessageRow = {
   body_html: string | null;
   received_at: number;
   is_unread: number;
+  metadata_json: string | null;
+};
+
+type MailboxMessageMetadata = {
+  imapUid?: number;
+  rfcMessageId?: string;
 };
 
 type MailboxSummaryRow = {
@@ -490,6 +501,7 @@ type NormalizedThreadInput = {
   messages: Array<{
     id: string;
     providerMessageId: string;
+    metadata?: MailboxMessageMetadata;
     direction: "incoming" | "outgoing";
     from?: MailboxParticipant;
     to: MailboxParticipant[];
@@ -522,6 +534,30 @@ function asNumber(value: unknown): number | null {
 
 function asBoolean(value: unknown): boolean | null {
   return typeof value === "boolean" ? value : null;
+}
+
+function parseTimestamp(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function parseMailboxMessageMetadata(value: string | null | undefined): MailboxMessageMetadata {
+  if (!value) return {};
+  try {
+    const parsed = asObject(JSON.parse(value));
+    return {
+      imapUid: asNumber(parsed?.imapUid) ?? undefined,
+      rfcMessageId: asString(parsed?.rfcMessageId) ?? undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 function parseJsonArray<T>(value: string | null | undefined): T[] {
@@ -1236,7 +1272,21 @@ export class MailboxService {
   }
 
   isAvailable(): boolean {
-    return GoogleWorkspaceSettingsManager.loadSettings().enabled || this.hasEmailChannel();
+    const agentMailSettings = AgentMailSettingsManager.loadSettings();
+    return (
+      GoogleWorkspaceSettingsManager.loadSettings().enabled ||
+      this.hasEmailChannel() ||
+      Boolean(agentMailSettings.enabled && agentMailSettings.apiKey)
+    );
+  }
+
+  private getAgentMailClient(): AgentMailClient {
+    return new AgentMailClient(AgentMailSettingsManager.loadSettings());
+  }
+
+  private agentMailEnabled(): boolean {
+    const settings = AgentMailSettingsManager.loadSettings();
+    return Boolean(settings.enabled && settings.apiKey);
   }
 
   private isLoomEmailChannel(): boolean {
@@ -1316,7 +1366,7 @@ export class MailboxService {
       classificationPendingCount: countsRow.classification_pending_count || 0,
       statusLabel:
         accounts.length === 0
-          ? "Connect Gmail or Email channel"
+          ? "Connect AgentMail, Gmail, or the Email channel"
           : `${accounts.length} account${accounts.length === 1 ? "" : "s"} synced${
               this.syncInFlight && this.syncProgress?.label
                 ? ` · ${this.syncProgress.label}`
@@ -1413,6 +1463,13 @@ export class MailboxService {
     });
   }
 
+  async createMailboxForward(recipe: MailboxForwardRecipe): Promise<MailboxAutomationRecord> {
+    return MailboxAutomationRegistry.createForward({
+      ...recipe,
+      workspaceId: recipe.workspaceId || this.resolveDefaultWorkspaceId(),
+    });
+  }
+
   async updateMailboxSchedule(
     automationId: string,
     patch: Partial<MailboxScheduleRecipe> & { status?: MailboxAutomationStatus },
@@ -1420,8 +1477,27 @@ export class MailboxService {
     return MailboxAutomationRegistry.updateSchedule(automationId, patch);
   }
 
+  async updateMailboxForward(
+    automationId: string,
+    patch: Partial<MailboxForwardRecipe> & { status?: MailboxAutomationStatus },
+  ): Promise<MailboxAutomationRecord | null> {
+    return MailboxAutomationRegistry.updateForward(automationId, patch);
+  }
+
   async deleteMailboxSchedule(automationId: string): Promise<boolean> {
     return MailboxAutomationRegistry.deleteSchedule(automationId);
+  }
+
+  async deleteMailboxForward(automationId: string): Promise<boolean> {
+    return MailboxAutomationRegistry.deleteForward(automationId);
+  }
+
+  async runMailboxForward(automationId: string): Promise<string> {
+    const service = getMailboxForwardingServiceInstance();
+    if (!service) {
+      throw new Error("Mailbox forwarding service is not available");
+    }
+    return service.runNow(automationId);
   }
 
   async listMailboxAutomationHistory(automationId: string, limit = 25): Promise<Any[]> {
@@ -1780,6 +1856,20 @@ export class MailboxService {
     ];
     const params: unknown[] = [];
     if (workspaceId) {
+      conditions.push(
+        `(
+          ${threadAlias}.provider != 'agentmail'
+          OR EXISTS (
+            SELECT 1
+            FROM agentmail_inboxes ai
+            WHERE ai.workspace_id = ?
+              AND ('agentmail:' || ai.pod_id || ':' || ai.inbox_id) = ${threadAlias}.account_id
+          )
+        )`,
+      );
+      params.push(workspaceId);
+    }
+    if (workspaceId) {
       // A thread is hidden from inbox if it belongs to at least one view with
       // show_in_inbox=0, but does NOT also belong to any view with show_in_inbox=1.
       conditions.push(
@@ -2014,6 +2104,19 @@ export class MailboxService {
         }
       }
 
+      if (this.agentMailEnabled()) {
+        try {
+          const result = await this.syncAgentMail(limit);
+          if (result) {
+            accounts.push(...result.accounts);
+            syncedThreads += result.syncedThreads;
+            syncedMessages += result.syncedMessages;
+          }
+        } catch (error) {
+          syncErrors.push(`AgentMail sync failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+
       if (this.hasEmailChannel()) {
         try {
           const result = await this.syncImap(limit);
@@ -2030,7 +2133,7 @@ export class MailboxService {
       if (accounts.length === 0) {
         throw new Error(
           syncErrors[0] ||
-            "No connected mailbox was found. Enable Google Workspace or configure the Email channel.",
+            "No connected mailbox was found. Enable AgentMail, Google Workspace, or configure the Email channel.",
         );
       }
 
@@ -2086,6 +2189,339 @@ export class MailboxService {
     } finally {
       this.syncInFlight = false;
     }
+  }
+
+  private buildAgentMailAccountId(podId: string, inboxId: string): string {
+    return `agentmail:${podId}:${inboxId}`;
+  }
+
+  private parseAgentMailAccountId(accountId?: string): { podId: string; inboxId: string } | null {
+    const raw = asString(accountId);
+    if (!raw || !raw.startsWith("agentmail:")) {
+      return null;
+    }
+    const parts = raw.split(":");
+    if (parts.length < 3) return null;
+    return {
+      podId: parts[1] || "",
+      inboxId: parts.slice(2).join(":"),
+    };
+  }
+
+  private getAgentMailBindings(): Array<{ workspace_id: string; pod_id: string }> {
+    return this.db
+      .prepare(
+        `SELECT workspace_id, pod_id
+         FROM agentmail_workspace_pods
+         ORDER BY updated_at DESC`,
+      )
+      .all() as Array<{ workspace_id: string; pod_id: string }>;
+  }
+
+  private buildAgentMailAccount(
+    podId: string,
+    inboxId: string,
+    address?: string,
+    displayName?: string,
+  ): MailboxAccount {
+    return {
+      id: this.buildAgentMailAccountId(podId, inboxId),
+      provider: "agentmail",
+      address: address || inboxId,
+      displayName,
+      status: "connected",
+      capabilities: ["archive", "trash", "mark_read", "label", "send_draft", "sync", "realtime"],
+      lastSyncedAt: Date.now(),
+    };
+  }
+
+  private normalizeAgentMailLabels(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    return value
+      .map((entry) => asString(entry))
+      .filter((entry): entry is string => Boolean(entry))
+      .map((entry) => entry.toLowerCase());
+  }
+
+  private normalizeAgentMailThread(
+    _workspaceId: string,
+    podId: string,
+    threadPayload: unknown,
+  ): NormalizedThreadInput | null {
+    const thread = asObject(threadPayload);
+    if (!thread) return null;
+
+    const inboxId = asString(thread.inbox_id);
+    const providerThreadId = asString(thread.thread_id);
+    if (!inboxId || !providerThreadId) {
+      return null;
+    }
+
+    const accountId = this.buildAgentMailAccountId(podId, inboxId);
+    const accountRow = this.db
+      .prepare("SELECT address FROM mailbox_accounts WHERE id = ?")
+      .get(accountId) as { address: string } | undefined;
+    const accountEmail = normalizeEmailAddress(accountRow?.address || inboxId) || inboxId.toLowerCase();
+    const threadLabels = this.normalizeAgentMailLabels(thread.labels);
+    const rawMessages = Array.isArray(thread.messages) ? thread.messages : [];
+
+    const normalizedMessages = rawMessages
+      .map<NormalizedMailboxMessage | null>((entry) => {
+        const message = asObject(entry);
+        if (!message) return null;
+        const providerMessageId = asString(message.message_id);
+        if (!providerMessageId) return null;
+        const from = parseAddressList(message.from)[0];
+        const to = parseAddressList(message.to);
+        const cc = parseAddressList(message.cc);
+        const bcc = parseAddressList(message.bcc);
+        const labels = this.normalizeAgentMailLabels(message.labels);
+        const bodyHtml = asString(message.html) || asString(message.body_html) || undefined;
+        const bodyText =
+          asString(message.text) ||
+          asString(message.body_text) ||
+          asString(message.body) ||
+          (bodyHtml ? stripHtml(bodyHtml) : "");
+        const receivedAt =
+          parseTimestamp(message.timestamp) ||
+          parseTimestamp(message.created_at) ||
+          parseTimestamp(message.updated_at) ||
+          Date.now();
+        const fromEmail = normalizeEmailAddress(from?.email);
+        const directionHint = asString(message.direction);
+        const outgoing =
+          directionHint === "outgoing" ||
+          directionHint === "sent" ||
+          fromEmail === accountEmail ||
+          labels.includes("sent");
+        const unread = labels.includes("unread") || threadLabels.includes("unread");
+
+        return {
+          id: `agentmail-message:${providerMessageId}`,
+          providerMessageId,
+          direction: outgoing ? ("outgoing" as const) : ("incoming" as const),
+          from,
+          to,
+          cc,
+          bcc,
+          subject:
+            asString(message.subject) ||
+            asString(thread.subject) ||
+            "Untitled thread",
+          snippet: normalizeWhitespace(
+            asString(message.preview) || bodyText || (bodyHtml ? stripHtml(bodyHtml) : ""),
+            240,
+          ),
+          body: normalizeWhitespace(bodyText, 12000),
+          bodyHtml,
+          receivedAt,
+          unread,
+          metadata: {
+            rfcMessageId:
+              asString(message.internet_message_id) ||
+              asString(message.message_id_header) ||
+              undefined,
+          },
+        };
+      })
+      .filter((message): message is NormalizedMailboxMessage => message !== null)
+      .sort((a, b) => a.receivedAt - b.receivedAt);
+
+    if (normalizedMessages.length === 0) {
+      return null;
+    }
+
+    const participants = uniqueParticipants(
+      [
+        ...parseAddressList(thread.senders),
+        ...parseAddressList(thread.recipients),
+        ...normalizedMessages.flatMap((message) => [
+          ...(message.from ? [message.from] : []),
+          ...message.to,
+          ...message.cc,
+          ...message.bcc,
+        ]),
+      ].filter((participant) => normalizeEmailAddress(participant.email) !== accountEmail),
+    );
+    const unreadCount = normalizedMessages.filter((message) => message.unread).length;
+    const lastMessage = normalizedMessages[normalizedMessages.length - 1]!;
+    const needsReply = normalizedMessages.some(
+      (message) => message.direction === "incoming" && message.unread,
+    );
+
+    return {
+      id: `agentmail-thread:${providerThreadId}`,
+      accountId,
+      provider: "agentmail",
+      providerThreadId,
+      subject:
+        asString(thread.subject) ||
+        lastMessage.subject ||
+        "Untitled thread",
+      snippet: normalizeWhitespace(
+        asString(thread.preview) ||
+          asString(thread.snippet) ||
+          lastMessage.snippet ||
+          lastMessage.body,
+        320,
+      ),
+      participants,
+      labels: threadLabels,
+      category: "other",
+      priorityScore: clampScore(needsReply ? 55 : unreadCount > 0 ? 35 : 10),
+      urgencyScore: clampScore(needsReply ? 30 : unreadCount > 0 ? 12 : 0),
+      needsReply,
+      staleFollowup: false,
+      cleanupCandidate: false,
+      handled: unreadCount === 0 && !needsReply,
+      unreadCount,
+      lastMessageAt:
+        parseTimestamp(thread.timestamp) ||
+        parseTimestamp(thread.received_timestamp) ||
+        parseTimestamp(thread.updated_at) ||
+        lastMessage.receivedAt,
+      messages: normalizedMessages,
+    };
+  }
+
+  async ingestAgentMailThread(
+    _workspaceId: string,
+    podId: string,
+    threadPayload: unknown,
+    options?: { classify?: boolean },
+  ): Promise<{ account: MailboxAccount; syncedMessages: number; isNewThread: boolean } | null> {
+    const normalized = this.normalizeAgentMailThread(_workspaceId, podId, threadPayload);
+    if (!normalized) return null;
+
+    const inboxParts = this.parseAgentMailAccountId(normalized.accountId);
+    const inboxRow = inboxParts
+      ? (this.db
+          .prepare(
+            `SELECT email, display_name
+             FROM agentmail_inboxes
+             WHERE pod_id = ? AND inbox_id = ?`,
+          )
+          .get(inboxParts.podId, inboxParts.inboxId) as
+          | { email: string | null; display_name: string | null }
+          | undefined)
+      : undefined;
+
+    const account = this.buildAgentMailAccount(
+      podId,
+      inboxParts?.inboxId || normalized.accountId,
+      inboxRow?.email || inboxParts?.inboxId,
+      inboxRow?.display_name || undefined,
+    );
+    this.upsertAccount(account);
+    const upsertResult = this.upsertThread(normalized);
+    if (upsertResult.shouldClassify && options?.classify !== false) {
+      await this.classifyMailboxThreadsForAccount(account.id, {
+        includeBackfill: true,
+        limit: Math.min(Math.max(normalized.messages.length, 1), MAILBOX_CLASSIFIER_MAX_BATCH),
+      });
+    }
+
+    this.db
+      .prepare("UPDATE mailbox_accounts SET last_synced_at = ?, updated_at = ? WHERE id = ?")
+      .run(Date.now(), Date.now(), account.id);
+
+    return {
+      account,
+      syncedMessages: normalized.messages.length,
+      isNewThread: upsertResult.isNewThread,
+    };
+  }
+
+  private async syncAgentMail(
+    limit: number,
+  ): Promise<{ accounts: MailboxAccount[]; syncedThreads: number; syncedMessages: number } | null> {
+    const bindings = this.getAgentMailBindings();
+    if (bindings.length === 0) {
+      return null;
+    }
+
+    const adminService = new AgentMailAdminService(this.db);
+    const client = this.getAgentMailClient();
+    const accountsById = new Map<string, MailboxAccount>();
+    const classificationCandidates = new Set<string>();
+    let processedThreads = 0;
+    let processedMessages = 0;
+
+    this.updateSyncProgress({
+      phase: "ingesting",
+      totalThreads: bindings.length * Math.min(Math.max(limit, 1), 50),
+      processedThreads: 0,
+      totalMessages: 0,
+      processedMessages: 0,
+      newThreads: 0,
+      classifiedThreads: 0,
+      skippedThreads: 0,
+      label: "Syncing AgentMail pods...",
+    });
+
+    for (const binding of bindings) {
+      const refreshed = await adminService.refreshWorkspace(binding.workspace_id);
+      for (const inbox of refreshed.inboxes) {
+        const account = this.buildAgentMailAccount(
+          inbox.podId,
+          inbox.inboxId,
+          inbox.email,
+          inbox.displayName,
+        );
+        this.upsertAccount(account);
+        accountsById.set(account.id, account);
+      }
+
+      const listResult = await client.listPodThreads(binding.pod_id, {
+        limit: Math.min(Math.max(limit * 3, limit), 100),
+        includeSpam: true,
+        includeBlocked: true,
+        includeTrash: true,
+      });
+      const threadRefs = Array.isArray(listResult.threads) ? listResult.threads : [];
+
+      for (const threadRef of threadRefs.slice(0, limit)) {
+        const providerThreadId = asString(asObject(threadRef)?.thread_id);
+        if (!providerThreadId) continue;
+        const thread = await client.getPodThread(binding.pod_id, providerThreadId);
+        const ingestResult = await this.ingestAgentMailThread(
+          binding.workspace_id,
+          binding.pod_id,
+          thread,
+          { classify: false },
+        );
+        if (!ingestResult) continue;
+        accountsById.set(ingestResult.account.id, ingestResult.account);
+        classificationCandidates.add(ingestResult.account.id);
+        processedThreads += 1;
+        processedMessages += ingestResult.syncedMessages;
+        this.updateSyncProgress({
+          phase: "ingesting",
+          accountId: ingestResult.account.id,
+          totalThreads: bindings.length * Math.min(Math.max(limit, 1), 50),
+          processedThreads,
+          totalMessages: Math.max(processedMessages, processedThreads),
+          processedMessages,
+          newThreads: processedThreads,
+          classifiedThreads: 0,
+          skippedThreads: 0,
+          label: `Syncing AgentMail ${processedThreads} thread${processedThreads === 1 ? "" : "s"} · ${processedMessages} message${processedMessages === 1 ? "" : "s"}`,
+        });
+      }
+    }
+
+    for (const accountId of classificationCandidates) {
+      await this.classifyMailboxThreadsForAccount(accountId, {
+        includeBackfill: true,
+        limit: MAILBOX_CLASSIFIER_MAX_BATCH,
+      });
+    }
+
+    return {
+      accounts: Array.from(accountsById.values()),
+      syncedThreads: processedThreads,
+      syncedMessages: processedMessages,
+    };
   }
 
   async reclassifyThread(threadId: string): Promise<MailboxReclassifyResult> {
@@ -4037,6 +4473,10 @@ export class MailboxService {
           return {
             id: `imap-message:${providerMessageId}`,
             providerMessageId,
+            metadata: {
+              imapUid: asNumber(message?.uid) ?? undefined,
+              rfcMessageId: asString(message?.messageId) || undefined,
+            },
             direction: fromEmail === accountEmail ? ("outgoing" as const) : ("incoming" as const),
             from: fromEmail
               ? {
@@ -4387,7 +4827,7 @@ export class MailboxService {
           encryptMailboxValue(message.bodyHtml || null),
           message.receivedAt,
           message.unread ? 1 : 0,
-          JSON.stringify({}),
+          JSON.stringify(message.metadata || {}),
           now,
           now,
         );
@@ -4988,7 +5428,8 @@ export class MailboxService {
            body_text,
            body_html,
            received_at,
-           is_unread
+           is_unread,
+           metadata_json
          FROM mailbox_messages
          WHERE thread_id = ?
          ORDER BY received_at ASC`,
@@ -5281,6 +5722,20 @@ export class MailboxService {
   }
 
   private resolveThreadWorkspaceId(_accountId?: string): string | undefined {
+    const agentMail = this.parseAgentMailAccountId(_accountId);
+    if (agentMail) {
+      const row = this.db
+        .prepare(
+          `SELECT workspace_id
+           FROM agentmail_inboxes
+           WHERE pod_id = ? AND inbox_id = ?
+           LIMIT 1`,
+        )
+        .get(agentMail.podId, agentMail.inboxId) as { workspace_id: string } | undefined;
+      if (row?.workspace_id) {
+        return row.workspace_id;
+      }
+    }
     return this.resolveDefaultWorkspaceId();
   }
 
@@ -5714,6 +6169,16 @@ export class MailboxService {
           removeLabelIds: ["INBOX"],
         },
       });
+    } else if (thread.provider === "agentmail") {
+      const account = this.parseAgentMailAccountId(thread.accountId);
+      const latestMessage = [...thread.messages].sort((a, b) => b.receivedAt - a.receivedAt)[0];
+      if (!account || !latestMessage) {
+        throw new Error("Unable to resolve AgentMail message for archive.");
+      }
+      await this.getAgentMailClient().updateMessage(account.inboxId, latestMessage.providerMessageId, {
+        addLabels: ["archived"],
+        removeLabels: ["inbox"],
+      });
     } else {
       throw new Error("Archive is not supported for the current IMAP adapter.");
     }
@@ -5738,6 +6203,15 @@ export class MailboxService {
         method: "POST",
         path: `/users/me/threads/${encodeURIComponent(thread.providerThreadId)}/trash`,
       });
+    } else if (thread.provider === "agentmail") {
+      const account = this.parseAgentMailAccountId(thread.accountId);
+      const latestMessage = [...thread.messages].sort((a, b) => b.receivedAt - a.receivedAt)[0];
+      if (!account || !latestMessage) {
+        throw new Error("Unable to resolve AgentMail message for trash.");
+      }
+      await this.getAgentMailClient().updateMessage(account.inboxId, latestMessage.providerMessageId, {
+        addLabels: ["trash"],
+      });
     } else {
       throw new Error("Trash is not supported for the current IMAP adapter.");
     }
@@ -5757,6 +6231,18 @@ export class MailboxService {
           removeLabelIds: ["UNREAD"],
         },
       });
+    } else if (thread.provider === "agentmail") {
+      const account = this.parseAgentMailAccountId(thread.accountId);
+      if (!account) {
+        throw new Error("Unable to resolve AgentMail inbox for mark_read.");
+      }
+      const unreadMessages = thread.messages.filter((message) => message.unread);
+      for (const message of unreadMessages) {
+        await this.getAgentMailClient().updateMessage(account.inboxId, message.providerMessageId, {
+          removeLabels: ["unread"],
+          addLabels: ["read"],
+        });
+      }
     } else {
       const channel = this.channelRepo.findByType("email");
       if (!channel) throw new Error("Email channel is not configured");
@@ -5785,9 +6271,8 @@ export class MailboxService {
         await client.markAsRead(uid);
       } else {
         const client = this.createStandardEmailClient(channel.id, cfg);
-        const latest = thread.messages.filter((message) => message.unread).slice(-1)[0];
-        const uid = Number(latest?.providerMessageId);
-        if (!Number.isFinite(uid)) {
+        const uid = await this.resolveImapUidForMarkRead(thread.id, client);
+        if (uid === null || !Number.isFinite(uid)) {
           throw new Error("Unable to resolve IMAP UID for mark_read");
         }
         await client.markAsRead(uid);
@@ -5800,21 +6285,134 @@ export class MailboxService {
       .run(Date.now(), thread.id);
   }
 
+  private extractStoredImapUid(row: Pick<MailboxMessageRow, "provider_message_id" | "metadata_json">): number | null {
+    const providerUid = Number(row.provider_message_id);
+    if (Number.isFinite(providerUid)) {
+      return providerUid;
+    }
+    const metadata = parseMailboxMessageMetadata(row.metadata_json);
+    return Number.isFinite(metadata.imapUid) ? metadata.imapUid || null : null;
+  }
+
+  private mailboxRowMatchesImapMessage(
+    row: Pick<MailboxMessageRow, "subject" | "from_email" | "received_at">,
+    message: EmailMessage,
+  ): boolean {
+    const rowSubject = normalizeWhitespace(row.subject || "", 160).toLowerCase();
+    const messageSubject = normalizeWhitespace(message.subject || "", 160).toLowerCase();
+    const rowFrom = normalizeEmailAddress(row.from_email || "");
+    const messageFrom = normalizeEmailAddress(message.from?.address || "");
+    return (
+      rowSubject.length > 0 &&
+      rowSubject === messageSubject &&
+      rowFrom !== null &&
+      rowFrom.length > 0 &&
+      rowFrom === messageFrom &&
+      Math.abs(message.date.getTime() - row.received_at) <= 5 * 60 * 1000
+    );
+  }
+
+  private persistResolvedImapMessageMetadata(
+    row: Pick<MailboxMessageRow, "id" | "metadata_json">,
+    message: EmailMessage,
+  ): void {
+    const previous = parseMailboxMessageMetadata(row.metadata_json);
+    this.db
+      .prepare("UPDATE mailbox_messages SET metadata_json = ?, updated_at = ? WHERE id = ?")
+      .run(
+        JSON.stringify({
+          ...previous,
+          imapUid: message.uid,
+          rfcMessageId: message.messageId,
+        }),
+        Date.now(),
+        row.id,
+      );
+  }
+
+  private async resolveImapUidForMarkRead(threadId: string, client: EmailClient): Promise<number | null> {
+    const rows = this.db
+      .prepare(
+        `SELECT
+           id,
+           provider_message_id,
+           subject,
+           from_email,
+           received_at,
+           is_unread,
+           metadata_json
+         FROM mailbox_messages
+         WHERE thread_id = ?
+         ORDER BY is_unread DESC, received_at DESC`,
+      )
+      .all(threadId) as Array<
+      Pick<
+        MailboxMessageRow,
+        "id" | "provider_message_id" | "subject" | "from_email" | "received_at" | "is_unread" | "metadata_json"
+      >
+    >;
+
+    for (const row of rows) {
+      const uid = this.extractStoredImapUid(row);
+      if (Number.isFinite(uid)) {
+        return uid;
+      }
+    }
+
+    const remoteMessages = await client.fetchRecentEmails(Math.min(Math.max(rows.length * 10, 25), 200));
+    const priorityRows = rows.some((row) => Boolean(row.is_unread))
+      ? rows.filter((row) => Boolean(row.is_unread))
+      : rows;
+
+    for (const row of priorityRows) {
+      const metadata = parseMailboxMessageMetadata(row.metadata_json);
+      const candidateIds = new Set(
+        [row.provider_message_id, metadata.rfcMessageId].filter((value): value is string => Boolean(value)),
+      );
+      const match =
+        remoteMessages.find((message) => candidateIds.has(message.messageId)) ||
+        remoteMessages.find((message) => this.mailboxRowMatchesImapMessage(row, message));
+      if (!match || !Number.isFinite(match.uid)) {
+        continue;
+      }
+      this.persistResolvedImapMessageMetadata(row, match);
+      mailboxLogger.warn("Recovered legacy IMAP UID for mailbox mark_read", {
+        threadId,
+        mailboxMessageId: row.id,
+        messageId: match.messageId,
+        uid: match.uid,
+      });
+      return match.uid;
+    }
+
+    return null;
+  }
+
   private async applyLabel(
     thread: MailboxThreadDetail | (MailboxThreadListItem & { messages: MailboxMessage[] }),
     label: string,
   ): Promise<void> {
-    if (thread.provider !== "gmail") {
-      throw new Error("Label actions are only supported for Gmail-backed threads.");
+    if (thread.provider === "agentmail") {
+      const account = this.parseAgentMailAccountId(thread.accountId);
+      const latestMessage = [...thread.messages].sort((a, b) => b.receivedAt - a.receivedAt)[0];
+      if (!account || !latestMessage) {
+        throw new Error("Unable to resolve AgentMail message for label update.");
+      }
+      await this.getAgentMailClient().updateMessage(account.inboxId, latestMessage.providerMessageId, {
+        addLabels: [label],
+      });
+    } else if (thread.provider !== "gmail") {
+      throw new Error("Label actions are only supported for Gmail- or AgentMail-backed threads.");
+    } else {
+      const settings = GoogleWorkspaceSettingsManager.loadSettings();
+      await gmailRequest(settings, {
+        method: "POST",
+        path: `/users/me/threads/${encodeURIComponent(thread.providerThreadId)}/modify`,
+        body: {
+          addLabelIds: [label],
+        },
+      });
     }
-    const settings = GoogleWorkspaceSettingsManager.loadSettings();
-    await gmailRequest(settings, {
-      method: "POST",
-      path: `/users/me/threads/${encodeURIComponent(thread.providerThreadId)}/modify`,
-      body: {
-        addLabelIds: [label],
-      },
-    });
 
     const labels = Array.from(new Set([...thread.labels, label]));
     this.db
@@ -5857,6 +6455,18 @@ export class MailboxService {
           raw,
           threadId: thread.providerThreadId,
         },
+      });
+    } else if (thread.provider === "agentmail") {
+      const account = this.parseAgentMailAccountId(thread.accountId);
+      const latestInbound = [...thread.messages]
+        .filter((message) => message.direction === "incoming")
+        .sort((a, b) => b.receivedAt - a.receivedAt)[0];
+      if (!account || !latestInbound) {
+        throw new Error("Unable to resolve AgentMail reply target.");
+      }
+      await this.getAgentMailClient().replyAllMessage(account.inboxId, latestInbound.providerMessageId, {
+        text: draft.body,
+        subject: draft.subject,
       });
     } else {
       const channel = this.channelRepo.findByType("email");

--- a/src/electron/mailbox/__tests__/MailboxAutomationRegistry.test.ts
+++ b/src/electron/mailbox/__tests__/MailboxAutomationRegistry.test.ts
@@ -258,4 +258,61 @@ describeWithSqlite("MailboxAutomationRegistry", () => {
       expect(triggerService.removeTrigger).toHaveBeenCalledWith(created.backingTriggerId);
     });
   });
+
+  describe("forward automations", () => {
+    it("creates a forwarding automation with normalized defaults", async () => {
+      const { MailboxAutomationRegistry } = await import("../MailboxAutomationRegistry");
+      const automation = MailboxAutomationRegistry.createForward({
+        name: "Forward invoices",
+        schedule: { kind: "every", everyMs: 15 * 60 * 1000 },
+        targetEmail: "ops@example.com",
+        allowedSenders: ["Billing@Vendor.com"],
+        allowedDomains: [],
+      });
+
+      expect(automation.kind).toBe("forward");
+      expect(automation.status).toBe("active");
+      expect(automation.forward?.allowedSenders).toEqual(["billing@vendor.com"]);
+      expect(automation.forward?.attachmentExtensions).toEqual([]);
+      expect(typeof automation.nextRunAt).toBe("number");
+    });
+
+    it("updates a forwarding automation and recomputes next run", async () => {
+      const { MailboxAutomationRegistry } = await import("../MailboxAutomationRegistry");
+      const created = MailboxAutomationRegistry.createForward({
+        name: "Forward invoices",
+        schedule: { kind: "every", everyMs: 15 * 60 * 1000 },
+        targetEmail: "ops@example.com",
+        allowedSenders: ["billing@vendor.com"],
+        allowedDomains: [],
+      });
+
+      const updated = MailboxAutomationRegistry.updateForward(created.id, {
+        dryRun: false,
+        subjectKeywords: ["invoice"],
+      });
+
+      expect(updated?.forward?.dryRun).toBe(false);
+      expect(updated?.forward?.subjectKeywords).toEqual(["invoice"]);
+      expect(typeof updated?.nextRunAt).toBe("number");
+    });
+
+    it("soft-deletes a forwarding automation", async () => {
+      const { MailboxAutomationRegistry } = await import("../MailboxAutomationRegistry");
+      const created = MailboxAutomationRegistry.createForward({
+        name: "Forward invoices",
+        schedule: { kind: "every", everyMs: 15 * 60 * 1000 },
+        targetEmail: "ops@example.com",
+        allowedSenders: ["billing@vendor.com"],
+        allowedDomains: [],
+      });
+
+      expect(MailboxAutomationRegistry.deleteForward(created.id)).toBe(true);
+      expect(
+        MailboxAutomationRegistry.listAutomations({ workspaceId: "ws-default" }).find(
+          (item) => item.id === created.id,
+        ),
+      ).toBeUndefined();
+    });
+  });
 });

--- a/src/electron/mailbox/__tests__/MailboxForwardingService.test.ts
+++ b/src/electron/mailbox/__tests__/MailboxForwardingService.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../cron", () => ({
+  getCronService: vi.fn().mockReturnValue(null),
+}));
+
+const gmailRequestMock = vi.fn();
+
+vi.mock("../../utils/gmail-api", () => ({
+  gmailRequest: (...args: unknown[]) => gmailRequestMock(...args),
+}));
+
+vi.mock("../../settings/google-workspace-manager", () => ({
+  GoogleWorkspaceSettingsManager: {
+    loadSettings: vi.fn(() => ({
+      enabled: true,
+      scopes: ["https://www.googleapis.com/auth/gmail.modify"],
+    })),
+  },
+}));
+
+const nativeSqliteAvailable = await import("better-sqlite3")
+  .then((module) => {
+    try {
+      const Database = module.default;
+      const probe = new Database(":memory:");
+      probe.close();
+      return true;
+    } catch {
+      return false;
+    }
+  })
+  .catch(() => false);
+
+const describeWithSqlite = nativeSqliteAvailable ? describe : describe.skip;
+
+describeWithSqlite("MailboxForwardingService", () => {
+  let db: import("better-sqlite3").Database;
+
+  beforeEach(async () => {
+    const Database = (await import("better-sqlite3")).default;
+    const { MailboxAutomationRegistry } = await import("../MailboxAutomationRegistry");
+    db = new Database(":memory:");
+    MailboxAutomationRegistry.reset();
+    MailboxAutomationRegistry.configure({
+      db,
+      resolveDefaultWorkspaceId: () => "ws-default",
+      triggerService: null,
+    });
+    gmailRequestMock.mockReset();
+  });
+
+  afterEach(async () => {
+    const { MailboxAutomationRegistry } = await import("../MailboxAutomationRegistry");
+    MailboxAutomationRegistry.reset();
+    db.close();
+  });
+
+  it("runs a dry-run forwarding automation and labels the thread as candidate", async () => {
+    const { MailboxAutomationRegistry } = await import("../MailboxAutomationRegistry");
+    const { MailboxForwardingService } = await import("../MailboxForwardingService");
+
+    const created = MailboxAutomationRegistry.createForward({
+      name: "Forward vendor invoices",
+      schedule: { kind: "every", everyMs: 15 * 60 * 1000 },
+      targetEmail: "ops@example.com",
+      allowedSenders: ["billing@vendor.com"],
+      allowedDomains: [],
+      attachmentExtensions: ["pdf"],
+      dryRun: true,
+    });
+
+    let createdLabelCount = 0;
+    const modifiedThreadCalls: Array<Record<string, unknown>> = [];
+
+    gmailRequestMock.mockImplementation(async (_settings: unknown, options: { path: string; method: string; body?: Any }) => {
+      if (options.path === "/users/me/labels" && options.method === "GET") {
+        return { status: 200, data: { labels: [] } };
+      }
+      if (options.path === "/users/me/labels" && options.method === "POST") {
+        createdLabelCount += 1;
+        return { status: 200, data: { id: `label-${createdLabelCount}` } };
+      }
+      if (options.path === "/users/me/messages" && options.method === "GET") {
+        return { status: 200, data: { messages: [{ id: "msg-1", threadId: "thread-1" }] } };
+      }
+      if (options.path === "/users/me/threads/thread-1" && options.method === "GET") {
+        return {
+          status: 200,
+          data: {
+            id: "thread-1",
+            messages: [
+              {
+                id: "msg-1",
+                threadId: "thread-1",
+                internalDate: Date.now(),
+                labelIds: ["INBOX"],
+                payload: {
+                  headers: [
+                    { name: "From", value: "Vendor Billing <billing@vendor.com>" },
+                    { name: "Subject", value: "Invoice April" },
+                  ],
+                  parts: [
+                    {
+                      mimeType: "text/plain",
+                      body: { data: Buffer.from("Invoice attached").toString("base64url") },
+                    },
+                    {
+                      filename: "invoice-april.pdf",
+                      mimeType: "application/pdf",
+                      body: { data: Buffer.from("fake-pdf").toString("base64url") },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+      if (options.path === "/users/me/threads/thread-1/modify" && options.method === "POST") {
+        modifiedThreadCalls.push(options.body || {});
+        return { status: 200, data: {} };
+      }
+      throw new Error(`Unhandled gmailRequest call: ${options.method} ${options.path}`);
+    });
+
+    const service = new MailboxForwardingService({ db });
+    const summary = await service.runNow(created.id);
+
+    expect(summary).toContain("Dry run matched 1 message");
+    expect(createdLabelCount).toBe(3);
+    expect(modifiedThreadCalls).toHaveLength(1);
+    expect(modifiedThreadCalls[0]).toMatchObject({
+      addLabelIds: ["label-3"],
+    });
+
+    const refreshed = MailboxAutomationRegistry.listAutomations({ workspaceId: "ws-default" }).find(
+      (item) => item.id === created.id,
+    );
+    expect(refreshed?.latestOutcome).toContain("Dry run matched 1 message");
+  });
+
+  it("scopes automations created from a thread to the Gmail provider thread id", async () => {
+    const { MailboxAutomationRegistry } = await import("../MailboxAutomationRegistry");
+    const { MailboxForwardingService } = await import("../MailboxForwardingService");
+
+    const created = MailboxAutomationRegistry.createForward({
+      name: "Forward one thread only",
+      threadId: "gmail-thread:alpha",
+      providerThreadId: "provider-thread-42",
+      schedule: { kind: "every", everyMs: 15 * 60 * 1000 },
+      targetEmail: "ops@example.com",
+      allowedSenders: ["billing@vendor.com"],
+      allowedDomains: [],
+      attachmentExtensions: ["pdf"],
+      dryRun: true,
+    });
+
+    gmailRequestMock.mockImplementation(async (_settings: unknown, options: { path: string; method: string; body?: Any }) => {
+      if (options.path === "/users/me/labels" && options.method === "GET") {
+        return { status: 200, data: { labels: [] } };
+      }
+      if (options.path === "/users/me/labels" && options.method === "POST") {
+        return { status: 200, data: { id: `label-${Math.random()}` } };
+      }
+      if (options.path === "/users/me/messages" && options.method === "GET") {
+        throw new Error("Mailbox-wide message search should not run for provider-thread scoped automations");
+      }
+      if (options.path === "/users/me/threads/provider-thread-42" && options.method === "GET") {
+        return {
+          status: 200,
+          data: {
+            id: "provider-thread-42",
+            messages: [
+              {
+                id: "msg-thread-only",
+                threadId: "provider-thread-42",
+                internalDate: Date.now(),
+                labelIds: ["INBOX"],
+                payload: {
+                  headers: [
+                    { name: "From", value: "Vendor Billing <billing@vendor.com>" },
+                    { name: "Subject", value: "Thread scoped invoice" },
+                  ],
+                  parts: [
+                    {
+                      mimeType: "text/plain",
+                      body: { data: Buffer.from("Invoice attached").toString("base64url") },
+                    },
+                    {
+                      filename: "thread-only.pdf",
+                      mimeType: "application/pdf",
+                      body: { data: Buffer.from("fake-pdf").toString("base64url") },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+      if (options.path === "/users/me/threads/provider-thread-42/modify" && options.method === "POST") {
+        return { status: 200, data: {} };
+      }
+      throw new Error(`Unhandled gmailRequest call: ${options.method} ${options.path}`);
+    });
+
+    const service = new MailboxForwardingService({ db });
+    const summary = await service.runNow(created.id);
+
+    expect(summary).toContain("Dry run matched 1 message");
+  });
+
+  it("uses the last successful scan watermark instead of now-minus-lookback after downtime", async () => {
+    const { MailboxAutomationRegistry } = await import("../MailboxAutomationRegistry");
+    const { MailboxForwardingService } = await import("../MailboxForwardingService");
+
+    let currentTime = Date.parse("2026-04-20T12:00:00.000Z");
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => currentTime);
+
+    const created = MailboxAutomationRegistry.createForward({
+      name: "Forward invoices reliably",
+      schedule: { kind: "every", everyMs: 15 * 60 * 1000 },
+      targetEmail: "ops@example.com",
+      allowedSenders: ["billing@vendor.com"],
+      allowedDomains: [],
+      attachmentExtensions: ["pdf"],
+      dryRun: false,
+      backfillDays: 30,
+      lookbackMinutes: 20,
+    });
+
+    const messageQueries: string[] = [];
+    let sendCount = 0;
+
+    gmailRequestMock.mockImplementation(async (_settings: unknown, options: { path: string; method: string; body?: Any; query?: Record<string, unknown> }) => {
+      if (options.path === "/users/me/labels" && options.method === "GET") {
+        return { status: 200, data: { labels: [] } };
+      }
+      if (options.path === "/users/me/labels" && options.method === "POST") {
+        return { status: 200, data: { id: `label-${Math.random()}` } };
+      }
+      if (options.path === "/users/me/messages" && options.method === "GET") {
+        messageQueries.push(String(options.query?.q || ""));
+        if (messageQueries.length === 1) {
+          return { status: 200, data: { messages: [{ id: "msg-1", threadId: "thread-1" }] } };
+        }
+        return { status: 200, data: { messages: [] } };
+      }
+      if (options.path === "/users/me/threads/thread-1" && options.method === "GET") {
+        return {
+          status: 200,
+          data: {
+            id: "thread-1",
+            messages: [
+              {
+                id: "msg-1",
+                threadId: "thread-1",
+                internalDate: Date.now(),
+                labelIds: ["INBOX"],
+                payload: {
+                  headers: [
+                    { name: "From", value: "Vendor Billing <billing@vendor.com>" },
+                    { name: "Subject", value: "Invoice April" },
+                  ],
+                  parts: [
+                    {
+                      mimeType: "text/plain",
+                      body: { data: Buffer.from("Invoice attached").toString("base64url") },
+                    },
+                    {
+                      filename: "invoice-april.pdf",
+                      mimeType: "application/pdf",
+                      body: { data: Buffer.from("fake-pdf").toString("base64url") },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+      if (options.path === "/users/me/threads/thread-1/modify" && options.method === "POST") {
+        return { status: 200, data: {} };
+      }
+      if (options.path === "/users/me/messages/send" && options.method === "POST") {
+        sendCount += 1;
+        return { status: 200, data: { id: `sent-${sendCount}` } };
+      }
+      throw new Error(`Unhandled gmailRequest call: ${options.method} ${options.path}`);
+    });
+
+    const service = new MailboxForwardingService({ db });
+    await service.runNow(created.id);
+
+    currentTime = Date.parse("2026-04-23T12:00:00.000Z");
+    await service.runNow(created.id);
+
+    expect(messageQueries).toHaveLength(2);
+    expect(messageQueries[0]).toContain("after:2026/03/21");
+    expect(messageQueries[1]).toContain("after:2026/04/20");
+    expect(messageQueries[1]).not.toContain("after:2026/04/23");
+
+    nowSpy.mockRestore();
+  });
+
+  it("recomputes nextRunAt after a manual run instead of reusing a stale past-due value", async () => {
+    const { MailboxAutomationRegistry } = await import("../MailboxAutomationRegistry");
+    const { MailboxForwardingService } = await import("../MailboxForwardingService");
+
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-23T12:00:00.000Z"));
+
+    const created = MailboxAutomationRegistry.createForward({
+      name: "Forward invoices",
+      schedule: { kind: "every", everyMs: 15 * 60 * 1000 },
+      targetEmail: "ops@example.com",
+      allowedSenders: ["billing@vendor.com"],
+      allowedDomains: [],
+      attachmentExtensions: ["pdf"],
+      dryRun: true,
+    });
+    MailboxAutomationRegistry.setForwardNextRun(created.id, Date.parse("2026-04-23T11:00:00.000Z"));
+
+    gmailRequestMock.mockImplementation(async (_settings: unknown, options: { path: string; method: string; body?: Any }) => {
+      if (options.path === "/users/me/labels" && options.method === "GET") {
+        return { status: 200, data: { labels: [] } };
+      }
+      if (options.path === "/users/me/labels" && options.method === "POST") {
+        return { status: 200, data: { id: `label-${Math.random()}` } };
+      }
+      if (options.path === "/users/me/messages" && options.method === "GET") {
+        return { status: 200, data: { messages: [] } };
+      }
+      throw new Error(`Unhandled gmailRequest call: ${options.method} ${options.path}`);
+    });
+
+    const service = new MailboxForwardingService({ db });
+    await service.runNow(created.id);
+
+    const refreshed = MailboxAutomationRegistry.listAutomations({ workspaceId: "ws-default" }).find(
+      (item) => item.id === created.id,
+    );
+    expect(refreshed?.nextRunAt).toBe(Date.parse("2026-04-23T12:15:00.000Z"));
+
+    nowSpy.mockRestore();
+  });
+});

--- a/src/electron/mailbox/__tests__/MailboxService.test.ts
+++ b/src/electron/mailbox/__tests__/MailboxService.test.ts
@@ -737,6 +737,143 @@ describeWithSqlite("MailboxService", () => {
     ]);
     expect(normalized[0]?.messages[0]?.body).toBe("MSN Mail App, test\n\nReview this sign-in.");
     expect(normalized[0]?.messages[0]?.bodyHtml).toContain("<p>MSN Mail App, test</p>");
+    expect(normalized[0]?.messages[0]?.metadata).toMatchObject({
+      imapUid: 901,
+      rfcMessageId: "msg-901@example.com",
+    });
+  });
+
+  it("recovers a legacy IMAP message-id and marks the thread read", async () => {
+    db.prepare(
+      `INSERT INTO mailbox_accounts
+        (id, provider, address, display_name, status, capabilities_json, sync_cursor, last_synced_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "imap:user@msn.com",
+      "imap",
+      "user@msn.com",
+      "MSN Mail",
+      "connected",
+      JSON.stringify(["send", "mark_read"]),
+      null,
+      now,
+      now,
+      now,
+    );
+
+    db.prepare(
+      `INSERT INTO mailbox_threads
+        (id, account_id, provider_thread_id, provider, subject, snippet, participants_json, labels_json, category, priority_score, urgency_score, needs_reply, stale_followup, cleanup_candidate, handled, unread_count, message_count, last_message_at, last_synced_at, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "imap-thread:legacy-mark-read",
+      "imap:user@msn.com",
+      "legacy-mark-read",
+      "imap",
+      "Legacy IMAP thread",
+      "Unread message synced before UID metadata existed.",
+      JSON.stringify([{ email: "sender@example.com", name: "Sender" }]),
+      JSON.stringify([]),
+      "other",
+      35,
+      22,
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      now - 5 * 60 * 1000,
+      now,
+      JSON.stringify({}),
+      now,
+      now,
+    );
+
+    const legacyMessageRowId = randomUUID();
+    db.prepare(
+      `INSERT INTO mailbox_messages
+        (id, thread_id, provider_message_id, direction, from_name, from_email, to_json, cc_json, bcc_json, subject, snippet, body_text, received_at, is_unread, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      legacyMessageRowId,
+      "imap-thread:legacy-mark-read",
+      "legacy-message-id@example.com",
+      "incoming",
+      "Sender",
+      "sender@example.com",
+      JSON.stringify([{ email: "user@msn.com", name: "MSN Mail" }]),
+      JSON.stringify([]),
+      JSON.stringify([]),
+      "Legacy IMAP thread",
+      "Unread message synced before UID metadata existed.",
+      "Please mark this thread as read.",
+      now - 5 * 60 * 1000,
+      1,
+      JSON.stringify({}),
+      now,
+      now,
+    );
+
+    const findByTypeSpy = vi.spyOn((service as Any).channelRepo, "findByType").mockReturnValue({
+      id: "email-channel",
+      enabled: true,
+      config: {
+        protocol: "imap-smtp",
+      },
+    } as never);
+    const fetchRecentEmails = vi.fn().mockResolvedValue([
+      {
+        uid: 901,
+        messageId: "legacy-message-id@example.com",
+        from: { name: "Sender", address: "sender@example.com" },
+        to: [{ name: "MSN Mail", address: "user@msn.com" }],
+        cc: [],
+        subject: "Legacy IMAP thread",
+        text: "Please mark this thread as read.",
+        date: new Date(now - 5 * 60 * 1000),
+        isRead: false,
+        headers: new Map(),
+      },
+    ]);
+    const markAsRead = vi.fn().mockResolvedValue(undefined);
+    const createStandardEmailClientSpy = vi.spyOn(service as Any, "createStandardEmailClient").mockReturnValue({
+      fetchRecentEmails,
+      markAsRead,
+    } as never);
+
+    try {
+      await expect(
+        service.applyAction({
+          threadId: "imap-thread:legacy-mark-read",
+          type: "mark_read",
+        }),
+      ).resolves.toMatchObject({
+        success: true,
+        action: "mark_read",
+        threadId: "imap-thread:legacy-mark-read",
+      });
+
+      expect(fetchRecentEmails).toHaveBeenCalled();
+      expect(markAsRead).toHaveBeenCalledWith(901);
+
+      const messageRow = db
+        .prepare("SELECT is_unread, metadata_json FROM mailbox_messages WHERE id = ?")
+        .get(legacyMessageRowId) as { is_unread: number; metadata_json: string | null };
+      expect(messageRow.is_unread).toBe(0);
+      expect(JSON.parse(messageRow.metadata_json || "{}")).toMatchObject({
+        imapUid: 901,
+        rfcMessageId: "legacy-message-id@example.com",
+      });
+
+      const threadRow = db
+        .prepare("SELECT unread_count FROM mailbox_threads WHERE id = ?")
+        .get("imap-thread:legacy-mark-read") as { unread_count: number };
+      expect(threadRow.unread_count).toBe(0);
+    } finally {
+      createStandardEmailClientSpy.mockRestore();
+      findByTypeSpy.mockRestore();
+    }
   });
 
   it("does not treat onboarding or automated mail as priority follow-up", async () => {

--- a/src/electron/mailbox/mailbox-forwarding-singleton.ts
+++ b/src/electron/mailbox/mailbox-forwarding-singleton.ts
@@ -1,0 +1,11 @@
+import type { MailboxForwardingService } from "./MailboxForwardingService";
+
+let activeMailboxForwardingService: MailboxForwardingService | null = null;
+
+export function setMailboxForwardingServiceInstance(service: MailboxForwardingService | null): void {
+  activeMailboxForwardingService = service;
+}
+
+export function getMailboxForwardingServiceInstance(): MailboxForwardingService | null {
+  return activeMailboxForwardingService;
+}

--- a/src/electron/settings/agentmail-manager.ts
+++ b/src/electron/settings/agentmail-manager.ts
@@ -1,0 +1,54 @@
+import { SecureSettingsRepository } from "../database/SecureSettingsRepository";
+import { AgentMailSettingsData } from "../../shared/types";
+
+const DEFAULT_SETTINGS: AgentMailSettingsData = {
+  enabled: false,
+  baseUrl: "https://api.agentmail.to/v0",
+  websocketUrl: "wss://api.agentmail.to/v0/websocket",
+  timeoutMs: 20000,
+  realtimeEnabled: true,
+};
+
+export class AgentMailSettingsManager {
+  private static cachedSettings: AgentMailSettingsData | null = null;
+
+  static loadSettings(): AgentMailSettingsData {
+    if (this.cachedSettings) {
+      return this.cachedSettings;
+    }
+
+    let settings: AgentMailSettingsData = { ...DEFAULT_SETTINGS };
+
+    try {
+      if (SecureSettingsRepository.isInitialized()) {
+        const repository = SecureSettingsRepository.getInstance();
+        const stored = repository.load<AgentMailSettingsData>("plugin:agentmail");
+        if (stored) {
+          settings = { ...DEFAULT_SETTINGS, ...stored };
+        }
+      }
+    } catch (error) {
+      console.error("[AgentMailSettingsManager] Failed to load settings:", error);
+    }
+
+    this.cachedSettings = settings;
+    return settings;
+  }
+
+  static saveSettings(settings: AgentMailSettingsData): void {
+    try {
+      if (!SecureSettingsRepository.isInitialized()) {
+        throw new Error("SecureSettingsRepository not initialized");
+      }
+      const repository = SecureSettingsRepository.getInstance();
+      repository.save("plugin:agentmail", settings);
+      this.cachedSettings = settings;
+    } catch (error) {
+      console.error("[AgentMailSettingsManager] Failed to save settings:", error);
+    }
+  }
+
+  static clearCache(): void {
+    this.cachedSettings = null;
+  }
+}

--- a/src/renderer/components/AgentMailSettings.tsx
+++ b/src/renderer/components/AgentMailSettings.tsx
@@ -1,0 +1,735 @@
+import { useEffect, useState } from "react";
+import type {
+  AgentMailApiKeySummary,
+  AgentMailDomain,
+  AgentMailInbox,
+  AgentMailListEntry,
+  AgentMailPod,
+  AgentMailSettingsData,
+  AgentMailStatus,
+  AgentMailWorkspaceBinding,
+  Workspace,
+} from "../../shared/types";
+
+const DEFAULT_TIMEOUT_MS = 20000;
+
+function formatTimestamp(value?: number): string {
+  if (!value) return "Never";
+  return new Date(value).toLocaleString();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function AgentMailSettings() {
+  const [settings, setSettings] = useState<AgentMailSettingsData | null>(null);
+  const [status, setStatus] = useState<AgentMailStatus | null>(null);
+  const [pods, setPods] = useState<AgentMailPod[]>([]);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>("");
+  const [binding, setBinding] = useState<AgentMailWorkspaceBinding | null>(null);
+  const [inboxes, setInboxes] = useState<AgentMailInbox[]>([]);
+  const [domains, setDomains] = useState<AgentMailDomain[]>([]);
+  const [selectedInboxId, setSelectedInboxId] = useState<string>("");
+  const [listEntries, setListEntries] = useState<AgentMailListEntry[]>([]);
+  const [apiKeys, setApiKeys] = useState<AgentMailApiKeySummary[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [createdApiKey, setCreatedApiKey] = useState<string | null>(null);
+  const [workspacePodChoice, setWorkspacePodChoice] = useState<string>("");
+  const [workspacePodName, setWorkspacePodName] = useState<string>("");
+  const [inboxForm, setInboxForm] = useState({
+    username: "",
+    domain: "",
+    displayName: "",
+  });
+  const [domainForm, setDomainForm] = useState({
+    domain: "",
+    feedbackEnabled: true,
+  });
+  const [listForm, setListForm] = useState<{
+    direction: AgentMailListEntry["direction"];
+    listType: AgentMailListEntry["listType"];
+    entry: string;
+    reason: string;
+  }>({
+    direction: "receive",
+    listType: "allow",
+    entry: "",
+    reason: "",
+  });
+  const [apiKeyName, setApiKeyName] = useState("");
+  const [testResult, setTestResult] = useState<{ success: boolean; error?: string; podCount?: number; inboxCount?: number } | null>(null);
+
+  useEffect(() => {
+    void loadBootstrap();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedWorkspaceId) return;
+    void loadWorkspace(selectedWorkspaceId);
+  }, [selectedWorkspaceId]);
+
+  useEffect(() => {
+    if (!selectedWorkspaceId) return;
+    void loadLists(selectedWorkspaceId, selectedInboxId || undefined);
+    if (selectedInboxId) {
+      void loadApiKeys(selectedWorkspaceId, selectedInboxId);
+    } else {
+      setApiKeys([]);
+    }
+  }, [selectedWorkspaceId, selectedInboxId]);
+
+  const loadBootstrap = async () => {
+    setError(null);
+    try {
+      const [loadedSettings, loadedStatus, loadedPods, loadedWorkspaces] = await Promise.all([
+        window.electronAPI.getAgentMailSettings(),
+        window.electronAPI.getAgentMailStatus(),
+        window.electronAPI.listAgentMailPods().catch(() => []),
+        window.electronAPI.listWorkspaces(),
+      ]);
+      setSettings(loadedSettings);
+      setStatus(loadedStatus);
+      setPods(loadedPods);
+      const stableWorkspaces = loadedWorkspaces.filter((workspace) => !workspace.isTemp);
+      setWorkspaces(stableWorkspaces);
+      const preferredWorkspaceId = stableWorkspaces[0]?.id || "";
+      setSelectedWorkspaceId((current) => current || preferredWorkspaceId);
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  const loadWorkspace = async (workspaceId: string) => {
+    setError(null);
+    try {
+      const [loadedBinding, loadedInboxes, loadedDomains] = await Promise.all([
+        window.electronAPI.getAgentMailWorkspaceBinding(workspaceId),
+        window.electronAPI.listAgentMailInboxes(workspaceId),
+        window.electronAPI.listAgentMailDomains(workspaceId),
+      ]);
+      setBinding(loadedBinding);
+      setInboxes(loadedInboxes);
+      setDomains(loadedDomains);
+      setWorkspacePodChoice(loadedBinding?.podId || "");
+      setSelectedInboxId((current) =>
+        current && loadedInboxes.some((inbox) => inbox.inboxId === current)
+          ? current
+          : loadedInboxes[0]?.inboxId || "",
+      );
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  const loadLists = async (workspaceId: string, inboxId?: string) => {
+    try {
+      const entries = await window.electronAPI.listAgentMailListEntries({ workspaceId, inboxId });
+      setListEntries(entries);
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  const loadApiKeys = async (workspaceId: string, inboxId: string) => {
+    try {
+      const keys = await window.electronAPI.listAgentMailInboxApiKeys({ workspaceId, inboxId });
+      setApiKeys(keys);
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  const withBusy = async (key: string, task: () => Promise<void>) => {
+    setBusy(key);
+    setError(null);
+    try {
+      await task();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const saveSettings = async () => {
+    if (!settings) return;
+    await withBusy("save-settings", async () => {
+      await window.electronAPI.saveAgentMailSettings(settings);
+      await loadBootstrap();
+    });
+  };
+
+  const testConnection = async () => {
+    await withBusy("test-connection", async () => {
+      const result = await window.electronAPI.testAgentMailConnection();
+      setTestResult(result);
+      await loadBootstrap();
+    });
+  };
+
+  const refreshWorkspace = async () => {
+    if (!selectedWorkspaceId) return;
+    await withBusy("refresh-workspace", async () => {
+      await window.electronAPI.refreshAgentMailWorkspace(selectedWorkspaceId);
+      await loadWorkspace(selectedWorkspaceId);
+      await loadBootstrap();
+    });
+  };
+
+  const bindWorkspacePod = async () => {
+    if (!selectedWorkspaceId || !workspacePodChoice) return;
+    await withBusy("bind-pod", async () => {
+      await window.electronAPI.bindAgentMailWorkspacePod({
+        workspaceId: selectedWorkspaceId,
+        podId: workspacePodChoice,
+      });
+      await loadWorkspace(selectedWorkspaceId);
+      await loadBootstrap();
+    });
+  };
+
+  const createWorkspacePod = async () => {
+    if (!selectedWorkspaceId) return;
+    await withBusy("create-pod", async () => {
+      await window.electronAPI.createAgentMailWorkspacePod({
+        workspaceId: selectedWorkspaceId,
+        podName: workspacePodName || undefined,
+      });
+      setWorkspacePodName("");
+      await loadWorkspace(selectedWorkspaceId);
+      await loadBootstrap();
+    });
+  };
+
+  const createInbox = async () => {
+    if (!selectedWorkspaceId) return;
+    await withBusy("create-inbox", async () => {
+      await window.electronAPI.createAgentMailInbox({
+        workspaceId: selectedWorkspaceId,
+        username: inboxForm.username || undefined,
+        domain: inboxForm.domain || undefined,
+        displayName: inboxForm.displayName || undefined,
+      });
+      setInboxForm({ username: "", domain: "", displayName: "" });
+      await loadWorkspace(selectedWorkspaceId);
+    });
+  };
+
+  const renameInbox = async (inbox: AgentMailInbox) => {
+    const nextDisplayName = window.prompt("Display name", inbox.displayName || inbox.email || inbox.inboxId);
+    if (!nextDisplayName || !selectedWorkspaceId) return;
+    await withBusy(`rename-${inbox.inboxId}`, async () => {
+      await window.electronAPI.updateAgentMailInbox({
+        workspaceId: selectedWorkspaceId,
+        inboxId: inbox.inboxId,
+        displayName: nextDisplayName,
+      });
+      await loadWorkspace(selectedWorkspaceId);
+    });
+  };
+
+  const deleteInbox = async (inbox: AgentMailInbox) => {
+    if (!selectedWorkspaceId) return;
+    if (!window.confirm(`Delete inbox ${inbox.email || inbox.inboxId}?`)) return;
+    await withBusy(`delete-${inbox.inboxId}`, async () => {
+      await window.electronAPI.deleteAgentMailInbox({
+        workspaceId: selectedWorkspaceId,
+        inboxId: inbox.inboxId,
+      });
+      await loadWorkspace(selectedWorkspaceId);
+    });
+  };
+
+  const createDomain = async () => {
+    if (!selectedWorkspaceId || !domainForm.domain) return;
+    await withBusy("create-domain", async () => {
+      await window.electronAPI.createAgentMailDomain({
+        workspaceId: selectedWorkspaceId,
+        domain: domainForm.domain,
+        feedbackEnabled: domainForm.feedbackEnabled,
+      });
+      setDomainForm({ domain: "", feedbackEnabled: true });
+      await loadWorkspace(selectedWorkspaceId);
+    });
+  };
+
+  const verifyDomain = async (domain: AgentMailDomain) => {
+    if (!selectedWorkspaceId) return;
+    await withBusy(`verify-${domain.domainId}`, async () => {
+      await window.electronAPI.verifyAgentMailDomain({
+        workspaceId: selectedWorkspaceId,
+        domainId: domain.domainId,
+      });
+      await loadWorkspace(selectedWorkspaceId);
+    });
+  };
+
+  const deleteDomain = async (domain: AgentMailDomain) => {
+    if (!selectedWorkspaceId) return;
+    if (!window.confirm(`Delete domain ${domain.domain || domain.domainId}?`)) return;
+    await withBusy(`delete-domain-${domain.domainId}`, async () => {
+      await window.electronAPI.deleteAgentMailDomain({
+        workspaceId: selectedWorkspaceId,
+        domainId: domain.domainId,
+      });
+      await loadWorkspace(selectedWorkspaceId);
+    });
+  };
+
+  const createListEntry = async () => {
+    if (!selectedWorkspaceId || !listForm.entry) return;
+    await withBusy("create-list-entry", async () => {
+      await window.electronAPI.createAgentMailListEntry({
+        workspaceId: selectedWorkspaceId,
+        inboxId: selectedInboxId || undefined,
+        direction: listForm.direction,
+        listType: listForm.listType,
+        entry: listForm.entry,
+        reason: listForm.reason || undefined,
+      });
+      setListForm((current) => ({ ...current, entry: "", reason: "" }));
+      await loadLists(selectedWorkspaceId, selectedInboxId || undefined);
+    });
+  };
+
+  const deleteListEntry = async (entry: AgentMailListEntry) => {
+    if (!selectedWorkspaceId) return;
+    await withBusy(`delete-list-${entry.entry}`, async () => {
+      await window.electronAPI.deleteAgentMailListEntry({
+        workspaceId: selectedWorkspaceId,
+        inboxId: entry.inboxId || undefined,
+        direction: entry.direction,
+        listType: entry.listType,
+        entry: entry.entry,
+      });
+      await loadLists(selectedWorkspaceId, selectedInboxId || undefined);
+    });
+  };
+
+  const createApiKey = async () => {
+    if (!selectedWorkspaceId || !selectedInboxId) return;
+    await withBusy("create-api-key", async () => {
+      const result = await window.electronAPI.createAgentMailInboxApiKey({
+        workspaceId: selectedWorkspaceId,
+        inboxId: selectedInboxId,
+        name: apiKeyName || undefined,
+      });
+      setCreatedApiKey(result.apiKey || null);
+      setApiKeyName("");
+      await loadApiKeys(selectedWorkspaceId, selectedInboxId);
+    });
+  };
+
+  const deleteApiKey = async (apiKey: AgentMailApiKeySummary) => {
+    if (!selectedWorkspaceId || !selectedInboxId) return;
+    await withBusy(`delete-api-key-${apiKey.apiKeyId}`, async () => {
+      await window.electronAPI.deleteAgentMailInboxApiKey({
+        workspaceId: selectedWorkspaceId,
+        inboxId: selectedInboxId,
+        apiKeyId: apiKey.apiKeyId,
+      });
+      await loadApiKeys(selectedWorkspaceId, selectedInboxId);
+    });
+  };
+
+  if (!settings) {
+    return <div className="settings-loading">Loading AgentMail settings...</div>;
+  }
+
+  return (
+    <div className="agentmail-settings">
+      <div className="settings-section">
+        <div className="settings-section-header">
+          <h3>AgentMail</h3>
+          <div className="settings-actions">
+            <button className="btn-secondary btn-sm" onClick={testConnection} disabled={busy !== null}>
+              {busy === "test-connection" ? "Testing..." : "Test Connection"}
+            </button>
+            <button className="btn-primary btn-sm" onClick={saveSettings} disabled={busy !== null}>
+              {busy === "save-settings" ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </div>
+        <p className="settings-description">
+          Native AgentMail support for workspace pods, inbox provisioning, domains, lists, inbox-scoped
+          API keys, REST sync, and realtime event streaming.
+        </p>
+        {error && <p className="settings-hint">Error: {error}</p>}
+        {testResult && (
+          <p className="settings-hint">
+            {testResult.success
+              ? `Connected. ${testResult.podCount || 0} pod(s), ${testResult.inboxCount || 0} inbox(es).`
+              : `Connection failed: ${testResult.error || "Unknown error"}`}
+          </p>
+        )}
+        {createdApiKey && (
+          <p className="settings-hint">
+            New inbox key: <code>{createdApiKey}</code> (shown once only)
+          </p>
+        )}
+        <div className="settings-grid">
+          <div className="setting-item">
+            <label>Enable AgentMail</label>
+            <input
+              type="checkbox"
+              checked={settings.enabled}
+              onChange={(event) => setSettings({ ...settings, enabled: event.target.checked })}
+            />
+          </div>
+          <div className="setting-item">
+            <label>Enable realtime WebSocket sync</label>
+            <input
+              type="checkbox"
+              checked={Boolean(settings.realtimeEnabled)}
+              onChange={(event) =>
+                setSettings({ ...settings, realtimeEnabled: event.target.checked })
+              }
+            />
+          </div>
+          <div className="setting-item">
+            <label>Org API Key</label>
+            <input
+              type="password"
+              value={settings.apiKey || ""}
+              onChange={(event) => setSettings({ ...settings, apiKey: event.target.value })}
+              placeholder="am_..."
+            />
+          </div>
+          <div className="setting-item">
+            <label>Base URL</label>
+            <input
+              type="text"
+              value={settings.baseUrl || ""}
+              onChange={(event) => setSettings({ ...settings, baseUrl: event.target.value })}
+              placeholder="https://api.agentmail.to/v0"
+            />
+          </div>
+          <div className="setting-item">
+            <label>WebSocket URL</label>
+            <input
+              type="text"
+              value={settings.websocketUrl || ""}
+              onChange={(event) => setSettings({ ...settings, websocketUrl: event.target.value })}
+              placeholder="wss://api.agentmail.to/v0/websocket"
+            />
+          </div>
+          <div className="setting-item">
+            <label>Timeout (ms)</label>
+            <input
+              type="number"
+              value={settings.timeoutMs || DEFAULT_TIMEOUT_MS}
+              onChange={(event) =>
+                setSettings({
+                  ...settings,
+                  timeoutMs: Number(event.target.value) || DEFAULT_TIMEOUT_MS,
+                })
+              }
+            />
+          </div>
+        </div>
+        <div className="settings-hint">
+          Status: {status?.connected ? "Connected" : "Not connected"} · Realtime:{" "}
+          {status?.connectionState || "disconnected"} · Last event: {formatTimestamp(status?.lastEventAt)}
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <div className="settings-section-header">
+          <h3>Workspace Pod Binding</h3>
+          <button className="btn-secondary btn-sm" onClick={refreshWorkspace} disabled={!selectedWorkspaceId || busy !== null}>
+            {busy === "refresh-workspace" ? "Refreshing..." : "Refresh Workspace"}
+          </button>
+        </div>
+        <div className="settings-grid">
+          <div className="setting-item">
+            <label>Workspace</label>
+            <select value={selectedWorkspaceId} onChange={(event) => setSelectedWorkspaceId(event.target.value)}>
+              {workspaces.map((workspace) => (
+                <option key={workspace.id} value={workspace.id}>
+                  {workspace.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="setting-item">
+            <label>Bound pod</label>
+            <div>{binding ? `${binding.podName || binding.podId} (${binding.podId})` : "Not bound"}</div>
+          </div>
+          <div className="setting-item">
+            <label>Bind existing pod</label>
+            <select value={workspacePodChoice} onChange={(event) => setWorkspacePodChoice(event.target.value)}>
+              <option value="">Select pod...</option>
+              {pods.map((pod) => (
+                <option key={pod.podId} value={pod.podId}>
+                  {pod.name || pod.podId}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="setting-item">
+            <label>New pod name</label>
+            <input
+              type="text"
+              value={workspacePodName}
+              onChange={(event) => setWorkspacePodName(event.target.value)}
+              placeholder="Acme workspace"
+            />
+          </div>
+        </div>
+        <div className="settings-actions">
+          <button className="btn-secondary btn-sm" onClick={bindWorkspacePod} disabled={!workspacePodChoice || busy !== null}>
+            {busy === "bind-pod" ? "Binding..." : "Bind Pod"}
+          </button>
+          <button className="btn-primary btn-sm" onClick={createWorkspacePod} disabled={!selectedWorkspaceId || busy !== null}>
+            {busy === "create-pod" ? "Creating..." : "Create Pod"}
+          </button>
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <div className="settings-section-header">
+          <h3>Inboxes</h3>
+          <div className="settings-hint">Provider badge in Inbox Agent will show `agentmail` for these threads.</div>
+        </div>
+        <div className="settings-grid">
+          <div className="setting-item">
+            <label>Username</label>
+            <input
+              type="text"
+              value={inboxForm.username}
+              onChange={(event) => setInboxForm({ ...inboxForm, username: event.target.value })}
+              placeholder="support"
+            />
+          </div>
+          <div className="setting-item">
+            <label>Domain</label>
+            <input
+              type="text"
+              value={inboxForm.domain}
+              onChange={(event) => setInboxForm({ ...inboxForm, domain: event.target.value })}
+              placeholder="example.com"
+            />
+          </div>
+          <div className="setting-item">
+            <label>Display name</label>
+            <input
+              type="text"
+              value={inboxForm.displayName}
+              onChange={(event) => setInboxForm({ ...inboxForm, displayName: event.target.value })}
+              placeholder="Support"
+            />
+          </div>
+        </div>
+        <div className="settings-actions">
+          <button className="btn-primary btn-sm" onClick={createInbox} disabled={!binding || busy !== null}>
+            {busy === "create-inbox" ? "Creating..." : "Create Inbox"}
+          </button>
+        </div>
+        <div style={{ display: "grid", gap: 10, marginTop: 12 }}>
+          {inboxes.map((inbox) => (
+            <div key={inbox.inboxId} className="setting-item" style={{ border: "1px solid var(--color-border-subtle)", padding: 12, borderRadius: 10 }}>
+              <div style={{ fontWeight: 600 }}>{inbox.displayName || inbox.email || inbox.inboxId}</div>
+              <div className="settings-hint">{inbox.inboxId}</div>
+              <div className="settings-actions">
+                <button className="btn-secondary btn-sm" onClick={() => renameInbox(inbox)} disabled={busy !== null}>
+                  Rename
+                </button>
+                <button className="btn-secondary btn-sm" onClick={() => setSelectedInboxId(inbox.inboxId)}>
+                  {selectedInboxId === inbox.inboxId ? "Selected" : "Manage"}
+                </button>
+                <button className="btn-secondary btn-sm" onClick={() => deleteInbox(inbox)} disabled={busy !== null}>
+                  Delete
+                </button>
+              </div>
+            </div>
+          ))}
+          {inboxes.length === 0 && <div className="settings-hint">No inboxes yet for this workspace pod.</div>}
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <div className="settings-section-header">
+          <h3>Domains</h3>
+        </div>
+        <div className="settings-grid">
+          <div className="setting-item">
+            <label>Domain</label>
+            <input
+              type="text"
+              value={domainForm.domain}
+              onChange={(event) => setDomainForm({ ...domainForm, domain: event.target.value })}
+              placeholder="example.com"
+            />
+          </div>
+          <div className="setting-item">
+            <label>Feedback enabled</label>
+            <input
+              type="checkbox"
+              checked={domainForm.feedbackEnabled}
+              onChange={(event) => setDomainForm({ ...domainForm, feedbackEnabled: event.target.checked })}
+            />
+          </div>
+        </div>
+        <div className="settings-actions">
+          <button className="btn-primary btn-sm" onClick={createDomain} disabled={!binding || busy !== null}>
+            {busy === "create-domain" ? "Creating..." : "Create Domain"}
+          </button>
+        </div>
+        <div style={{ display: "grid", gap: 10, marginTop: 12 }}>
+          {domains.map((domain) => (
+            <div key={domain.domainId} className="setting-item" style={{ border: "1px solid var(--color-border-subtle)", padding: 12, borderRadius: 10 }}>
+              <div style={{ fontWeight: 600 }}>
+                {domain.domain} <span className="settings-hint">({domain.status || "unknown"})</span>
+              </div>
+              <div style={{ display: "grid", gap: 4, marginTop: 8 }}>
+                {domain.records.map((record, index) => (
+                  <div key={`${domain.domainId}-${index}`} className="settings-hint">
+                    {record.type} {record.name} → {record.value} {record.status ? `(${record.status})` : ""}
+                  </div>
+                ))}
+              </div>
+              <div className="settings-actions">
+                <button className="btn-secondary btn-sm" onClick={() => verifyDomain(domain)} disabled={busy !== null}>
+                  Verify
+                </button>
+                <button className="btn-secondary btn-sm" onClick={() => deleteDomain(domain)} disabled={busy !== null}>
+                  Delete
+                </button>
+              </div>
+            </div>
+          ))}
+          {domains.length === 0 && <div className="settings-hint">No custom domains yet.</div>}
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <div className="settings-section-header">
+          <h3>Lists And Inbox Keys</h3>
+        </div>
+        <div className="settings-grid">
+          <div className="setting-item">
+            <label>Inbox scope</label>
+            <select value={selectedInboxId} onChange={(event) => setSelectedInboxId(event.target.value)}>
+              <option value="">Organization scope</option>
+              {inboxes.map((inbox) => (
+                <option key={inbox.inboxId} value={inbox.inboxId}>
+                  {inbox.email || inbox.inboxId}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="setting-item">
+            <label>Direction</label>
+            <select
+              value={listForm.direction}
+              onChange={(event) =>
+                setListForm({
+                  ...listForm,
+                  direction: event.target.value as AgentMailListEntry["direction"],
+                })
+              }
+            >
+              <option value="receive">receive</option>
+              <option value="reply">reply</option>
+              <option value="send">send</option>
+            </select>
+          </div>
+          <div className="setting-item">
+            <label>Type</label>
+            <select
+              value={listForm.listType}
+              onChange={(event) =>
+                setListForm({
+                  ...listForm,
+                  listType: event.target.value as AgentMailListEntry["listType"],
+                })
+              }
+            >
+              <option value="allow">allow</option>
+              <option value="block">block</option>
+            </select>
+          </div>
+          <div className="setting-item">
+            <label>Entry</label>
+            <input
+              type="text"
+              value={listForm.entry}
+              onChange={(event) => setListForm({ ...listForm, entry: event.target.value })}
+              placeholder="vip@example.com or example.com"
+            />
+          </div>
+          <div className="setting-item">
+            <label>Reason</label>
+            <input
+              type="text"
+              value={listForm.reason}
+              onChange={(event) => setListForm({ ...listForm, reason: event.target.value })}
+              placeholder="Optional"
+            />
+          </div>
+        </div>
+        <div className="settings-actions">
+          <button className="btn-primary btn-sm" onClick={createListEntry} disabled={busy !== null}>
+            {busy === "create-list-entry" ? "Saving..." : "Add List Entry"}
+          </button>
+        </div>
+        <div style={{ display: "grid", gap: 8, marginTop: 12 }}>
+          {listEntries.map((entry) => (
+            <div key={`${entry.inboxId || "org"}:${entry.direction}:${entry.listType}:${entry.entry}`} className="setting-item" style={{ border: "1px solid var(--color-border-subtle)", padding: 10, borderRadius: 10 }}>
+              <div style={{ fontWeight: 600 }}>
+                {entry.entry} <span className="settings-hint">({entry.direction}/{entry.listType})</span>
+              </div>
+              {entry.reason && <div className="settings-hint">{entry.reason}</div>}
+              <div className="settings-actions">
+                <button className="btn-secondary btn-sm" onClick={() => deleteListEntry(entry)} disabled={busy !== null}>
+                  Delete
+                </button>
+              </div>
+            </div>
+          ))}
+          {listEntries.length === 0 && <div className="settings-hint">No list entries for this scope.</div>}
+        </div>
+
+        <div style={{ marginTop: 18 }}>
+          <div className="settings-grid">
+            <div className="setting-item">
+              <label>New inbox API key name</label>
+              <input
+                type="text"
+                value={apiKeyName}
+                onChange={(event) => setApiKeyName(event.target.value)}
+                placeholder="support-agent-key"
+              />
+            </div>
+          </div>
+          <div className="settings-actions">
+            <button className="btn-primary btn-sm" onClick={createApiKey} disabled={!selectedInboxId || busy !== null}>
+              {busy === "create-api-key" ? "Creating..." : "Create Inbox API Key"}
+            </button>
+          </div>
+          <div style={{ display: "grid", gap: 8, marginTop: 12 }}>
+            {apiKeys.map((apiKey) => (
+              <div key={apiKey.apiKeyId} className="setting-item" style={{ border: "1px solid var(--color-border-subtle)", padding: 10, borderRadius: 10 }}>
+                <div style={{ fontWeight: 600 }}>{apiKey.name || apiKey.prefix}</div>
+                <div className="settings-hint">
+                  {apiKey.prefix} · {formatTimestamp(apiKey.createdAt)}
+                </div>
+                <div className="settings-actions">
+                  <button className="btn-secondary btn-sm" onClick={() => deleteApiKey(apiKey)} disabled={busy !== null}>
+                    Delete
+                  </button>
+                </div>
+              </div>
+            ))}
+            {selectedInboxId && apiKeys.length === 0 && (
+              <div className="settings-hint">No inbox-scoped API keys for the selected inbox.</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/InboxAgentPanel.tsx
+++ b/src/renderer/components/InboxAgentPanel.tsx
@@ -25,6 +25,7 @@ import {
   MailboxAutomationRecord,
   MailboxCommitment,
   MailboxCompanyCandidate,
+  MailboxForwardRecipe,
   MailboxDigestSnapshot,
   MailboxConditionOperator,
   MailboxMissionControlHandoffPreview,
@@ -763,6 +764,25 @@ export function InboxAgentPanel(props: InboxAgentPanelProps = {}) {
   const gmailCleanupActionsEnabled = googleWorkspaceEnabled && gmailModifyScopeGranted;
   const selectedThreadNeedsGmailCleanupAttention =
     selectedThread?.provider === "gmail" && Boolean(gmailCleanupDisabledReason);
+  const selectedBulkThreads = useMemo(() => {
+    const threadById = new Map(threads.map((thread) => [thread.id, thread]));
+    if (selectedThread) {
+      threadById.set(selectedThread.id, selectedThread);
+    }
+    return selectedBulkThreadIds
+      .map((threadId) => threadById.get(threadId) || null)
+      .filter((thread): thread is NonNullable<typeof selectedThread> => Boolean(thread));
+  }, [selectedBulkThreadIds, selectedThread, threads]);
+  const bulkSelectionHasGmailThread = selectedBulkThreads.some((thread) => thread.provider === "gmail");
+  const bulkSelectionHasNonGmailThread = selectedBulkThreads.some((thread) => thread.provider !== "gmail");
+  const bulkArchiveTrashDisabledReason = bulkSelectionHasNonGmailThread
+    ? "Archive and Trash are currently supported only for Gmail threads."
+    : bulkSelectionHasGmailThread && gmailCleanupDisabledReason
+      ? gmailCleanupDisabledReason
+      : null;
+  const bulkMarkReadDisabledReason = bulkSelectionHasGmailThread && gmailCleanupDisabledReason
+    ? gmailCleanupDisabledReason
+    : null;
 
   const clearThreadSelection = () => {
     setSelectedThreadIds([]);
@@ -1190,14 +1210,18 @@ export function InboxAgentPanel(props: InboxAgentPanelProps = {}) {
 
   const handleBulkThreadAction = async (type: "archive" | "trash" | "mark_read") => {
     if (!selectedBulkThreadIds.length) return;
-    if (type !== "mark_read") {
-      if (!gmailCleanupActionsEnabled) {
-        setError(gmailCleanupDisabledReason || "Reconnect Google Workspace to archive or trash Gmail threads.");
+    if (type === "mark_read") {
+      if (bulkMarkReadDisabledReason) {
+        setError(bulkMarkReadDisabledReason);
         return;
       }
-      const selectedThreads = threads.filter((thread) => selectedBulkThreadIds.includes(thread.id));
-      if (selectedThreads.some((thread) => thread.provider !== "gmail")) {
+    } else {
+      if (bulkSelectionHasNonGmailThread) {
         setError("Archive and Trash are currently supported only for Gmail threads.");
+        return;
+      }
+      if (!gmailCleanupActionsEnabled) {
+        setError(gmailCleanupDisabledReason || "Reconnect Google Workspace to archive or trash Gmail threads.");
         return;
       }
     }
@@ -1254,6 +1278,89 @@ export function InboxAgentPanel(props: InboxAgentPanelProps = {}) {
         cooldownMs: 30 * 60 * 1000,
       });
       await reloadAll(thread?.id);
+    });
+  };
+
+  const createForwardAutomationFromCurrentContext = async () => {
+    if (!selectedThread) return;
+    if (selectedThread.provider !== "gmail") {
+      setError("Forwarding automations currently require a Gmail-backed thread.");
+      return;
+    }
+
+    const targetEmail = window.prompt("Forward matching Gmail messages to which email address?", "");
+    if (targetEmail === null) return;
+    const normalizedTarget = targetEmail.trim();
+    if (!normalizedTarget) {
+      setError("Target email is required.");
+      return;
+    }
+
+    const suggestedSenders = Array.from(
+      new Set(
+        selectedThread.messages
+          .filter((message) => message.direction === "incoming")
+          .map((message) => message.from?.email?.trim().toLowerCase())
+          .filter((value): value is string => Boolean(value)),
+      ),
+    );
+    const senderCsv = window.prompt(
+      "Allowed sender emails (comma-separated). Leave blank to use sender domains instead.",
+      suggestedSenders.join(", "),
+    );
+    if (senderCsv === null) return;
+    const allowedSenders = senderCsv
+      .split(",")
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+    const allowedDomains =
+      allowedSenders.length === 0
+        ? Array.from(
+            new Set(
+              suggestedSenders
+                .map((value) => value.split("@")[1]?.trim().toLowerCase())
+                .filter((value): value is string => Boolean(value)),
+            ),
+          )
+        : [];
+    if (allowedSenders.length === 0 && allowedDomains.length === 0) {
+      setError("At least one sender or sender domain is required.");
+      return;
+    }
+
+    const subjectKeywordsRaw = window.prompt(
+      "Optional subject keywords (comma-separated). Leave blank to match any PDF from the allowed sender(s).",
+      "",
+    );
+    if (subjectKeywordsRaw === null) return;
+    const subjectKeywords = subjectKeywordsRaw
+      .split(",")
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+    const dryRun = window.confirm(
+      "Create this forwarding automation in dry-run mode first?\n\nOK = dry-run only\nCancel = send matching emails for real",
+    );
+
+    await runAction(async () => {
+      const recipe: MailboxForwardRecipe = {
+        name: `Auto-forward: ${selectedThread.subject?.slice(0, 80) || "Gmail thread"}`,
+        description: `Forward Gmail messages matching ${selectedThread.subject || "this thread"} to ${normalizedTarget}.`,
+        threadId: selectedThread.id,
+        providerThreadId: selectedThread.providerThreadId,
+        schedule: { kind: "every", everyMs: 15 * 60 * 1000 },
+        targetEmail: normalizedTarget,
+        allowedSenders,
+        allowedDomains,
+        subjectKeywords,
+        attachmentExtensions: ["pdf"],
+        dryRun,
+        maxMessagesPerRun: 100,
+        backfillDays: 30,
+        lookbackMinutes: 20,
+        enabled: true,
+      };
+      await window.electronAPI.createMailboxForward(recipe);
+      await reloadAll(selectedThread.id);
     });
   };
 
@@ -2086,20 +2193,23 @@ export function InboxAgentPanel(props: InboxAgentPanelProps = {}) {
                   onClick={() => void handleBulkThreadAction("archive")}
                   icon={<Archive size={11} />}
                   label="Archive"
-                  disabled={busy}
+                  disabled={busy || Boolean(bulkArchiveTrashDisabledReason)}
+                  title={bulkArchiveTrashDisabledReason || undefined}
                 />
                 <ActionBtn
                   onClick={() => void handleBulkThreadAction("mark_read")}
                   icon={<MailOpen size={11} />}
                   label="Mark read"
-                  disabled={busy}
+                  disabled={busy || Boolean(bulkMarkReadDisabledReason)}
+                  title={bulkMarkReadDisabledReason || undefined}
                 />
                 <ActionBtn
                   onClick={() => void handleBulkThreadAction("trash")}
                   icon={<Trash2 size={11} />}
                   label="Trash"
                   variant="danger"
-                  disabled={busy}
+                  disabled={busy || Boolean(bulkArchiveTrashDisabledReason)}
+                  title={bulkArchiveTrashDisabledReason || undefined}
                 />
                 <ActionBtn
                   onClick={clearThreadSelection}
@@ -2680,6 +2790,21 @@ export function InboxAgentPanel(props: InboxAgentPanelProps = {}) {
                   >
                     {selectedThread.provider}
                   </span>
+                  {selectedThread.provider === "agentmail" && (
+                    <span
+                      style={{
+                        padding: "3px 8px",
+                        borderRadius: "999px",
+                        background: "rgba(14,165,233,0.10)",
+                        color: "#0369a1",
+                        fontSize: "0.68rem",
+                        border: "1px solid rgba(14,165,233,0.20)",
+                      }}
+                      title="Manage AgentMail pods, domains, lists, and inbox keys in Settings > Integrations > AgentMail."
+                    >
+                      Settings → Integrations → AgentMail
+                    </span>
+                  )}
                   <span
                     style={{
                       padding: "3px 8px",
@@ -3695,6 +3820,15 @@ export function InboxAgentPanel(props: InboxAgentPanelProps = {}) {
               </div>
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "6px", marginBottom: "10px" }}>
                 <ActionBtn
+                  onClick={() => void createForwardAutomationFromCurrentContext()}
+                  icon={<Send size={13} />}
+                  label="Auto-forward…"
+                  disabled={busy || !selectedThread || selectedThread.provider !== "gmail"}
+                />
+                <div />
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "6px", marginBottom: "10px" }}>
+                <ActionBtn
                   onClick={() => {
                     if (!selectedThread) return;
                     setLabelSimilarName(selectedThread.subject?.slice(0, 120) || "My saved view");
@@ -3818,36 +3952,62 @@ export function InboxAgentPanel(props: InboxAgentPanelProps = {}) {
                               {automation.kind}
                               {" · "}
                               {automation.status}
+                              {automation.forward?.dryRun ? " · dry-run" : ""}
                               {automation.latestOutcome ? ` · ${automation.latestOutcome}` : ""}
                               {automation.nextRunAt ? ` · Next ${formatFullTime(automation.nextRunAt)}` : ""}
                               {automation.latestFireAt ? ` · Fired ${formatFullTime(automation.latestFireAt)}` : ""}
                             </div>
                           </div>
-                          <button
-                            type="button"
-                            onClick={() =>
-                              void runAction(async () => {
-                                if (automation.kind === "rule") {
-                                  await window.electronAPI.deleteMailboxRule(automation.id);
-                                } else {
-                                  await window.electronAPI.deleteMailboxSchedule(automation.id);
+                          <div style={{ display: "flex", gap: "6px", flexShrink: 0 }}>
+                            {automation.kind === "forward" && (
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  void runAction(async () => {
+                                    await window.electronAPI.runMailboxForward(automation.id);
+                                    await reloadAll(selectedThread.id);
+                                  })
                                 }
-                                await reloadAll(selectedThread.id);
-                              })
-                            }
-                            style={{
-                              border: "1px solid var(--color-border-subtle)",
-                              background: "var(--color-bg-secondary)",
-                              borderRadius: "999px",
-                              color: "var(--color-text-muted)",
-                              fontSize: "0.68rem",
-                              padding: "2px 8px",
-                              cursor: "pointer",
-                              flexShrink: 0,
-                            }}
-                          >
-                            Remove
-                          </button>
+                                style={{
+                                  border: "1px solid var(--color-border-subtle)",
+                                  background: "var(--color-bg-secondary)",
+                                  borderRadius: "999px",
+                                  color: "var(--color-text-muted)",
+                                  fontSize: "0.68rem",
+                                  padding: "2px 8px",
+                                  cursor: "pointer",
+                                }}
+                              >
+                                Run now
+                              </button>
+                            )}
+                            <button
+                              type="button"
+                              onClick={() =>
+                                void runAction(async () => {
+                                  if (automation.kind === "rule") {
+                                    await window.electronAPI.deleteMailboxRule(automation.id);
+                                  } else if (automation.kind === "forward") {
+                                    await window.electronAPI.deleteMailboxForward(automation.id);
+                                  } else {
+                                    await window.electronAPI.deleteMailboxSchedule(automation.id);
+                                  }
+                                  await reloadAll(selectedThread.id);
+                                })
+                              }
+                              style={{
+                                border: "1px solid var(--color-border-subtle)",
+                                background: "var(--color-bg-secondary)",
+                                borderRadius: "999px",
+                                color: "var(--color-text-muted)",
+                                fontSize: "0.68rem",
+                                padding: "2px 8px",
+                                cursor: "pointer",
+                              }}
+                            >
+                              Remove
+                            </button>
+                          </div>
                         </div>
                       </div>
                     ))}

--- a/src/shared/mailbox.ts
+++ b/src/shared/mailbox.ts
@@ -1,4 +1,4 @@
-export type MailboxProvider = "gmail" | "imap";
+export type MailboxProvider = "gmail" | "imap" | "agentmail";
 
 export type MailboxThreadSortOrder = "priority" | "recent";
 export type MailboxThreadMailboxView = "inbox" | "sent" | "all";
@@ -30,7 +30,7 @@ export type MailboxProposalStatus = "suggested" | "approved" | "applied" | "dism
 
 export type MailboxCommitmentState = "suggested" | "accepted" | "done" | "dismissed";
 
-export type MailboxAutomationKind = "rule" | "schedule" | "reminder";
+export type MailboxAutomationKind = "rule" | "schedule" | "reminder" | "forward";
 
 export type MailboxAutomationStatus = "active" | "paused" | "error" | "deleted";
 
@@ -462,6 +462,32 @@ export interface MailboxScheduleRecipe {
   enabled?: boolean;
 }
 
+export interface MailboxForwardRecipe {
+  name: string;
+  description?: string;
+  workspaceId?: string;
+  threadId?: string;
+  providerThreadId?: string;
+  schedule: import("../electron/cron/types").CronSchedule;
+  targetEmail: string;
+  allowedSenders: string[];
+  allowedDomains: string[];
+  excludedSenders?: string[];
+  excludedDomains?: string[];
+  subjectKeywords?: string[];
+  attachmentKeywords?: string[];
+  attachmentExtensions?: string[];
+  dryRun?: boolean;
+  maxMessagesPerRun?: number;
+  backfillDays?: number;
+  lookbackMinutes?: number;
+  gmailQuery?: string;
+  forwardedLabelName?: string;
+  rejectedLabelName?: string;
+  candidateLabelName?: string;
+  enabled?: boolean;
+}
+
 export interface MailboxAutomationRecord {
   id: string;
   workspaceId: string;
@@ -473,6 +499,7 @@ export interface MailboxAutomationRecord {
   source: "mailbox_event" | "cron";
   rule?: MailboxRuleRecipe;
   schedule?: MailboxScheduleRecipe;
+  forward?: MailboxForwardRecipe;
   backingTriggerId?: string;
   backingCronJobId?: string;
   latestOutcome?: string;


### PR DESCRIPTION
## Summary
- Adds AgentMail admin/client/realtime services and settings persistence.
- Adds AgentMail-backed mailbox sync/action support and workspace pod/inbox/domain/list/API-key schema.
- Adds mailbox forwarding automation support with registry/service helpers and UI settings.

## Validation
- npm run type-check
- npx vitest run src/electron/mailbox/__tests__/MailboxForwardingService.test.ts src/electron/mailbox/__tests__/MailboxAutomationRegistry.test.ts src/electron/mailbox/__tests__/MailboxService.test.ts

## Test note
The targeted mailbox Vitest command completed successfully, but these suites are currently skipped by their definitions: 46 skipped tests across 3 files.

## Notes
This is the next stack layer after merged PR #78.