### PR TITLE
feat(agents): add managed agents and routines

### DIFF
--- a/docs/core-automation.md
+++ b/docs/core-automation.md
@@ -12,10 +12,19 @@ The core runtime is only:
 
 Everything else is a surrounding surface:
 
+- `Routines` are the top-level saved automation product, but not part of the always-on cognitive core
 - `Mission Control` is the cockpit for observing and configuring the core
 - `Triggers` are ingress and signal normalization only
 - `Devices` are execution routing only
 - `Digital Twins` are optional persona presets and are not part of core ownership
+
+`Routines` now sit above several lower-level engines:
+
+- schedule triggers compile into `Scheduled Tasks`
+- API triggers compile into `Webhooks`
+- event triggers compile into `Event Triggers`
+
+That makes `Routines` the main user-facing automation abstraction without redefining the actual core runtime boundary.
 
 ## Ownership Model
 

--- a/src/electron/agents/autonomy-policy.ts
+++ b/src/electron/agents/autonomy-policy.ts
@@ -18,6 +18,8 @@ function normalizeApprovalTypes(value: unknown): ApprovalType[] | undefined {
         entry === "run_command" ||
         entry === "external_service" ||
         entry === "network_access" ||
+        entry === "data_export" ||
+        entry === "computer_use" ||
         entry === "delete_file" ||
         entry === "delete_multiple" ||
         entry === "bulk_rename",

--- a/src/electron/database/__tests__/TaskRepository.findAll.test.ts
+++ b/src/electron/database/__tests__/TaskRepository.findAll.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { TaskRepository } from "../repositories";
+
+describe("TaskRepository.findAll", () => {
+  it("uses latest-activity-first order by default", () => {
+    const { repository, prepare, all } = createRepository();
+
+    expect(repository.findAll(25, 50).map((task) => task.title)).toEqual(["Task"]);
+    expect(prepare).toHaveBeenCalledWith(
+      expect.stringContaining("ORDER BY COALESCE(updated_at, created_at) DESC, created_at DESC"),
+    );
+    expect(prepare).not.toHaveBeenCalledWith(expect.stringContaining("COALESCE(is_pinned"));
+    expect(all).toHaveBeenCalledWith(25, 50);
+  });
+
+  it("can prioritize pinned and active sessions for sidebar pagination", () => {
+    const { repository, prepare, all } = createRepository();
+
+    repository.findAll(100, 0, { prioritizeSidebar: true });
+
+    const sql = prepare.mock.calls[0]?.[0] || "";
+    expect(sql).toContain("COALESCE(is_pinned, 0) = 1");
+    expect(sql).toContain("status IN ('executing', 'planning', 'interrupted', 'paused', 'blocked')");
+    expect(sql).toContain("COALESCE(updated_at, created_at) DESC");
+    expect(sql).toContain("created_at DESC");
+    expect(all).toHaveBeenCalledWith(100, 0);
+  });
+
+  it("touches a task updated timestamp", () => {
+    const beforeRow = {
+      id: "task-1",
+      title: "Task",
+      prompt: "Task",
+      status: "pending",
+      workspace_id: "workspace-1",
+      created_at: 1,
+      updated_at: 1,
+      is_pinned: 0,
+    };
+    const afterRow = { ...beforeRow, updated_at: 1234 };
+    const get = vi.fn()
+      .mockReturnValueOnce(beforeRow)
+      .mockReturnValueOnce(afterRow);
+    const run = vi.fn(() => ({ changes: 1 }));
+    const prepare = vi.fn((sql: string) => {
+      if (sql.includes("SELECT * FROM tasks WHERE id = ?")) return { get };
+      return { run };
+    });
+    const repository = new TaskRepository({ prepare } as unknown as ConstructorParameters<
+      typeof TaskRepository
+    >[0]);
+
+    const touched = repository.touch("task-1", 1234);
+
+    expect(run).toHaveBeenCalledWith(1234, "task-1");
+    expect(touched?.updatedAt).toBe(1234);
+  });
+});
+
+function createRepository() {
+  const all = vi.fn(() => [
+    {
+      id: "task-1",
+      title: "Task",
+      prompt: "Task",
+      status: "pending",
+      workspace_id: "workspace-1",
+      created_at: 1,
+      updated_at: 1,
+      is_pinned: 0,
+    },
+  ]);
+  const prepare = vi.fn(() => ({ all }));
+  const repository = new TaskRepository({ prepare } as unknown as ConstructorParameters<
+    typeof TaskRepository
+  >[0]);
+
+  return { repository, prepare, all };
+}

--- a/src/electron/hooks/__tests__/server.test.ts
+++ b/src/electron/hooks/__tests__/server.test.ts
@@ -354,6 +354,44 @@ describe("HooksServer", () => {
       );
     });
 
+    it("accepts a route-specific token for mapped agent hooks and forwards workspaceId", async () => {
+      server.setHooksConfig({
+        enabled: true,
+        token: "test-secret-token",
+        path: "/hooks",
+        maxBodyBytes: 256 * 1024,
+        presets: [],
+        mappings: [
+          {
+            id: "routine-api",
+            token: "routine-token",
+            match: { path: "routines/test" },
+            action: "agent",
+            workspaceId: "ws-routine",
+            messageTemplate: "Routine payload: {{payload.text}}",
+          },
+        ],
+      });
+
+      const onAgent = vi.fn().mockResolvedValue({ taskId: "task-routine" });
+      server.setHandlers({ onAgent });
+
+      const response = await makeRequest(
+        "POST",
+        "/hooks/routines/test",
+        { text: "deploy alert" },
+        { Authorization: "Bearer routine-token" },
+      );
+
+      expect(response.statusCode).toBe(202);
+      expect(onAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Routine payload: deploy alert",
+          workspaceId: "ws-routine",
+        }),
+      );
+    });
+
     it("should call onTaskMessage handler", async () => {
       const onTaskMessage = vi.fn().mockResolvedValue(undefined);
       server.setHandlers({ onTaskMessage });

--- a/src/electron/hooks/agent-ingress.ts
+++ b/src/electron/hooks/agent-ingress.ts
@@ -2,7 +2,7 @@ import path from "path";
 import * as fs from "fs/promises";
 import * as os from "os";
 import { AgentDaemon } from "../agent/daemon";
-import { Workspace } from "../../shared/types";
+import { AgentConfig, Workspace } from "../../shared/types";
 import { WorkspaceRepository } from "../database/repositories";
 import {
   createScopedTempWorkspaceIdentity,
@@ -29,6 +29,7 @@ export interface AgentIngressAction {
   thinking?: string;
   timeoutSeconds?: number;
   workspaceId?: string;
+  agentConfig?: AgentConfig;
 }
 
 export interface AgentIngressOptions {
@@ -142,6 +143,7 @@ export class HookAgentIngress {
         source: "hook",
         agentConfig: {
           allowUserInput: false,
+          ...(action.agentConfig || {}),
         },
       });
 

--- a/src/electron/hooks/mappings.ts
+++ b/src/electron/hooks/mappings.ts
@@ -6,6 +6,7 @@
 
 import path from "path";
 import { pathToFileURL } from "url";
+import type { AgentConfig } from "../../shared/types";
 import {
   HooksConfig,
   HookMappingConfig,
@@ -34,9 +35,17 @@ type HookTransformResult = Partial<{
   allowUnsafeExternalContent: boolean;
   channel: HookMessageChannel;
   to: string;
+  workspaceId: string;
+  agentConfig: AgentConfig;
   model: string;
   thinking: string;
   timeoutSeconds: number;
+  metadata: Record<string, string>;
+  response: {
+    statusCode?: number;
+    message?: string;
+    includeTaskId?: boolean;
+  };
 }> | null;
 
 type HookTransformFn = (
@@ -164,6 +173,7 @@ function normalizeHookMapping(
     matchPath,
     matchSource,
     matchType,
+    token: mapping.token?.trim() || undefined,
     action,
     wakeMode,
     name: mapping.name,
@@ -174,9 +184,13 @@ function normalizeHookMapping(
     allowUnsafeExternalContent: mapping.allowUnsafeExternalContent,
     channel: mapping.channel,
     to: mapping.to,
+    workspaceId: mapping.workspaceId,
+    agentConfig: mapping.agentConfig,
     model: mapping.model,
     thinking: mapping.thinking,
     timeoutSeconds: mapping.timeoutSeconds,
+    metadata: mapping.metadata,
+    response: mapping.response,
     transform,
   };
 }
@@ -231,9 +245,13 @@ function buildActionFromMapping(
       allowUnsafeExternalContent: mapping.allowUnsafeExternalContent,
       channel: mapping.channel,
       to: renderOptional(mapping.to, ctx),
+      workspaceId: renderOptional(mapping.workspaceId, ctx),
+      agentConfig: mapping.agentConfig,
       model: renderOptional(mapping.model, ctx),
       thinking: renderOptional(mapping.thinking, ctx),
       timeoutSeconds: mapping.timeoutSeconds,
+      metadata: mapping.metadata,
+      response: mapping.response,
     },
   };
 }
@@ -278,9 +296,13 @@ function mergeAction(
         : baseAgent?.allowUnsafeExternalContent,
     channel: override.channel ?? baseAgent?.channel,
     to: override.to ?? baseAgent?.to,
+    workspaceId: override.workspaceId ?? baseAgent?.workspaceId,
+    agentConfig: override.agentConfig ?? baseAgent?.agentConfig,
     model: override.model ?? baseAgent?.model,
     thinking: override.thinking ?? baseAgent?.thinking,
     timeoutSeconds: override.timeoutSeconds ?? baseAgent?.timeoutSeconds,
+    metadata: override.metadata ?? baseAgent?.metadata,
+    response: override.response ?? baseAgent?.response,
   });
 }
 
@@ -373,6 +395,9 @@ function renderTemplate(template: string, ctx: HookMappingContext): string {
  */
 function resolveTemplateExpr(expr: string, ctx: HookMappingContext): unknown {
   if (expr === "path") return ctx.path;
+  if (expr === "payload") return ctx.payload;
+  if (expr === "headers") return ctx.headers;
+  if (expr === "query") return Object.fromEntries(ctx.url.searchParams.entries());
   if (expr === "now") return new Date().toISOString();
   if (expr.startsWith("headers.")) {
     return getByPath(ctx.headers, expr.slice("headers.".length));

--- a/src/electron/hooks/server.ts
+++ b/src/electron/hooks/server.ts
@@ -10,7 +10,7 @@ import crypto from "crypto";
 import {
   HooksConfig,
   HooksConfigResolved,
-  HookMappingResolved as _HookMappingResolved,
+  HookMappingResolved,
   HookMappingContext,
   HookAction as _HookAction,
   WakeHookPayload,
@@ -54,7 +54,14 @@ export interface HooksServerHandlers {
     thinking?: string;
     timeoutSeconds?: number;
     workspaceId?: string;
-  }) => Promise<{ taskId?: string }>;
+    agentConfig?: import("../../shared/types").AgentConfig;
+    metadata?: Record<string, string>;
+    response?: {
+      statusCode?: number;
+      message?: string;
+      includeTaskId?: boolean;
+    };
+  }) => Promise<{ taskId?: string; statusCode?: number; body?: Record<string, unknown> }>;
 
   /**
    * Handle a follow-up message to an existing task
@@ -252,6 +259,8 @@ export class HooksServer {
     // Extract the hook path after base
     const hookPath = url.pathname.slice(basePath.length).replace(/^\/+/, "").replace(/\/+$/, "");
 
+    const mappedToken = this.findMappedToken(hookPath, req.method || "GET");
+
     // Emit request event
     this.emitEvent({
       action: "request",
@@ -262,7 +271,7 @@ export class HooksServer {
 
     // Verify authentication
     const tokenResult = this.extractHookToken(req, url);
-    if (!this.verifyToken(tokenResult.token)) {
+    if (!this.verifyToken(tokenResult.token, mappedToken)) {
       this.sendJsonResponse(res, 401, { success: false, error: "Invalid or missing token" });
       return;
     }
@@ -362,13 +371,16 @@ export class HooksServer {
       thinking: body.thinking?.trim(),
       timeoutSeconds: body.timeoutSeconds,
       workspaceId: body.workspaceId?.trim(),
+      agentConfig: body.agentConfig,
+      metadata: body.metadata,
+      response: body.response,
     };
 
     if (this.handlers.onAgent) {
       try {
         const result = await this.handlers.onAgent(agentPayload);
         // Return 202 Accepted for async operation
-        this.sendJsonResponse(res, 202, { success: true, taskId: result.taskId });
+        this.sendJsonResponse(res, result.statusCode ?? 202, result.body ?? { success: true, taskId: result.taskId });
       } catch (error) {
         console.error("[HooksServer] Agent handler error:", error);
         this.sendJsonResponse(res, 500, { success: false, error: String(error) });
@@ -567,11 +579,24 @@ export class HooksServer {
             deliver: action.deliver,
             channel: action.channel,
             to: action.to,
+            workspaceId: action.workspaceId,
+            agentConfig: action.agentConfig,
             model: action.model,
             thinking: action.thinking,
             timeoutSeconds: action.timeoutSeconds,
+            metadata: action.metadata,
+            response: action.response,
           });
-          this.sendJsonResponse(res, 202, { success: true, taskId: result.taskId });
+          this.sendJsonResponse(
+            res,
+            result.statusCode ?? action.response?.statusCode ?? 202,
+            result.body ??
+              buildHookSuccessBody({
+                taskId: result.taskId,
+                message: action.response?.message,
+                includeTaskId: action.response?.includeTaskId,
+              }),
+          );
         } catch (error) {
           console.error("[HooksServer] Agent handler error:", error);
           this.sendJsonResponse(res, 500, { success: false, error: String(error) });
@@ -612,15 +637,28 @@ export class HooksServer {
   /**
    * Verify the provided token
    */
-  private verifyToken(provided: string | undefined): boolean {
-    if (!this.hooksConfig?.token) return false;
+  private verifyToken(provided: string | undefined, override?: string): boolean {
+    const expectedToken = override ?? this.hooksConfig?.token;
+    if (!expectedToken) return false;
     if (!provided) return false;
 
     // Use timing-safe comparison
-    const expected = Buffer.from(this.hooksConfig.token);
+    const expected = Buffer.from(expectedToken);
     const actual = Buffer.from(provided);
     if (expected.length !== actual.length) return false;
     return crypto.timingSafeEqual(expected, actual);
+  }
+
+  private findMappedToken(hookPath: string, method: string): string | undefined {
+    if (method.toUpperCase() !== "POST") return undefined;
+    const mapping = this.findMappingByPath(hookPath);
+    return mapping?.token;
+  }
+
+  private findMappingByPath(hookPath: string): HookMappingResolved | undefined {
+    if (!this.hooksConfig?.mappings?.length) return undefined;
+    const normalizedPath = hookPath.replace(/^\/+/, "").replace(/\/+$/, "");
+    return this.hooksConfig.mappings.find((mapping) => mapping.matchPath === normalizedPath);
   }
 
   /**
@@ -821,4 +859,19 @@ export class HooksServer {
       }
     }
   }
+}
+
+function buildHookSuccessBody(params: {
+  taskId?: string;
+  message?: string;
+  includeTaskId?: boolean;
+}): Record<string, unknown> {
+  const body: Record<string, unknown> = { success: true };
+  if (params.message) {
+    body.message = params.message;
+  }
+  if (params.includeTaskId ?? true) {
+    body.taskId = params.taskId;
+  }
+  return body;
 }

--- a/src/electron/hooks/types.ts
+++ b/src/electron/hooks/types.ts
@@ -4,7 +4,7 @@
  * Webhook ingress for wake and isolated agent runs.
  */
 
-import type { ChannelType } from "../../shared/types";
+import type { AgentConfig, ChannelType } from "../../shared/types";
 
 // ============ Hook Configuration ============
 
@@ -59,6 +59,7 @@ export interface HookMappingConfig {
     source?: string;
     type?: string;
   };
+  token?: string;
   action?: "wake" | "agent";
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
@@ -69,9 +70,17 @@ export interface HookMappingConfig {
   allowUnsafeExternalContent?: boolean;
   channel?: HookMessageChannel;
   to?: string;
+  workspaceId?: string;
+  agentConfig?: AgentConfig;
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  metadata?: Record<string, string>;
+  response?: {
+    statusCode?: number;
+    message?: string;
+    includeTaskId?: boolean;
+  };
   transform?: {
     module: string;
     export?: string;
@@ -87,6 +96,7 @@ export interface HookMappingResolved {
   matchPath?: string;
   matchSource?: string;
   matchType?: string;
+  token?: string;
   action: "wake" | "agent";
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
@@ -97,9 +107,17 @@ export interface HookMappingResolved {
   allowUnsafeExternalContent?: boolean;
   channel?: HookMessageChannel;
   to?: string;
+  workspaceId?: string;
+  agentConfig?: AgentConfig;
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  metadata?: Record<string, string>;
+  response?: {
+    statusCode?: number;
+    message?: string;
+    includeTaskId?: boolean;
+  };
   transform?: HookMappingTransformResolved;
 }
 
@@ -127,6 +145,13 @@ export interface AgentHookPayload {
   thinking?: string;
   timeoutSeconds?: number;
   workspaceId?: string;
+  agentConfig?: AgentConfig;
+  metadata?: Record<string, string>;
+  response?: {
+    statusCode?: number;
+    message?: string;
+    includeTaskId?: boolean;
+  };
 }
 
 export interface TaskMessageHookPayload {
@@ -157,9 +182,17 @@ export type HookAction =
       allowUnsafeExternalContent?: boolean;
       channel?: HookMessageChannel;
       to?: string;
+      workspaceId?: string;
+      agentConfig?: AgentConfig;
       model?: string;
       thinking?: string;
       timeoutSeconds?: number;
+      metadata?: Record<string, string>;
+      response?: {
+        statusCode?: number;
+        message?: string;
+        includeTaskId?: boolean;
+      };
     };
 
 export type HookMappingResult =

--- a/src/electron/ipc/routine-handlers.ts
+++ b/src/electron/ipc/routine-handlers.ts
@@ -1,0 +1,40 @@
+import { ipcMain } from "electron";
+import { IPC_CHANNELS } from "../../shared/types";
+import { RoutineService } from "../routines/service";
+
+export function setupRoutineHandlers(routineService: RoutineService): void {
+  ipcMain.handle(IPC_CHANNELS.ROUTINE_LIST, async () => {
+    return routineService.list();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ROUTINE_GET, async (_, id: string) => {
+    return routineService.get(id);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ROUTINE_LIST_RUNS, async (_, payload?: { routineId?: string; limit?: number }) => {
+    return routineService.listRuns(payload?.routineId, payload?.limit);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ROUTINE_CREATE, async (_, input) => {
+    return routineService.create(input);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ROUTINE_UPDATE, async (_, payload: { id: string; updates: Any }) => {
+    return routineService.update(payload.id, payload.updates);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ROUTINE_REMOVE, async (_, id: string) => {
+    return routineService.remove(id);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ROUTINE_RUN_NOW, async (_, id: string) => {
+    return routineService.runNow(id);
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.ROUTINE_REGENERATE_API_TOKEN,
+    async (_, payload: { routineId: string; triggerId: string }) => {
+      return routineService.regenerateApiToken(payload.routineId, payload.triggerId);
+    },
+  );
+}

--- a/src/electron/managed/AgentTemplateService.ts
+++ b/src/electron/managed/AgentTemplateService.ts
@@ -1,0 +1,13 @@
+import type { AgentTemplate } from "../../shared/types";
+import { BUILTIN_AGENT_TEMPLATES } from "./agent-templates";
+
+export class AgentTemplateService {
+  list(): AgentTemplate[] {
+    return [...BUILTIN_AGENT_TEMPLATES];
+  }
+
+  get(id: string): AgentTemplate | undefined {
+    return BUILTIN_AGENT_TEMPLATES.find((template) => template.id === id);
+  }
+}
+

--- a/src/electron/managed/ImageGenProfileService.ts
+++ b/src/electron/managed/ImageGenProfileService.ts
@@ -1,0 +1,182 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { randomUUID } from "crypto";
+import mime from "mime-types";
+import type { ImageGenProfile, ImageGenReferencePhoto } from "../../shared/types";
+import { getUserDataDir } from "../utils/user-data-dir";
+
+type StoredProfiles = {
+  profiles: ImageGenProfile[];
+};
+
+function sanitizeFileName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, "-");
+}
+
+export class ImageGenProfileService {
+  private getRootDir(): string {
+    return path.join(getUserDataDir(), "agents", "image-profiles");
+  }
+
+  private getManifestPath(): string {
+    return path.join(this.getRootDir(), "profiles.json");
+  }
+
+  private async ensureRoot(): Promise<void> {
+    await fs.mkdir(this.getRootDir(), { recursive: true });
+  }
+
+  private async readStore(): Promise<StoredProfiles> {
+    await this.ensureRoot();
+    try {
+      const raw = await fs.readFile(this.getManifestPath(), "utf-8");
+      const parsed = JSON.parse(raw) as StoredProfiles;
+      return {
+        profiles: Array.isArray(parsed?.profiles) ? parsed.profiles : [],
+      };
+    } catch {
+      return { profiles: [] };
+    }
+  }
+
+  private async writeStore(store: StoredProfiles): Promise<void> {
+    await this.ensureRoot();
+    await fs.writeFile(this.getManifestPath(), JSON.stringify(store, null, 2), "utf-8");
+  }
+
+  private async importReferencePhotos(
+    profileId: string,
+    filePaths: string[],
+  ): Promise<ImageGenReferencePhoto[]> {
+    const profileDir = path.join(this.getRootDir(), profileId);
+    await fs.mkdir(profileDir, { recursive: true });
+    const photos: ImageGenReferencePhoto[] = [];
+    for (const originalPath of filePaths) {
+      const resolved = path.resolve(originalPath);
+      const stats = await fs.stat(resolved);
+      if (!stats.isFile()) continue;
+      const ext = path.extname(resolved) || ".img";
+      const fileName = sanitizeFileName(path.basename(resolved, ext));
+      const id = randomUUID();
+      const nextPath = path.join(profileDir, `${fileName}-${id}${ext}`);
+      await fs.copyFile(resolved, nextPath);
+      photos.push({
+        id,
+        path: nextPath,
+        name: path.basename(resolved),
+        mimeType: (mime.lookup(resolved) || undefined) as string | undefined,
+        size: stats.size,
+      });
+    }
+    return photos;
+  }
+
+  async list(): Promise<ImageGenProfile[]> {
+    const store = await this.readStore();
+    return store.profiles.sort((left, right) => {
+      if (left.isDefault && !right.isDefault) return -1;
+      if (right.isDefault && !left.isDefault) return 1;
+      return right.updatedAt - left.updatedAt;
+    });
+  }
+
+  async create(input: {
+    name: string;
+    description?: string;
+    isDefault?: boolean;
+    referencePhotoPaths?: string[];
+  }): Promise<ImageGenProfile> {
+    const store = await this.readStore();
+    const now = Date.now();
+    const profile: ImageGenProfile = {
+      id: randomUUID(),
+      name: input.name.trim(),
+      description: input.description?.trim() || undefined,
+      isDefault: !!input.isDefault,
+      referencePhotos: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    profile.referencePhotos = await this.importReferencePhotos(
+      profile.id,
+      input.referencePhotoPaths || [],
+    );
+    if (profile.isDefault) {
+      for (const existing of store.profiles) existing.isDefault = false;
+    }
+    store.profiles.unshift(profile);
+    await this.writeStore(store);
+    return profile;
+  }
+
+  async update(
+    id: string,
+    patch: {
+      name?: string;
+      description?: string;
+      isDefault?: boolean;
+      addReferencePhotoPaths?: string[];
+      removeReferencePhotoIds?: string[];
+    },
+  ): Promise<ImageGenProfile | null> {
+    const store = await this.readStore();
+    const profile = store.profiles.find((entry) => entry.id === id);
+    if (!profile) return null;
+    if (patch.name !== undefined) profile.name = patch.name.trim();
+    if (patch.description !== undefined) {
+      profile.description = patch.description.trim() || undefined;
+    }
+    if (patch.isDefault !== undefined) {
+      if (patch.isDefault) {
+        for (const existing of store.profiles) existing.isDefault = false;
+      }
+      profile.isDefault = patch.isDefault;
+    }
+    if (patch.removeReferencePhotoIds?.length) {
+      const toRemove = new Set(patch.removeReferencePhotoIds);
+      const removed = profile.referencePhotos.filter((photo) => toRemove.has(photo.id));
+      profile.referencePhotos = profile.referencePhotos.filter((photo) => !toRemove.has(photo.id));
+      await Promise.all(
+        removed.map(async (photo) => {
+          try {
+            await fs.unlink(photo.path);
+          } catch {
+            // Ignore stale file cleanup failures.
+          }
+        }),
+      );
+    }
+    if (patch.addReferencePhotoPaths?.length) {
+      const imported = await this.importReferencePhotos(id, patch.addReferencePhotoPaths);
+      profile.referencePhotos.push(...imported);
+    }
+    profile.updatedAt = Date.now();
+    await this.writeStore(store);
+    return profile;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const store = await this.readStore();
+    const index = store.profiles.findIndex((entry) => entry.id === id);
+    if (index === -1) return false;
+    const [removed] = store.profiles.splice(index, 1);
+    if (removed) {
+      try {
+        await fs.rm(path.join(this.getRootDir(), removed.id), { recursive: true, force: true });
+      } catch {
+        // Ignore stale profile directory cleanup failures.
+      }
+    }
+    if (!store.profiles.some((entry) => entry.isDefault) && store.profiles[0]) {
+      store.profiles[0].isDefault = true;
+      store.profiles[0].updatedAt = Date.now();
+    }
+    await this.writeStore(store);
+    return true;
+  }
+
+  async get(id: string): Promise<ImageGenProfile | null> {
+    const store = await this.readStore();
+    return store.profiles.find((entry) => entry.id === id) || null;
+  }
+}

--- a/src/electron/managed/ManagedSessionService.ts
+++ b/src/electron/managed/ManagedSessionService.ts
@@ -1,5 +1,41 @@
-import { randomUUID } from "crypto";
-import type { AgentConfig, InputRequestResponse, ManagedSessionEventType } from "../../shared/types";
+import { createHash, randomUUID } from "crypto";
+import * as fs from "fs/promises";
+import * as path from "path";
+import type {
+  AgentConfig,
+  AgentRole,
+  AgentWorkspaceMembership,
+  AgentWorkspacePermissionSnapshot,
+  ApprovalType,
+  AgentToolRestrictions,
+  ConvertAgentRoleToManagedAgentRequest,
+  ConvertAutomationProfileToManagedAgentRequest,
+  CreateManagedAgentRoutineRequest,
+  AudioSummaryConfig,
+  AudioSummaryResult,
+  GatewayContextType,
+  InputRequestResponse,
+  UpdateManagedAgentRoutineRequest,
+  ManagedAgentAuditEntry,
+  ManagedAgentChannelTarget,
+  ManagedAgentConversionResult,
+  ManagedAgentFileRef,
+  ManagedAgentInsights,
+  ManagedAgentLinkedRoutineRef,
+  ManagedAgentApprovalPolicy,
+  ManagedAgentMemoryConfig,
+  ManagedAgentRoutineRecord,
+  ManagedAgentRoutineTriggerConfig,
+  ManagedAgentRuntimeToolCatalog,
+  ManagedAgentRuntimeToolCatalogEntry,
+  ManagedAgentScheduleConfig,
+  ManagedAgentStudioConfig,
+  ManagedAgentToolFamily,
+  ManagedSessionWorkpaper,
+  ManagedSessionEventType,
+  OperationalAutonomyPolicy,
+  Workspace,
+} from "../../shared/types";
 import type {
   ManagedAgent,
   ManagedAgentVersion,
@@ -13,21 +49,30 @@ import type {
   TaskEvent,
 } from "../../shared/types";
 import { deriveCanonicalTaskStatus, isTerminalTaskStatus } from "../../shared/task-status";
+import { isComputerUseToolName } from "../../shared/computer-use-contract";
 import type { AgentDaemon } from "../agent/daemon";
+import type { LLMTool } from "../agent/llm/types";
+import { ToolRegistry } from "../agent/tools/registry";
 import { AgentRoleRepository } from "../agents/AgentRoleRepository";
+import { AutomationProfileRepository } from "../agents/AutomationProfileRepository";
 import { AgentTeamItemRepository } from "../agents/AgentTeamItemRepository";
 import { AgentTeamMemberRepository } from "../agents/AgentTeamMemberRepository";
 import { AgentTeamRepository } from "../agents/AgentTeamRepository";
 import { AgentTeamRunRepository } from "../agents/AgentTeamRunRepository";
 import {
   ArtifactRepository,
+  ChannelRepository,
   InputRequestRepository,
   TaskEventRepository,
   TaskRepository,
   WorkspaceRepository,
 } from "../database/repositories";
+import { createMediaPlaybackUrl } from "../media";
 import { MCPSettingsManager } from "../mcp/settings";
 import { ManagedAccountManager } from "../accounts/managed-account-manager";
+import { getVoiceService } from "../voice/VoiceService";
+import { ImageGenProfileService } from "./ImageGenProfileService";
+import type { Routine, RoutineTrigger } from "../routines/types";
 import {
   ManagedAgentRepository,
   ManagedAgentVersionRepository,
@@ -38,6 +83,116 @@ import {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function slugifyName(value: string): string {
+  const normalized = String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "managed-agent";
+}
+
+function getStudioConfig(version: ManagedAgentVersion): ManagedAgentStudioConfig | undefined {
+  const metadata = isRecord(version.metadata) ? version.metadata : undefined;
+  const studio = metadata?.studio;
+  return isRecord(studio) ? (studio as ManagedAgentStudioConfig) : undefined;
+}
+
+function roleMirrorsManagedAgent(role: AgentRole | undefined, agentId: string): boolean {
+  if (!role?.soul) return false;
+  try {
+    const parsed = JSON.parse(role.soul) as unknown;
+    return isRecord(parsed) && parsed.managedAgentId === agentId;
+  } catch {
+    return false;
+  }
+}
+
+function setStudioConfigMetadata(
+  metadata: Record<string, unknown> | undefined,
+  studio: ManagedAgentStudioConfig,
+): Record<string, unknown> {
+  return {
+    ...(metadata || {}),
+    studio,
+  };
+}
+
+function listManagedFileRefs(
+  fileRefs: ManagedAgentFileRef[] | undefined,
+  environment: ManagedEnvironment | undefined,
+): string[] {
+  const fromStudio = (fileRefs || []).map((file) => file.path).filter(Boolean);
+  const fromEnvironment = environment?.config.filePaths || [];
+  return Array.from(new Set([...fromStudio, ...fromEnvironment]));
+}
+
+function toMemoryToolRestrictions(
+  memoryConfig?: ManagedAgentMemoryConfig,
+): AgentToolRestrictions | undefined {
+  if (memoryConfig?.mode !== "disabled") return undefined;
+  return {
+    deniedTools: [
+      "search_quotes",
+      "search_sessions",
+      "memory_topics_load",
+      "memory_save",
+      "memory_curate",
+      "memory_curated_read",
+      "supermemory_profile",
+      "supermemory_search",
+      "supermemory_remember",
+      "supermemory_forget",
+    ],
+  };
+}
+
+function toManagedApprovalTypes(
+  approvalPolicy?: ManagedAgentApprovalPolicy,
+): ApprovalType[] {
+  const requested = new Set(approvalPolicy?.requireApprovalFor || []);
+  const allowed = new Set<ApprovalType>();
+
+  if (approvalPolicy?.autoApproveReadOnly !== false) {
+    allowed.add("network_access");
+  }
+  if (!requested.has("edit spreadsheet")) {
+    allowed.add("data_export");
+  }
+  return Array.from(allowed);
+}
+
+function toManagedAutonomyPolicy(
+  approvalPolicy?: ManagedAgentApprovalPolicy,
+): OperationalAutonomyPolicy | undefined {
+  if (!approvalPolicy) return undefined;
+  return {
+    preset: "manual",
+    autoApproveTypes: toManagedApprovalTypes(approvalPolicy),
+    allowUserInput: true,
+    pauseForRequiredDecision: true,
+  };
+}
+
+function deriveCapabilities(
+  templateId: string | undefined,
+): import("../../shared/types").AgentCapability[] {
+  switch (templateId) {
+    case "team-chat-qna":
+    case "customer-reply-drafter":
+    case "inbox-follow-up-assistant":
+      return ["communicate", "research", "document"];
+    case "morning-planner":
+    case "chief-of-staff":
+      return ["manage", "plan", "communicate"];
+    case "bug-triage":
+      return ["review", "analyze", "document"];
+    case "research-analyst":
+      return ["research", "analyze", "document"];
+    default:
+      return ["research", "plan", "document"];
+  }
 }
 
 const MANAGED_EVENT_MAX_STRING_CHARS = 2000;
@@ -169,12 +324,252 @@ export function resolveManagedAllowedMcpTools(
   return Array.from(out);
 }
 
+function cloneWorkspaceForManagedEnvironment(
+  workspace: Workspace,
+  environment: ManagedEnvironment,
+): Workspace {
+  return {
+    ...workspace,
+    permissions: {
+      ...workspace.permissions,
+      shell: Boolean(workspace.permissions.shell && environment.config.enableShell),
+    },
+  };
+}
+
+function deriveManagedToolFamily(tool: LLMTool): ManagedAgentToolFamily | undefined {
+  const toolName = tool.name;
+  const capabilityTags = tool.runtime?.capabilityTags || [];
+
+  if (toolName === "run_command" || capabilityTags.includes("shell")) return "shell";
+  if (toolName.startsWith("browser_") || capabilityTags.includes("browser")) return "browser";
+  if (isComputerUseToolName(toolName)) return "computer-use";
+  if (
+    toolName.startsWith("memory_") ||
+    toolName.startsWith("supermemory_") ||
+    toolName === "search_memories" ||
+    toolName === "search_quotes" ||
+    toolName === "search_sessions" ||
+    capabilityTags.includes("memory")
+  ) {
+    return "memory";
+  }
+  if (
+    toolName === "generate_image" ||
+    toolName === "analyze_image" ||
+    toolName === "batch_image_process" ||
+    toolName.startsWith("canvas_") ||
+    toolName.startsWith("visual_") ||
+    toolName.startsWith("video_")
+  ) {
+    return "images";
+  }
+  if (
+    toolName === "read_pdf_visual" ||
+    toolName.startsWith("document_") ||
+    toolName.startsWith("pdf_") ||
+    toolName.startsWith("docx_")
+  ) {
+    return "documents";
+  }
+  if (
+    toolName.startsWith("read_") ||
+    toolName.startsWith("write_") ||
+    toolName.startsWith("edit_") ||
+    toolName.startsWith("list_") ||
+    toolName.startsWith("get_file_") ||
+    toolName.startsWith("search_files") ||
+    toolName === "glob" ||
+    toolName === "grep" ||
+    toolName.startsWith("copy_") ||
+    toolName.startsWith("rename_") ||
+    toolName.startsWith("create_directory") ||
+    toolName.startsWith("delete_file") ||
+    toolName.startsWith("scratchpad_") ||
+    toolName.startsWith("git_")
+  ) {
+    return "files";
+  }
+  if (
+    toolName === "web_fetch" ||
+    toolName === "web_search" ||
+    toolName === "http_request" ||
+    tool.runtime?.resultKind === "search"
+  ) {
+    return "search";
+  }
+  if (
+    toolName.startsWith("mcp_") ||
+    toolName.endsWith("_action") ||
+    toolName === "voice_call" ||
+    toolName.startsWith("gmail_") ||
+    toolName.startsWith("mailbox_") ||
+    toolName.startsWith("channel_") ||
+    toolName.startsWith("google_calendar_") ||
+    toolName.startsWith("apple_calendar_") ||
+    toolName.startsWith("apple_reminders_") ||
+    toolName.startsWith("email_")
+  ) {
+    return "communication";
+  }
+  return undefined;
+}
+
+function toolMatchesManagedFamily(tool: LLMTool, family: ManagedAgentToolFamily): boolean {
+  return deriveManagedToolFamily(tool) === family;
+}
+
+function isToolEnabledForManagedEnvironment(
+  tool: LLMTool,
+  environment: ManagedEnvironment,
+  allowedMcpTools: Set<string>,
+): boolean {
+  if (environment.config.enableBrowser === false && tool.name.startsWith("browser_")) {
+    return false;
+  }
+  if (!environment.config.enableComputerUse && isComputerUseToolName(tool.name)) {
+    return false;
+  }
+  if (tool.name.startsWith("mcp_") && allowedMcpTools.size > 0 && !allowedMcpTools.has(tool.name)) {
+    return false;
+  }
+  const allowedFamilies = environment.config.allowedToolFamilies || [];
+  if (allowedFamilies.length === 0) return true;
+  return allowedFamilies.some((family) => toolMatchesManagedFamily(tool, family));
+}
+
+function deriveApprovalBehavior(
+  tool: LLMTool,
+  approvalType: ApprovalType | null,
+  autoApproveTypes: Set<ApprovalType>,
+): ManagedAgentRuntimeToolCatalogEntry["approvalBehavior"] {
+  if (approvalType) {
+    return autoApproveTypes.has(approvalType) ? "auto_approve" : "require_approval";
+  }
+  if (tool.runtime?.approvalKind === "workspace_policy") {
+    return "workspace_policy";
+  }
+  return "no_approval";
+}
+
+function mapRuntimeToolCatalogEntry(
+  tool: LLMTool,
+  approvalType: ApprovalType | null,
+  autoApproveTypes: Set<ApprovalType>,
+  mcpServerName: string | null,
+): ManagedAgentRuntimeToolCatalogEntry {
+  return {
+    name: tool.name,
+    description: tool.description,
+    readOnly: tool.runtime?.readOnly ?? false,
+    approvalKind: tool.runtime?.approvalKind || "none",
+    approvalType,
+    approvalBehavior: deriveApprovalBehavior(tool, approvalType, autoApproveTypes),
+    sideEffectLevel: tool.runtime?.sideEffectLevel || "none",
+    resultKind: tool.runtime?.resultKind || "generic",
+    capabilityTags: tool.runtime?.capabilityTags || [],
+    exposure: tool.runtime?.exposure || "conditional",
+    family: deriveManagedToolFamily(tool),
+    mcpServerName,
+  };
+}
+
+function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function normalizePrincipalId(value?: string): string {
+  return value?.trim() || "local-user";
+}
+
+function getWorkspaceRoleRank(role: import("../../shared/types").AgentWorkspaceRole): number {
+  switch (role) {
+    case "viewer":
+      return 0;
+    case "operator":
+      return 1;
+    case "builder":
+      return 2;
+    case "publisher":
+      return 3;
+    case "admin":
+    default:
+      return 4;
+  }
+}
+
+function getPermissionSnapshot(
+  workspaceId: string,
+  principalId: string,
+  role: import("../../shared/types").AgentWorkspaceRole | undefined,
+): AgentWorkspacePermissionSnapshot {
+  if (!role) {
+    return {
+      workspaceId,
+      principalId,
+      role: "viewer",
+      canViewAgents: false,
+      canRunAgents: false,
+      canResumeSessions: false,
+      canAnswerApprovals: false,
+      canEditDrafts: false,
+      canManageEnvironments: false,
+      canPublishAgents: false,
+      canManageRoutines: false,
+      canManageMemberships: false,
+      canAuditAgents: false,
+    };
+  }
+  const rank = getWorkspaceRoleRank(role);
+  return {
+    workspaceId,
+    principalId,
+    role,
+    canViewAgents: rank >= 0,
+    canRunAgents: rank >= 1,
+    canResumeSessions: rank >= 1,
+    canAnswerApprovals: rank >= 1,
+    canEditDrafts: rank >= 2,
+    canManageEnvironments: rank >= 2,
+    canPublishAgents: rank >= 3,
+    canManageRoutines: rank >= 3,
+    canManageMemberships: rank >= 4,
+    canAuditAgents: rank >= 4,
+  };
+}
+
+function summarizeRoutineTrigger(trigger: ManagedAgentRoutineTriggerConfig): string {
+  switch (trigger.type) {
+    case "schedule":
+      return trigger.cadenceMinutes ? `Every ${trigger.cadenceMinutes} min` : "Scheduled";
+    case "api":
+      return trigger.path ? `API: ${trigger.path}` : "API trigger";
+    case "channel_event":
+      return trigger.channelType || "Channel event";
+    case "mailbox_event":
+      return trigger.provider || "Mailbox event";
+    case "github_event":
+      return trigger.repository || "GitHub event";
+    case "connector_event":
+      return trigger.connectorId || "Connector event";
+    case "manual":
+    default:
+      return "Manual";
+  }
+}
+
 export class ManagedSessionService {
   private readonly taskRepo: TaskRepository;
   private readonly taskEventRepo: TaskEventRepository;
   private readonly workspaceRepo: WorkspaceRepository;
   private readonly artifactRepo: ArtifactRepository;
   private readonly inputRequestRepo: InputRequestRepository;
+  private readonly channelRepo: ChannelRepository;
   private readonly managedAgentRepo: ManagedAgentRepository;
   private readonly managedAgentVersionRepo: ManagedAgentVersionRepository;
   private readonly managedEnvironmentRepo: ManagedEnvironmentRepository;
@@ -185,16 +580,20 @@ export class ManagedSessionService {
   private readonly teamRunRepo: AgentTeamRunRepository;
   private readonly teamItemRepo: AgentTeamItemRepository;
   private readonly agentRoleRepo: AgentRoleRepository;
+  private readonly automationProfileRepo: AutomationProfileRepository;
+  private readonly imageGenProfileService: ImageGenProfileService;
 
   constructor(
     private readonly db: import("better-sqlite3").Database,
     private readonly agentDaemon: AgentDaemon,
   ) {
+    this.ensureGovernanceSchema();
     this.taskRepo = new TaskRepository(db);
     this.taskEventRepo = new TaskEventRepository(db);
     this.workspaceRepo = new WorkspaceRepository(db);
     this.artifactRepo = new ArtifactRepository(db);
     this.inputRequestRepo = new InputRequestRepository(db);
+    this.channelRepo = new ChannelRepository(db);
     this.managedAgentRepo = new ManagedAgentRepository(db);
     this.managedAgentVersionRepo = new ManagedAgentVersionRepository(db);
     this.managedEnvironmentRepo = new ManagedEnvironmentRepository(db);
@@ -205,6 +604,263 @@ export class ManagedSessionService {
     this.teamRunRepo = new AgentTeamRunRepository(db);
     this.teamItemRepo = new AgentTeamItemRepository(db);
     this.agentRoleRepo = new AgentRoleRepository(db);
+    this.automationProfileRepo = new AutomationProfileRepository(db);
+    this.imageGenProfileService = new ImageGenProfileService();
+  }
+
+  private ensureGovernanceSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_workspace_memberships (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        principal_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_workspace_memberships_unique
+        ON agent_workspace_memberships(workspace_id, principal_id);
+      CREATE TABLE IF NOT EXISTS managed_agent_audit (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        workspace_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        metadata_json TEXT,
+        created_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_managed_agent_audit_agent
+        ON managed_agent_audit(agent_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_managed_agent_audit_workspace
+        ON managed_agent_audit(workspace_id, created_at DESC);
+    `);
+  }
+
+  private resolveWorkspaceIdForAgent(agentId: string): string | undefined {
+    const detail = this.getAgent(agentId);
+    const studio = detail?.currentVersion ? getStudioConfig(detail.currentVersion) : undefined;
+    const environmentId = studio?.defaultEnvironmentId;
+    if (environmentId) {
+      const environment = this.getEnvironment(environmentId);
+      if (environment?.config.workspaceId) return environment.config.workspaceId;
+    }
+    const latestSession = this.listSessions({ limit: 200 }).find((session) => session.agentId === agentId);
+    return latestSession?.workspaceId;
+  }
+
+  private getStoredWorkspaceRole(
+    workspaceId: string,
+    principalId = normalizePrincipalId(),
+  ): import("../../shared/types").AgentWorkspaceRole | undefined {
+    this.ensureWorkspaceMembershipSeeded(workspaceId);
+    const row = this.db
+      .prepare(
+        `SELECT role
+         FROM agent_workspace_memberships
+         WHERE workspace_id = ? AND principal_id = ?`,
+      )
+      .get(workspaceId, principalId) as { role?: string } | undefined;
+    const role = row?.role;
+    if (
+      role === "viewer" ||
+      role === "operator" ||
+      role === "builder" ||
+      role === "publisher" ||
+      role === "admin"
+    ) {
+      return role;
+    }
+    return undefined;
+  }
+
+  private ensureWorkspaceMembershipSeeded(workspaceId: string): void {
+    const membershipCount = this.db
+      .prepare(
+        `SELECT COUNT(*) AS count
+         FROM agent_workspace_memberships
+         WHERE workspace_id = ?`,
+      )
+      .get(workspaceId) as { count?: number } | undefined;
+    if ((membershipCount?.count || 0) > 0) return;
+    const now = Date.now();
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO agent_workspace_memberships
+         (id, workspace_id, principal_id, role, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(randomUUID(), workspaceId, normalizePrincipalId(), "admin", now, now);
+  }
+
+  private assertWorkspacePermission(
+    workspaceId: string,
+    check:
+      | "canViewAgents"
+      | "canRunAgents"
+      | "canResumeSessions"
+      | "canAnswerApprovals"
+      | "canEditDrafts"
+      | "canManageEnvironments"
+      | "canPublishAgents"
+      | "canManageRoutines"
+      | "canManageMemberships"
+      | "canAuditAgents",
+    principalId = normalizePrincipalId(),
+  ): void {
+    const snapshot = this.getMyWorkspacePermissions(workspaceId, principalId);
+    if (!snapshot[check]) {
+      throw new Error(`Workspace role ${snapshot.role} does not permit ${check}`);
+    }
+  }
+
+  getMyWorkspacePermissions(
+    workspaceId: string,
+    _principalId = normalizePrincipalId(),
+  ): AgentWorkspacePermissionSnapshot {
+    const principalId = normalizePrincipalId();
+    return getPermissionSnapshot(
+      workspaceId,
+      principalId,
+      this.getStoredWorkspaceRole(workspaceId, principalId),
+    );
+  }
+
+  listWorkspaceMemberships(workspaceId?: string): AgentWorkspaceMembership[] {
+    if (workspaceId) {
+      this.ensureWorkspaceMembershipSeeded(workspaceId);
+    } else {
+      for (const workspace of this.workspaceRepo.findAll()) {
+        this.ensureWorkspaceMembershipSeeded(workspace.id);
+      }
+    }
+    const rows = (workspaceId
+      ? this.db
+          .prepare(
+            `SELECT * FROM agent_workspace_memberships
+             WHERE workspace_id = ?
+             ORDER BY updated_at DESC`,
+          )
+          .all(workspaceId)
+      : this.db
+          .prepare(
+            `SELECT * FROM agent_workspace_memberships
+             ORDER BY updated_at DESC`,
+          )
+          .all()) as Any[];
+    return rows.map((row) => ({
+      id: String(row.id),
+      workspaceId: String(row.workspace_id),
+      principalId: String(row.principal_id),
+      role: String(row.role) as import("../../shared/types").AgentWorkspaceRole,
+      createdAt: Number(row.created_at || 0),
+      updatedAt: Number(row.updated_at || 0),
+    }));
+  }
+
+  updateWorkspaceMembership(input: {
+    workspaceId: string;
+    principalId: string;
+    role: import("../../shared/types").AgentWorkspaceRole;
+  }): AgentWorkspaceMembership {
+    this.assertWorkspacePermission(input.workspaceId, "canManageMemberships");
+    const now = Date.now();
+    const existing = this.db
+      .prepare(
+        `SELECT * FROM agent_workspace_memberships
+         WHERE workspace_id = ? AND principal_id = ?`,
+      )
+      .get(input.workspaceId, input.principalId) as Any | undefined;
+    const id = existing?.id ? String(existing.id) : randomUUID();
+    this.db
+      .prepare(
+        `INSERT INTO agent_workspace_memberships
+         (id, workspace_id, principal_id, role, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(workspace_id, principal_id) DO UPDATE SET
+           role = excluded.role,
+           updated_at = excluded.updated_at`,
+      )
+      .run(
+        id,
+        input.workspaceId,
+        input.principalId,
+        input.role,
+        existing?.created_at ? Number(existing.created_at) : now,
+        now,
+      );
+    const membership = this.listWorkspaceMemberships(input.workspaceId).find((entry) => entry.id === id);
+    if (!membership) {
+      throw new Error("Failed to persist workspace membership");
+    }
+    this.appendAudit({
+      agentId: `workspace:${input.workspaceId}`,
+      workspaceId: input.workspaceId,
+      action: "membership_updated",
+      summary: `Updated ${input.principalId} to ${input.role}`,
+      metadata: { principalId: input.principalId, role: input.role },
+    });
+    return membership;
+  }
+
+  listAuditEntries(agentId: string, limit = 50): ManagedAgentAuditEntry[] {
+    const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
+    if (workspaceId) this.assertWorkspacePermission(workspaceId, "canAuditAgents");
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM managed_agent_audit
+         WHERE agent_id = ?
+         ORDER BY created_at DESC
+         LIMIT ?`,
+      )
+      .all(agentId, limit) as Any[];
+    return rows.map((row) => ({
+      id: String(row.id),
+      agentId: String(row.agent_id),
+      workspaceId: String(row.workspace_id),
+      actorId: String(row.actor_id),
+      action: String(row.action) as ManagedAgentAuditEntry["action"],
+      summary: String(row.summary),
+      metadata: safeJsonParse<Record<string, unknown> | undefined>(row.metadata_json, undefined),
+      createdAt: Number(row.created_at || 0),
+    }));
+  }
+
+  private appendAudit(input: {
+    agentId: string;
+    workspaceId: string;
+    action: ManagedAgentAuditEntry["action"];
+    summary: string;
+    metadata?: Record<string, unknown>;
+    actorId?: string;
+  }): ManagedAgentAuditEntry {
+    const entry: ManagedAgentAuditEntry = {
+      id: randomUUID(),
+      agentId: input.agentId,
+      workspaceId: input.workspaceId,
+      actorId: normalizePrincipalId(input.actorId),
+      action: input.action,
+      summary: input.summary,
+      metadata: input.metadata,
+      createdAt: Date.now(),
+    };
+    this.db
+      .prepare(
+        `INSERT INTO managed_agent_audit
+         (id, agent_id, workspace_id, actor_id, action, summary, metadata_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        entry.id,
+        entry.agentId,
+        entry.workspaceId,
+        entry.actorId,
+        entry.action,
+        entry.summary,
+        entry.metadata ? JSON.stringify(entry.metadata) : null,
+        entry.createdAt,
+      );
+    return entry;
   }
 
   listAgents(params?: { limit?: number; offset?: number; status?: ManagedAgent["status"] }): ManagedAgent[] {
@@ -217,6 +873,254 @@ export class ManagedSessionService {
     return {
       agent,
       currentVersion: this.managedAgentVersionRepo.find(agentId, agent.currentVersion),
+    };
+  }
+
+  private mapManagedAgentRoutineRow(agentId: string, row: Any): ManagedAgentRoutineRecord {
+    const definition = safeJsonParse<Routine | null>(row.definition_json, null);
+    const triggers = Array.isArray(definition?.triggers)
+      ? (definition?.triggers as RoutineTrigger[])
+      : safeJsonParse<RoutineTrigger[]>(row.triggers_json, []);
+    const trigger = triggers[0];
+    const executionTarget = definition?.executionTarget;
+    const outputKinds = Array.isArray(definition?.outputs)
+      ? definition.outputs.map((output) => output.kind)
+      : ["task_only"];
+
+    const normalizedTrigger: ManagedAgentRoutineTriggerConfig = {
+      id: trigger?.id,
+      type: (trigger?.type || "manual") as ManagedAgentRoutineTriggerConfig["type"],
+      enabled: trigger?.enabled !== false,
+      cadenceMinutes:
+        trigger?.type === "schedule" && trigger.schedule?.kind === "every"
+          ? Math.max(15, Math.round((trigger.schedule.everyMs || 3_600_000) / 60_000))
+          : undefined,
+      path: trigger?.type === "api" ? trigger.path : undefined,
+      connectorId: trigger?.type === "connector_event" ? trigger.connectorId : undefined,
+      changeType: trigger?.type === "connector_event" ? trigger.changeType : undefined,
+      resourceUriContains:
+        trigger?.type === "connector_event" ? trigger.resourceUriContains : undefined,
+      channelType: trigger?.type === "channel_event" ? trigger.channelType : undefined,
+      chatId: trigger?.type === "channel_event" ? trigger.chatId : undefined,
+      textContains: trigger?.type === "channel_event" ? trigger.textContains : undefined,
+      senderContains: trigger?.type === "channel_event" ? trigger.senderContains : undefined,
+      eventType: trigger?.type === "mailbox_event" ? trigger.eventType : undefined,
+      subjectContains: trigger?.type === "mailbox_event" ? trigger.subjectContains : undefined,
+      provider: trigger?.type === "mailbox_event" ? trigger.provider : undefined,
+      labelContains: trigger?.type === "mailbox_event" ? trigger.labelContains : undefined,
+      eventName: trigger?.type === "github_event" ? trigger.eventName : undefined,
+      repository: trigger?.type === "github_event" ? trigger.repository : undefined,
+      action: trigger?.type === "github_event" ? trigger.action : undefined,
+      ref: trigger?.type === "github_event" ? trigger.ref : undefined,
+    };
+
+    return {
+      id: String(row.id),
+      agentId,
+      name: String(row.name || ""),
+      description: row.description ? String(row.description) : undefined,
+      enabled: Boolean(row.enabled),
+      workspaceId: String(row.workspace_id || ""),
+      environmentId:
+        executionTarget?.kind === "managed_environment"
+          ? executionTarget.managedEnvironmentId
+          : undefined,
+      trigger: normalizedTrigger,
+      outputKinds,
+      createdAt: Number(row.created_at || 0),
+      updatedAt: Number(row.updated_at || 0),
+    };
+  }
+
+  listManagedAgentRoutines(agentId: string): ManagedAgentRoutineRecord[] {
+    const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
+    if (workspaceId) this.assertWorkspacePermission(workspaceId, "canViewAgents");
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM automation_routines
+         ORDER BY updated_at DESC, created_at DESC`,
+      )
+      .all() as Any[];
+    return rows
+      .map((row) => {
+        const definition = safeJsonParse<Routine | null>(row.definition_json, null);
+        const metadata = definition?.contextBindings?.metadata || {};
+        if (metadata.managedAgentId !== agentId) return null;
+        return this.mapManagedAgentRoutineRow(agentId, row);
+      })
+      .filter((entry): entry is ManagedAgentRoutineRecord => Boolean(entry));
+  }
+
+  buildManagedAgentRoutineDefinition(
+    request: CreateManagedAgentRoutineRequest | UpdateManagedAgentRoutineRequest,
+  ): {
+    name?: string;
+    description?: string;
+    enabled?: boolean;
+    workspaceId: string;
+    environmentId: string;
+    trigger: ManagedAgentRoutineTriggerConfig;
+    instructions: string;
+  } {
+    const detail = this.getAgent(request.agentId);
+    if (!detail?.agent || !detail.currentVersion) {
+      throw new Error(`Managed agent not found: ${request.agentId}`);
+    }
+    const studio = getStudioConfig(detail.currentVersion);
+    const environmentId = studio?.defaultEnvironmentId;
+    if (!environmentId) {
+      throw new Error("Managed agent needs a default environment before routines can be configured");
+    }
+    const environment = this.getEnvironment(environmentId);
+    if (!environment) {
+      throw new Error(`Managed environment not found: ${environmentId}`);
+    }
+    this.assertWorkspacePermission(environment.config.workspaceId, "canManageRoutines");
+    const trigger = ("trigger" in request && request.trigger
+      ? request.trigger
+      : undefined) as ManagedAgentRoutineTriggerConfig | undefined;
+    if (!trigger?.type) {
+      throw new Error("Routine trigger type is required");
+    }
+    const workflowBrief = studio?.workflowBrief?.trim();
+    return {
+      name: "name" in request ? request.name : undefined,
+      description: "description" in request ? request.description : undefined,
+      enabled: "enabled" in request ? request.enabled : undefined,
+      workspaceId: environment.config.workspaceId,
+      environmentId,
+      trigger: {
+        enabled: true,
+        ...trigger,
+      },
+      instructions:
+        workflowBrief ||
+        detail.currentVersion.systemPrompt ||
+        `Run the configured workflow for ${detail.agent.name}.`,
+    };
+  }
+
+  private updateCurrentStudioConfig(
+    agentId: string,
+    mutate: (studio: ManagedAgentStudioConfig, version: ManagedAgentVersion) => ManagedAgentStudioConfig,
+  ): ManagedAgentVersion {
+    const detail = this.getAgent(agentId);
+    if (!detail?.currentVersion) {
+      throw new Error(`Managed agent not found: ${agentId}`);
+    }
+    const currentStudio = getStudioConfig(detail.currentVersion) || {};
+    const nextStudio = mutate(currentStudio, detail.currentVersion);
+    const updated = this.managedAgentVersionRepo.updateMetadata(
+      detail.currentVersion.agentId,
+      detail.currentVersion.version,
+      setStudioConfigMetadata(detail.currentVersion.metadata, nextStudio),
+    );
+    return updated || detail.currentVersion;
+  }
+
+  syncManagedAgentRoutineRefs(agentId: string): ManagedAgentLinkedRoutineRef[] {
+    const routines = this.listManagedAgentRoutines(agentId);
+    const linkedRoutines = routines.map((routine) => ({
+      routineId: routine.id,
+      name: routine.name,
+      enabled: routine.enabled,
+      triggerTypes: [routine.trigger.type],
+      summary: summarizeRoutineTrigger(routine.trigger),
+    }));
+    this.updateCurrentStudioConfig(agentId, (studio) => ({
+      ...studio,
+      routineIds: linkedRoutines.map((entry) => entry.routineId),
+      linkedRoutines,
+      scheduleSummary:
+        linkedRoutines
+          .filter((entry) => entry.enabled)
+          .map((entry) => entry.summary)
+          .filter(Boolean)
+          .join(" · ") || undefined,
+    }));
+    return linkedRoutines;
+  }
+
+  private setRoutineEnabled(routineId: string, enabled: boolean): void {
+    const row = this.db
+      .prepare("SELECT * FROM automation_routines WHERE id = ?")
+      .get(routineId) as Any | undefined;
+    if (!row) return;
+    const definition = safeJsonParse<Routine | null>(row.definition_json, null);
+    if (!definition) {
+      this.db
+        .prepare("UPDATE automation_routines SET enabled = ?, updated_at = ? WHERE id = ?")
+        .run(enabled ? 1 : 0, Date.now(), routineId);
+      return;
+    }
+    const nextDefinition = { ...definition, enabled, updatedAt: Date.now() };
+    this.db
+      .prepare(
+        `UPDATE automation_routines
+         SET enabled = ?, definition_json = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(enabled ? 1 : 0, JSON.stringify(nextDefinition), nextDefinition.updatedAt, routineId);
+  }
+
+  getRuntimeToolCatalog(agentId: string): ManagedAgentRuntimeToolCatalog {
+    const agentDetail = this.getAgent(agentId);
+    if (!agentDetail?.agent) {
+      throw new Error(`Managed agent not found: ${agentId}`);
+    }
+    const version = agentDetail.currentVersion;
+    if (!version) {
+      throw new Error(`Managed agent version missing: ${agentId}@${agentDetail.agent.currentVersion}`);
+    }
+    const studio = getStudioConfig(version);
+    const environmentId = studio?.defaultEnvironmentId;
+    if (!environmentId) {
+      return {
+        agentId,
+        chatgpt: [],
+        slack: [],
+      };
+    }
+    const environment = this.getEnvironment(environmentId);
+    if (!environment) {
+      throw new Error(`Managed environment not found: ${environmentId}`);
+    }
+    const workspace = this.workspaceRepo.findById(environment.config.workspaceId);
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${environment.config.workspaceId}`);
+    }
+    const managedWorkspace = cloneWorkspaceForManagedEnvironment(workspace, environment);
+    const agentConfig = this.buildAgentConfig(environment, version);
+    const autoApproveTypes = new Set<ApprovalType>(
+      (agentConfig.autoApproveTypes || []).filter((entry): entry is ApprovalType => Boolean(entry)),
+    );
+    const allowedMcpTools = new Set<string>(this.resolveAllowedMcpTools(environment));
+    const buildSurfaceCatalog = (gatewayContext?: GatewayContextType) => {
+      const registry = new ToolRegistry(
+        managedWorkspace,
+        this.agentDaemon,
+        `managed-agent-catalog:${agentId}:${gatewayContext || "chatgpt"}`,
+        gatewayContext,
+        agentConfig.toolRestrictions,
+      );
+      const tools = registry
+        .getTools()
+        .filter((tool) => isToolEnabledForManagedEnvironment(tool, environment, allowedMcpTools));
+      return tools.map((tool) =>
+        mapRuntimeToolCatalogEntry(
+          tool,
+          registry.getApprovalType(tool.name),
+          autoApproveTypes,
+          registry.getMcpServerName(tool.name),
+        ),
+      );
+    };
+
+    return {
+      agentId,
+      environmentId,
+      chatgpt: buildSurfaceCatalog(),
+      slack: buildSurfaceCatalog("group"),
     };
   }
 
@@ -237,7 +1141,7 @@ export class ManagedSessionService {
       id,
       name: input.name,
       description: input.description,
-      status: "active",
+      status: "draft",
       currentVersion: 1,
     });
     const version: ManagedAgentVersion = {
@@ -254,7 +1158,20 @@ export class ManagedSessionService {
       createdAt: Date.now(),
     };
     this.managedAgentVersionRepo.create(version);
-    return { agent, version };
+    const syncedVersion = this.syncLegacyMirror(agent, version);
+    const workspaceId =
+      getStudioConfig(syncedVersion)?.defaultEnvironmentId
+        ? this.getEnvironment(getStudioConfig(syncedVersion)?.defaultEnvironmentId || "")?.config.workspaceId
+        : undefined;
+    if (workspaceId) {
+      this.appendAudit({
+        agentId: agent.id,
+        workspaceId,
+        action: "created",
+        summary: `Created managed agent ${agent.name}`,
+      });
+    }
+    return { agent, version: syncedVersion };
   }
 
   updateAgent(
@@ -274,6 +1191,10 @@ export class ManagedSessionService {
   ): { agent: ManagedAgent; version: ManagedAgentVersion } {
     const existing = this.managedAgentRepo.findById(agentId);
     if (!existing) throw new Error(`Managed agent not found: ${agentId}`);
+    const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
+    if (workspaceId) {
+      this.assertWorkspacePermission(workspaceId, "canEditDrafts");
+    }
     const currentVersion = this.managedAgentVersionRepo.find(agentId, existing.currentVersion);
     if (!currentVersion) {
       throw new Error(`Managed agent version missing: ${agentId}@${existing.currentVersion}`);
@@ -299,11 +1220,92 @@ export class ManagedSessionService {
       createdAt: Date.now(),
     };
     this.managedAgentVersionRepo.create(version);
-    return { agent, version };
+    const syncedVersion = this.syncLegacyMirror(agent, version, getStudioConfig(currentVersion));
+    if (workspaceId) {
+      this.appendAudit({
+        agentId,
+        workspaceId,
+        action: "updated",
+        summary: `Updated managed agent ${agent.name}`,
+      });
+    }
+    return { agent, version: syncedVersion };
   }
 
   archiveAgent(agentId: string): ManagedAgent | undefined {
-    return this.managedAgentRepo.update(agentId, { status: "archived" });
+    const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
+    if (workspaceId) this.assertWorkspacePermission(workspaceId, "canPublishAgents");
+    const agent = this.managedAgentRepo.update(agentId, { status: "archived" });
+    if (!agent) return undefined;
+    const routines = this.listManagedAgentRoutines(agentId);
+    for (const routine of routines) {
+      this.setRoutineEnabled(routine.id, false);
+    }
+    const detail = this.getAgent(agentId);
+    if (detail?.currentVersion) {
+      this.syncLegacyMirror(agent, detail.currentVersion, getStudioConfig(detail.currentVersion));
+    }
+    if (workspaceId) {
+      this.appendAudit({
+        agentId,
+        workspaceId,
+        action: "archived",
+        summary: `Archived managed agent ${agent.name}`,
+      });
+    }
+    this.syncManagedAgentRoutineRefs(agentId);
+    return agent;
+  }
+
+  publishAgent(agentId: string): ManagedAgent | undefined {
+    const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
+    if (workspaceId) this.assertWorkspacePermission(workspaceId, "canPublishAgents");
+    const agent = this.managedAgentRepo.update(agentId, { status: "active" });
+    if (!agent) return undefined;
+    const detail = this.getAgent(agentId);
+    const studio = detail?.currentVersion ? getStudioConfig(detail.currentVersion) : undefined;
+    for (const routine of this.listManagedAgentRoutines(agentId)) {
+      this.setRoutineEnabled(routine.id, routine.trigger.enabled !== false);
+    }
+    if (detail?.currentVersion) {
+      this.syncLegacyMirror(agent, detail.currentVersion, studio);
+    }
+    if (workspaceId) {
+      this.appendAudit({
+        agentId,
+        workspaceId,
+        action: "published",
+        summary: `Published managed agent ${agent.name}`,
+      });
+    }
+    this.syncManagedAgentRoutineRefs(agentId);
+    return agent;
+  }
+
+  suspendAgent(agentId: string): ManagedAgent | undefined {
+    const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
+    if (workspaceId) this.assertWorkspacePermission(workspaceId, "canPublishAgents");
+    const agent = this.managedAgentRepo.update(agentId, { status: "suspended" });
+    if (!agent) return undefined;
+    const detail = this.getAgent(agentId);
+    const currentVersion = detail?.currentVersion;
+    const studio = currentVersion ? getStudioConfig(currentVersion) : undefined;
+    for (const routine of this.listManagedAgentRoutines(agentId)) {
+      this.setRoutineEnabled(routine.id, false);
+    }
+    if (currentVersion) {
+      this.syncLegacyMirror(agent, currentVersion, studio);
+    }
+    if (workspaceId) {
+      this.appendAudit({
+        agentId,
+        workspaceId,
+        action: "suspended",
+        summary: `Suspended managed agent ${agent.name}`,
+      });
+    }
+    this.syncManagedAgentRoutineRefs(agentId);
+    return agent;
   }
 
   listAgentVersions(agentId: string): ManagedAgentVersion[] {
@@ -334,6 +1336,7 @@ export class ManagedSessionService {
     if (!this.workspaceRepo.findById(input.config.workspaceId)) {
       throw new Error(`Workspace not found: ${input.config.workspaceId}`);
     }
+    this.assertWorkspacePermission(input.config.workspaceId, "canManageEnvironments");
     this.validateManagedAccountRefs(input.config.managedAccountRefs);
     return this.managedEnvironmentRepo.create({
       id: randomUUID(),
@@ -355,6 +1358,10 @@ export class ManagedSessionService {
     if (nextConfig?.workspaceId && !this.workspaceRepo.findById(nextConfig.workspaceId)) {
       throw new Error(`Workspace not found: ${nextConfig.workspaceId}`);
     }
+    this.assertWorkspacePermission(
+      nextConfig?.workspaceId || existing.config.workspaceId,
+      "canManageEnvironments",
+    );
     this.validateManagedAccountRefs(nextConfig?.managedAccountRefs);
     return this.managedEnvironmentRepo.update(environmentId, {
       name: input.name,
@@ -364,18 +1371,28 @@ export class ManagedSessionService {
   }
 
   archiveEnvironment(environmentId: string): ManagedEnvironment | undefined {
+    const existing = this.managedEnvironmentRepo.findById(environmentId);
+    if (!existing) return undefined;
+    this.assertWorkspacePermission(existing.config.workspaceId, "canManageEnvironments");
     return this.managedEnvironmentRepo.update(environmentId, { status: "archived" });
   }
 
   async createSession(input: ManagedSessionCreateInput): Promise<ManagedSession> {
     const agent = this.managedAgentRepo.findById(input.agentId);
     if (!agent) throw new Error(`Managed agent not found: ${input.agentId}`);
+    if (agent.status === "suspended") {
+      throw new Error(`Managed agent is suspended and cannot be run: ${agent.name}`);
+    }
+    if (agent.status === "archived") {
+      throw new Error(`Managed agent is archived and cannot be run: ${agent.name}`);
+    }
     const version = this.managedAgentVersionRepo.find(agent.id, agent.currentVersion);
     if (!version) throw new Error(`Managed agent version missing: ${agent.id}@${agent.currentVersion}`);
     const environment = this.managedEnvironmentRepo.findById(input.environmentId);
     if (!environment) throw new Error(`Managed environment not found: ${input.environmentId}`);
     const workspace = this.workspaceRepo.findById(environment.config.workspaceId);
     if (!workspace) throw new Error(`Workspace not found: ${environment.config.workspaceId}`);
+    this.assertWorkspacePermission(environment.config.workspaceId, "canRunAgents");
 
     const now = Date.now();
     const userPrompt = this.materializeContent(input.initialEvent?.content || []);
@@ -527,6 +1544,7 @@ export class ManagedSessionService {
   async cancelSession(sessionId: string): Promise<ManagedSession | undefined> {
     const session = this.managedSessionRepo.findById(sessionId);
     if (!session) return undefined;
+    this.assertWorkspacePermission(session.workspaceId, "canRunAgents");
     if (session.backingTeamRunId) {
       await this.cancelManagedTeamRun(session.backingTeamRunId);
     }
@@ -545,6 +1563,7 @@ export class ManagedSessionService {
   async resumeSession(sessionId: string): Promise<{ resumed: boolean; session?: ManagedSession }> {
     const session = this.managedSessionRepo.findById(sessionId);
     if (!session?.backingTaskId) return { resumed: false, session };
+    this.assertWorkspacePermission(session.workspaceId, "canResumeSessions");
     if (session.backingTeamRunId) {
       await this.tickManagedTeamRun(session.backingTeamRunId);
       const refreshed = this.refreshSession(sessionId);
@@ -563,6 +1582,10 @@ export class ManagedSessionService {
   ): Promise<ManagedSession | undefined> {
     const session = this.managedSessionRepo.findById(sessionId);
     if (!session?.backingTaskId) return undefined;
+    this.assertWorkspacePermission(
+      session.workspaceId,
+      event.type === "input.received" ? "canAnswerApprovals" : "canRunAgents",
+    );
 
     if (event.type === "user.message") {
       if (session.backingTeamRunId) {
@@ -595,6 +1618,468 @@ export class ManagedSessionService {
       answers: event.answers,
     });
     return this.refreshSession(sessionId);
+  }
+
+  async generateAudioSummary(
+    sessionId: string,
+    input?: Partial<AudioSummaryConfig>,
+  ): Promise<AudioSummaryResult> {
+    const session = this.refreshSession(sessionId);
+    if (!session?.backingTaskId) {
+      throw new Error(`Managed session not found: ${sessionId}`);
+    }
+    const task = this.taskRepo.findById(session.backingTaskId);
+    if (!task) {
+      throw new Error(`Backing task not found for managed session: ${sessionId}`);
+    }
+    const workspace = this.workspaceRepo.findById(session.workspaceId);
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${session.workspaceId}`);
+    }
+    const { currentVersion } = this.getAgent(session.agentId) || {};
+    const studio = currentVersion ? getStudioConfig(currentVersion) : undefined;
+    const style =
+      input?.style ||
+      studio?.audioSummaryConfig?.style ||
+      "executive-briefing";
+    const title =
+      input?.title ||
+      studio?.audioSummaryConfig?.title ||
+      `${session.title} audio summary`;
+    const script = this.buildAudioSummaryScript(session, style);
+    const audioBuffer = await getVoiceService().speak(script);
+    if (!audioBuffer) {
+      throw new Error("Audio summary generation returned no audio");
+    }
+    const outputDir = path.join(workspace.path, "output", "agents", "audio-summaries");
+    await fs.mkdir(outputDir, { recursive: true });
+    const safeTitle = slugifyName(title);
+    const outputPath = path.join(outputDir, `${safeTitle}-${Date.now()}.mp3`);
+    await fs.writeFile(outputPath, audioBuffer);
+    const artifact = this.artifactRepo.create({
+      taskId: session.backingTaskId,
+      path: outputPath,
+      mimeType: "audio/mpeg",
+      sha256: createHash("sha256").update(audioBuffer).digest("hex"),
+      size: audioBuffer.length,
+      createdAt: Date.now(),
+    });
+    this.managedSessionEventRepo.create({
+      sessionId,
+      timestamp: Date.now(),
+      type: "tool.result",
+      payload: {
+        toolName: "generate_audio_summary",
+        style,
+        artifactId: artifact.id,
+        path: outputPath,
+        title,
+      },
+    });
+    if (currentVersion && studio) {
+      const nextStudio: ManagedAgentStudioConfig = {
+        ...studio,
+        audioSummaryConfig: {
+          enabled: true,
+          style,
+          title,
+          voice: input?.voice || studio.audioSummaryConfig?.voice,
+          lastArtifactId: artifact.id,
+        },
+      };
+      this.managedAgentVersionRepo.updateMetadata(
+        currentVersion.agentId,
+        currentVersion.version,
+        setStudioConfigMetadata(currentVersion.metadata, nextStudio),
+      );
+    }
+    return {
+      sessionId,
+      artifact,
+      style,
+      title,
+      script,
+      playbackUrl: createMediaPlaybackUrl({
+        resolvedPath: outputPath,
+        workspaceRoot: workspace.path,
+        mimeType: "audio/mpeg",
+      }),
+    };
+  }
+
+  getAgentInsights(agentId: string): ManagedAgentInsights {
+    const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
+    if (workspaceId) this.assertWorkspacePermission(workspaceId, "canViewAgents");
+    const sessions = this.listSessions({ limit: 500 }).filter((session) => session.agentId === agentId);
+    const completedDurations = sessions
+      .filter((session) => session.completedAt && session.startedAt && session.completedAt >= session.startedAt)
+      .map((session) => (session.completedAt || 0) - (session.startedAt || 0));
+    const totalDuration = completedDurations.reduce((sum, value) => sum + value, 0);
+    const toolCounts = new Map<string, number>();
+    const recentErrors: ManagedAgentInsights["recentErrors"] = [];
+    const userKeys = new Set<string>();
+    let approvalTotal = 0;
+    let approvalResolved = 0;
+
+    for (const session of sessions) {
+      if (session.status === "failed" || session.status === "cancelled") {
+        recentErrors.push({
+          id: session.id,
+          message: session.latestSummary || session.status,
+          occurredAt: session.updatedAt,
+          sessionId: session.id,
+        });
+      }
+      if (!session.backingTaskId) continue;
+      const events = this.taskEventRepo.findByTaskId(session.backingTaskId);
+      for (const event of events) {
+        const effectiveType = event.legacyType || event.type;
+        if (effectiveType === "tool_call") {
+          const toolName = String(event.payload?.toolName || event.payload?.tool || "").trim();
+          if (toolName) {
+            toolCounts.set(toolName, (toolCounts.get(toolName) || 0) + 1);
+          }
+        }
+        for (const userKey of this.extractUserKeysFromPayload(event.payload)) {
+          userKeys.add(userKey);
+        }
+      }
+      for (const event of this.listSessionEvents(session.id, 200)) {
+        for (const userKey of this.extractUserKeysFromPayload(event.payload)) {
+          userKeys.add(userKey);
+        }
+      }
+      const inputs = this.inputRequestRepo.list({
+        limit: 100,
+        offset: 0,
+        taskId: session.backingTaskId,
+      });
+      approvalTotal += inputs.length;
+      approvalResolved += inputs.filter((request) => request.status === "submitted").length;
+    }
+
+    const triggerBreakdown = new Map<string, number>();
+    const deploymentBreakdown = new Map<string, number>();
+    for (const row of this.listRoutineRunsForAgent(agentId)) {
+      const triggerType = row.run.triggerType || "manual";
+      triggerBreakdown.set(triggerType, (triggerBreakdown.get(triggerType) || 0) + 1);
+      deploymentBreakdown.set(row.surface, (deploymentBreakdown.get(row.surface) || 0) + 1);
+      if (row.run.errorSummary) {
+        recentErrors.push({
+          id: row.run.id,
+          message: row.run.errorSummary,
+          occurredAt: row.run.updatedAt || row.run.createdAt || 0,
+          routineRunId: row.run.id,
+        });
+      }
+    }
+    if (sessions.length > 0) {
+      deploymentBreakdown.set(
+        "chatgpt",
+        (deploymentBreakdown.get("chatgpt") || 0) + sessions.length,
+      );
+      triggerBreakdown.set("manual", (triggerBreakdown.get("manual") || 0) + sessions.length);
+    }
+
+    return {
+      agentId,
+      totalRuns: sessions.length,
+      uniqueUsers: userKeys.size > 0 ? userKeys.size : sessions.length > 0 ? 1 : 0,
+      successCount: sessions.filter((session) => session.status === "completed").length,
+      failureCount: sessions.filter((session) => session.status === "failed").length,
+      cancelledCount: sessions.filter((session) => session.status === "cancelled").length,
+      averageCompletionTimeMs:
+        completedDurations.length > 0 ? Math.round(totalDuration / completedDurations.length) : 0,
+      approvalRate: approvalTotal > 0 ? Math.round((approvalResolved / approvalTotal) * 100) : 0,
+      topTools: Array.from(toolCounts.entries())
+        .map(([toolName, count]) => ({ toolName, count }))
+        .sort((left, right) => right.count - left.count)
+        .slice(0, 5),
+      triggerBreakdown: Array.from(triggerBreakdown.entries()).map(([key, count]) => ({ key, count })),
+      deploymentSurfaceBreakdown: Array.from(deploymentBreakdown.entries()).map(([key, count]) => ({
+        key,
+        count,
+      })),
+      recentErrors: recentErrors
+        .sort((left, right) => right.occurredAt - left.occurredAt)
+        .slice(0, 5),
+      updatedAt: Date.now(),
+    };
+  }
+
+  getSlackDeploymentHealth(agentId: string): import("../../shared/types").ManagedAgentSlackDeploymentHealth {
+    const detail = this.getAgent(agentId);
+    if (!detail?.agent || !detail.currentVersion) {
+      throw new Error(`Managed agent not found: ${agentId}`);
+    }
+    const studio = getStudioConfig(detail.currentVersion);
+    const targets = (studio?.channelTargets || []).filter((target) => target.channelType === "slack");
+    const healthTargets = targets.map((target) => {
+      const channel = this.channelRepo.findById(target.channelId);
+      const status = channel?.status || "disconnected";
+      return {
+        channelId: target.channelId,
+        channelName: target.channelName || channel?.name || target.channelId,
+        status,
+        connected: status === "connected" && !channel?.configReadError,
+        misconfigured: Boolean(channel?.configReadError) || status !== "connected",
+        securityMode: target.securityMode,
+        progressRelayMode: target.progressRelayMode,
+        configReadError: channel?.configReadError,
+      };
+    });
+    const slackRuns = this.listRoutineRunsForAgent(agentId)
+      .filter((row) => row.surface === "slack")
+      .map((row) => row.run);
+    const lastSuccessful = slackRuns.find((run) => this.isSuccessfulSlackRun(run));
+    const failedRun = slackRuns.find((run) => run.status === "failed" || run.outputStatus === "failed");
+    return {
+      agentId,
+      connectedCount: healthTargets.filter((target) => target.connected).length,
+      misconfiguredCount: healthTargets.filter((target) => target.misconfigured).length,
+      targets: healthTargets,
+      lastSuccessfulRoutedRunAt: lastSuccessful?.updatedAt || lastSuccessful?.finishedAt,
+      lastSuccessfulRoutedRunId: lastSuccessful?.id,
+      lastDeploymentError:
+        healthTargets.find((target) => target.configReadError)?.configReadError ||
+        failedRun?.errorSummary,
+      updatedAt: Date.now(),
+    };
+  }
+
+  getSessionWorkpaper(sessionId: string): ManagedSessionWorkpaper {
+    const session = this.getSession(sessionId);
+    if (!session) {
+      throw new Error(`Managed session not found: ${sessionId}`);
+    }
+    this.assertWorkspacePermission(session.workspaceId, "canViewAgents");
+    const taskId = session.backingTaskId;
+    const workspace = this.workspaceRepo.findById(session.workspaceId);
+    const events = this.listSessionEvents(sessionId, 200);
+    const inputRequests = taskId
+      ? this.inputRequestRepo.list({ limit: 100, offset: 0, taskId })
+      : [];
+    const artifacts = taskId ? this.artifactRepo.findByTaskId(taskId) : [];
+    const summary =
+      session.latestSummary ||
+      events
+        .map((event) => String(event.payload?.message || event.payload?.content || "").trim())
+        .filter(Boolean)
+        .slice(-1)[0] ||
+      "No summary recorded yet.";
+    const canAudit = this.getMyWorkspacePermissions(session.workspaceId).canAuditAgents;
+
+    return {
+      sessionId,
+      agentId: session.agentId,
+      summary,
+      evidenceRefs: artifacts.slice(0, 5).map((artifact) => ({
+        evidenceId: artifact.id,
+        sourceType: "file",
+        sourceUrlOrPath: artifact.path,
+        capturedAt: artifact.createdAt,
+      })),
+      decisions: events
+        .filter((event) => event.type === "assistant.message")
+        .map((event) => ({
+          summary: String(event.payload?.message || event.payload?.content || "").trim(),
+          timestamp: event.timestamp,
+          sourceEventId: event.id,
+        }))
+        .filter((entry) => entry.summary)
+        .slice(-5),
+      approvals: inputRequests.map((request) => ({
+        requestId: request.id,
+        status: request.status,
+        summary: request.questions.map((question) => question.question).join(" "),
+        createdAt: request.requestedAt,
+        resolvedAt: request.resolvedAt,
+      })),
+      artifacts: artifacts.map((artifact) => ({
+        artifactId: artifact.id,
+        label: path.basename(artifact.path),
+        path: artifact.path,
+        mimeType: artifact.mimeType,
+        playbackUrl:
+          workspace && artifact.mimeType?.startsWith("audio/")
+            ? createMediaPlaybackUrl({
+                resolvedPath: artifact.path,
+                workspaceRoot: workspace.path,
+                mimeType: artifact.mimeType,
+              })
+            : undefined,
+      })),
+      auditTrail: canAudit
+        ? this.listAuditEntries(session.agentId, 8).map((entry) => ({
+            id: entry.id,
+            action: entry.action,
+            summary: entry.summary,
+            createdAt: entry.createdAt,
+            actorId: entry.actorId,
+          }))
+        : [],
+      generatedAt: Date.now(),
+    };
+  }
+
+  convertAgentRoleToManagedAgent(
+    request: ConvertAgentRoleToManagedAgentRequest,
+  ): Omit<ManagedAgentConversionResult, "routines"> & { routineDrafts: CreateManagedAgentRoutineRequest[] } {
+    const role = this.agentRoleRepo.findById(request.agentRoleId);
+    if (!role) {
+      throw new Error(`Agent role not found: ${request.agentRoleId}`);
+    }
+    const workspace = request.workspaceId
+      ? this.workspaceRepo.findById(request.workspaceId)
+      : this.workspaceRepo.findAll()[0];
+    if (!workspace) {
+      throw new Error("At least one workspace is required before converting agent personas");
+    }
+    const parsedSoul = safeJsonParse<Record<string, unknown>>(role.soul || undefined, {});
+    const capabilityFamilies: ManagedAgentToolFamily[] = [];
+    if (role.capabilities.includes("research")) capabilityFamilies.push("search", "communication");
+    if (role.capabilities.includes("code")) capabilityFamilies.push("files", "shell");
+    if (role.capabilities.includes("document")) capabilityFamilies.push("documents");
+    const environment = this.createEnvironment({
+      name: `${role.displayName} Environment`,
+      config: {
+        workspaceId: workspace.id,
+        enableShell: role.capabilities.includes("code"),
+        enableBrowser: true,
+        enableComputerUse: false,
+        allowedToolFamilies: Array.from(new Set(capabilityFamilies)),
+      },
+    });
+    const metadata: Record<string, unknown> = {
+      studio: {
+        workflowBrief: role.description || role.displayName,
+        instructions: {
+          operatingNotes:
+            typeof parsedSoul.operatorMandate === "string"
+              ? parsedSoul.operatorMandate
+              : undefined,
+        },
+        apps: {
+          allowedToolFamilies: Array.from(new Set(capabilityFamilies)),
+        },
+        approvalPolicy: {
+          autoApproveReadOnly: true,
+          requireApprovalFor: [],
+        },
+        sharing: {
+          visibility: "team",
+          ownerLabel: "Converted from Agent Persona",
+        },
+        deployment: {
+          surfaces: ["chatgpt"],
+        },
+        legacyMirror: {
+          agentRoleId: role.id,
+        },
+        defaultEnvironmentId: environment.id,
+        conversion: {
+          sourceType: "agent_role",
+          sourceId: role.id,
+          sourceLabel: role.displayName,
+          migratedAt: Date.now(),
+        },
+      } satisfies ManagedAgentStudioConfig,
+    };
+    const created = this.createAgent({
+      name: role.displayName,
+      description: role.description,
+      systemPrompt: role.systemPrompt || `Act as ${role.displayName}.`,
+      executionMode: "solo",
+      model: role.providerType || role.modelKey ? {
+        providerType: role.providerType,
+        modelKey: role.modelKey,
+      } : undefined,
+      metadata,
+    });
+    this.agentRoleRepo.update({
+      id: role.id,
+      soul: JSON.stringify({
+        ...parsedSoul,
+        managedAgentMigrated: true,
+        managedAgentId: created.agent.id,
+      }),
+    });
+    this.appendAudit({
+      agentId: created.agent.id,
+      workspaceId: workspace.id,
+      action: "converted_from_agent_role",
+      summary: `Converted agent persona ${role.displayName}`,
+      metadata: { sourceId: role.id },
+    });
+    return {
+      agent: created.agent,
+      version: created.version,
+      environment,
+      sourceType: "agent_role",
+      sourceId: role.id,
+      routineDrafts: [],
+    };
+  }
+
+  convertAutomationProfileToManagedAgent(
+    request: ConvertAutomationProfileToManagedAgentRequest,
+  ): Omit<ManagedAgentConversionResult, "routines"> & { routineDrafts: CreateManagedAgentRoutineRequest[] } {
+    const profile = this.automationProfileRepo.findById(request.automationProfileId);
+    if (!profile) {
+      throw new Error(`Automation profile not found: ${request.automationProfileId}`);
+    }
+    const role = this.agentRoleRepo.findById(profile.agentRoleId);
+    if (!role) {
+      throw new Error(`Agent role not found for automation profile: ${profile.agentRoleId}`);
+    }
+    const converted = this.convertAgentRoleToManagedAgent({
+      agentRoleId: role.id,
+      workspaceId: request.workspaceId,
+    });
+    const routineDrafts: CreateManagedAgentRoutineRequest[] = profile.enabled
+      ? [
+          {
+            agentId: converted.agent.id,
+            name: `${role.displayName} routine`,
+            description: "Converted from Automation Profile",
+            enabled: true,
+            trigger: {
+              type: "schedule",
+              enabled: true,
+              cadenceMinutes: Math.max(15, profile.cadenceMinutes || 60),
+            },
+          },
+        ]
+      : [];
+    this.automationProfileRepo.update({
+      id: profile.id,
+      enabled: false,
+      cadenceMinutes: profile.cadenceMinutes,
+      profile: profile.profile,
+      activeHours: profile.activeHours ?? null,
+    });
+    this.updateCurrentStudioConfig(converted.agent.id, (studio) => ({
+      ...studio,
+      conversion: {
+        sourceType: "automation_profile",
+        sourceId: profile.id,
+        sourceLabel: role.displayName,
+        migratedAt: Date.now(),
+      },
+    }));
+    this.appendAudit({
+      agentId: converted.agent.id,
+      workspaceId: converted.environment.config.workspaceId,
+      action: "converted_from_automation_profile",
+      summary: `Converted automation profile for ${role.displayName}`,
+      metadata: { sourceId: profile.id },
+    });
+    return {
+      ...converted,
+      sourceType: "automation_profile",
+      sourceId: profile.id,
+      routineDrafts,
+    };
   }
 
   bridgeTaskEventNotification(
@@ -707,6 +2192,19 @@ export class ManagedSessionService {
 
   private composeRootPrompt(version: ManagedAgentVersion, userPrompt: string): string {
     const promptParts = [version.systemPrompt.trim()];
+    const studio = getStudioConfig(version);
+    if (studio?.instructions?.operatingNotes?.trim()) {
+      promptParts.push("", "Operating notes:", studio.instructions.operatingNotes.trim());
+    }
+    const fileRefs = listManagedFileRefs(studio?.fileRefs, undefined);
+    if (fileRefs.length > 0) {
+      promptParts.push("", "Reference files:", ...fileRefs.map((filePath) => `- ${filePath}`));
+    }
+    if (studio?.memoryConfig?.mode === "disabled") {
+      promptParts.push("", "Memory policy:", "Avoid relying on long-term memory tools unless the user re-enables them.");
+    } else if (studio?.memoryConfig?.sources?.length) {
+      promptParts.push("", "Preferred memory sources:", ...studio.memoryConfig.sources.map((source) => `- ${source}`));
+    }
     if (userPrompt.trim()) {
       promptParts.push("", "User request:", userPrompt.trim());
     }
@@ -734,6 +2232,7 @@ export class ManagedSessionService {
 
   private buildAgentConfig(environment: ManagedEnvironment, version: ManagedAgentVersion): AgentConfig {
     const runtimeDefaults = version.runtimeDefaults || {};
+    const studio = getStudioConfig(version);
     const agentConfig: AgentConfig = {
       ...(version.model?.providerType ? { providerType: version.model.providerType } : {}),
       ...(version.model?.modelKey ? { modelKey: version.model.modelKey } : {}),
@@ -754,6 +2253,24 @@ export class ManagedSessionService {
         ? { toolRestrictions: [...runtimeDefaults.toolRestrictions] }
         : {}),
     };
+
+    const memoryRestrictions = toMemoryToolRestrictions(studio?.memoryConfig)?.deniedTools || [];
+    if (memoryRestrictions.length > 0) {
+      agentConfig.toolRestrictions = Array.from(
+        new Set([...(agentConfig.toolRestrictions || []), ...memoryRestrictions]),
+      );
+    }
+
+    const managedApprovalTypes = toManagedApprovalTypes(studio?.approvalPolicy);
+    if (managedApprovalTypes.length > 0) {
+      agentConfig.autoApproveTypes = Array.from(
+        new Set([...(agentConfig.autoApproveTypes || []), ...managedApprovalTypes]),
+      );
+    }
+    if (studio?.approvalPolicy) {
+      agentConfig.allowUserInput = true;
+      agentConfig.pauseForRequiredDecision = true;
+    }
 
     const allowedTools = new Set<string>(runtimeDefaults.allowedTools || []);
     const allowedMcpTools = this.resolveAllowedMcpTools(environment);
@@ -874,6 +2391,316 @@ export class ManagedSessionService {
         return "status.changed";
       default:
         return "task.event.bridge";
+    }
+  }
+
+  private syncLegacyMirror(
+    agent: ManagedAgent,
+    version: ManagedAgentVersion,
+    previousStudio?: ManagedAgentStudioConfig,
+  ): ManagedAgentVersion {
+    const studio = getStudioConfig(version);
+    if (!studio) return version;
+
+    const templateId = studio.templateId;
+    const roleId = studio.legacyMirror?.agentRoleId ?? previousStudio?.legacyMirror?.agentRoleId;
+    const existingRole =
+      (roleId ? this.agentRoleRepo.findById(roleId) : undefined) ||
+      this.agentRoleRepo.findAll(true).find((role) => roleMirrorsManagedAgent(role, agent.id)) ||
+      (() => {
+        const namedRole = this.agentRoleRepo.findByName(`managed-${slugifyName(agent.name)}`);
+        return roleMirrorsManagedAgent(namedRole, agent.id) ? namedRole : undefined;
+      })();
+    const heartbeatPolicy =
+      studio.scheduleConfig?.enabled
+        ? {
+            enabled: true,
+            cadenceMinutes: Math.max(15, studio.scheduleConfig.cadenceMinutes || 180),
+            activeHours: studio.scheduleConfig.activeHours ?? null,
+            profile: "operator" as const,
+          }
+        : undefined;
+    const sourceTemplateVersion =
+      typeof version.version === "number" ? String(version.version) : undefined;
+    const autonomyPolicy = toManagedAutonomyPolicy(studio.approvalPolicy);
+    let mirroredRole = existingRole;
+    if (existingRole) {
+      mirroredRole = this.agentRoleRepo.update({
+        id: existingRole.id,
+        displayName: agent.name,
+        description: agent.description,
+        sourceTemplateId: templateId ?? null,
+        sourceTemplateVersion: sourceTemplateVersion ?? null,
+        systemPrompt: version.systemPrompt,
+        providerType: version.model?.providerType,
+        modelKey: version.model?.modelKey,
+        capabilities: deriveCapabilities(templateId),
+        toolRestrictions: toMemoryToolRestrictions(studio.memoryConfig),
+        autonomyLevel: studio.scheduleConfig?.enabled ? "lead" : "specialist",
+        soul: JSON.stringify({
+          managedAgentId: agent.id,
+          managedAgentVersion: version.version,
+          studio,
+          autonomyPolicy,
+          sourceTemplateId: templateId,
+          sourceTemplateVersion,
+        }),
+      });
+    } else {
+      mirroredRole = this.agentRoleRepo.create({
+        name: `managed-${slugifyName(agent.name)}`,
+        displayName: agent.name,
+        description: agent.description,
+        roleKind: "custom",
+        sourceTemplateId: templateId,
+        sourceTemplateVersion,
+        systemPrompt: version.systemPrompt,
+        providerType: version.model?.providerType,
+        modelKey: version.model?.modelKey,
+        capabilities: deriveCapabilities(templateId),
+        toolRestrictions: toMemoryToolRestrictions(studio.memoryConfig),
+        autonomyLevel: studio.scheduleConfig?.enabled ? "lead" : "specialist",
+        soul: JSON.stringify({
+          managedAgentId: agent.id,
+          managedAgentVersion: version.version,
+          studio,
+          autonomyPolicy,
+          sourceTemplateId: templateId,
+          sourceTemplateVersion,
+        }),
+        heartbeatPolicy,
+      });
+    }
+
+    let automationProfileId = studio.legacyMirror?.automationProfileId;
+    if (mirroredRole) {
+      if (studio.scheduleConfig?.enabled) {
+        const profile = this.automationProfileRepo.createOrReplace({
+          agentRoleId: mirroredRole.id,
+          enabled: false,
+          cadenceMinutes: Math.max(15, studio.scheduleConfig.cadenceMinutes || 180),
+          profile: "operator",
+          activeHours: studio.scheduleConfig.activeHours ?? null,
+        });
+        automationProfileId = profile.id;
+      } else {
+        const existingProfile = this.automationProfileRepo.findByAgentRoleId(mirroredRole.id);
+        if (existingProfile) {
+          this.automationProfileRepo.update({
+            id: existingProfile.id,
+            enabled: false,
+            cadenceMinutes: existingProfile.cadenceMinutes,
+            profile: existingProfile.profile,
+            activeHours: existingProfile.activeHours ?? null,
+          });
+          automationProfileId = existingProfile.id;
+        }
+      }
+      this.syncSlackTargets(
+        mirroredRole.id,
+        previousStudio?.channelTargets,
+        agent.status === "active" ? studio.channelTargets : [],
+      );
+    }
+
+    const nextStudio: ManagedAgentStudioConfig = {
+      ...studio,
+      legacyMirror: {
+        ...studio.legacyMirror,
+        ...(mirroredRole ? { agentRoleId: mirroredRole.id } : {}),
+        ...(automationProfileId ? { automationProfileId } : {}),
+      },
+    };
+    return (
+      this.managedAgentVersionRepo.updateMetadata(
+        version.agentId,
+        version.version,
+        setStudioConfigMetadata(version.metadata, nextStudio),
+      ) || version
+    );
+  }
+
+  private syncSlackTargets(
+    mirroredRoleId: string,
+    previousTargets?: ManagedAgentChannelTarget[],
+    nextTargets?: ManagedAgentChannelTarget[],
+  ): void {
+    const relevantChannelIds = new Set<string>();
+    for (const target of previousTargets || []) {
+      if (target.channelType === "slack") relevantChannelIds.add(target.channelId);
+    }
+    for (const target of nextTargets || []) {
+      if (target.channelType === "slack") relevantChannelIds.add(target.channelId);
+    }
+
+    for (const channelId of relevantChannelIds) {
+      const channel = this.channelRepo.findById(channelId);
+      if (!channel || channel.configReadError) continue;
+      const nextTarget = (nextTargets || []).find(
+        (target) => target.channelType === "slack" && target.channelId === channelId,
+      );
+      const currentConfig = { ...(channel.config || {}) };
+      const nextAllowed = Array.isArray(currentConfig.allowedAgentRoleIds)
+        ? [...(currentConfig.allowedAgentRoleIds as string[])]
+        : [];
+      const nextSecurityConfig = { ...(channel.securityConfig || { mode: "pairing" as const }) };
+
+      if (nextTarget && nextTarget.enabled !== false) {
+        currentConfig.defaultAgentRoleId = mirroredRoleId;
+        if (!nextAllowed.includes(mirroredRoleId)) nextAllowed.push(mirroredRoleId);
+        currentConfig.allowedAgentRoleIds = nextAllowed;
+        if (nextTarget.progressRelayMode) {
+          currentConfig.progressRelayMode = nextTarget.progressRelayMode;
+        }
+        if (nextTarget.securityMode) {
+          nextSecurityConfig.mode = nextTarget.securityMode;
+        }
+      } else {
+        if (currentConfig.defaultAgentRoleId === mirroredRoleId) {
+          delete currentConfig.defaultAgentRoleId;
+        }
+        currentConfig.allowedAgentRoleIds = nextAllowed.filter((id) => id !== mirroredRoleId);
+      }
+
+      this.channelRepo.update(channelId, {
+        config: currentConfig,
+        securityConfig: nextSecurityConfig,
+      });
+    }
+  }
+
+  private listRoutineRunsForAgent(agentId: string): Array<{
+    run: import("../routines/types").RoutineRun;
+    definition: Routine;
+    surface: "slack" | "chatgpt";
+  }> {
+    const rows = this.db
+      .prepare(
+        `SELECT rr.*, ar.definition_json
+         FROM routine_runs rr
+         JOIN automation_routines ar ON ar.id = rr.routine_id
+         ORDER BY rr.updated_at DESC`,
+      )
+      .all() as Any[];
+    const runs: Array<{
+      run: import("../routines/types").RoutineRun;
+      definition: Routine;
+      surface: "slack" | "chatgpt";
+    }> = [];
+    for (const row of rows) {
+      const definition = safeJsonParse<Routine | null>(row.definition_json, null);
+      if (!definition || definition.contextBindings?.metadata?.managedAgentId !== agentId) continue;
+      const run = {
+        id: String(row.id),
+        routineId: String(row.routine_id),
+        triggerId: String(row.trigger_id),
+        triggerType: String(row.trigger_type || "manual") as import("../routines/types").RoutineRun["triggerType"],
+        status: String(row.status || "queued") as import("../routines/types").RoutineRun["status"],
+        startedAt: Number(row.started_at || 0),
+        finishedAt: row.finished_at ? Number(row.finished_at) : undefined,
+        sourceEventSummary: row.source_event_summary ? String(row.source_event_summary) : undefined,
+        backingTaskId: row.backing_task_id ? String(row.backing_task_id) : undefined,
+        backingManagedSessionId: row.backing_managed_session_id
+          ? String(row.backing_managed_session_id)
+          : undefined,
+        outputStatus: String(row.output_status || "none") as import("../routines/types").RoutineRun["outputStatus"],
+        errorSummary: row.error_summary ? String(row.error_summary) : undefined,
+        artifactsSummary: row.artifacts_summary ? String(row.artifacts_summary) : undefined,
+        createdAt: Number(row.created_at || 0),
+        updatedAt: Number(row.updated_at || 0),
+      };
+      const surface =
+        definition.contextBindings?.chatContext?.channelType === "slack" ||
+        run.triggerType === "channel_event"
+          ? "slack"
+          : "chatgpt";
+      runs.push({ run, definition, surface });
+    }
+    return runs;
+  }
+
+  private isSuccessfulSlackRun(run: import("../routines/types").RoutineRun): boolean {
+    if (run.outputStatus === "sent" || run.outputStatus === "responded") return true;
+    return run.status === "completed" || run.status === "partial_success";
+  }
+
+  private extractUserKeysFromPayload(payload: unknown): string[] {
+    const seen = new Set<string>();
+    const visit = (value: unknown, depth = 0): void => {
+      if (!value || depth > 3) return;
+      if (Array.isArray(value)) {
+        for (const item of value) visit(item, depth + 1);
+        return;
+      }
+      if (!isRecord(value)) return;
+
+      const candidates = [
+        ["requestingUserId", "user"],
+        ["userId", "user"],
+        ["senderId", "user"],
+        ["actorId", "user"],
+        ["email", "email"],
+        ["senderEmail", "email"],
+        ["requestingUserName", "name"],
+        ["userName", "name"],
+        ["senderName", "name"],
+      ] as const;
+      for (const [key, prefix] of candidates) {
+        const raw = value[key];
+        if (typeof raw === "string" && raw.trim()) {
+          seen.add(`${prefix}:${raw.trim().toLowerCase()}`);
+        }
+      }
+
+      for (const nested of Object.values(value)) {
+        visit(nested, depth + 1);
+      }
+    };
+    visit(payload);
+    return Array.from(seen);
+  }
+
+  private buildAudioSummaryScript(
+    session: ManagedSession,
+    style: AudioSummaryConfig["style"],
+  ): string {
+    const events = this.managedSessionEventRepo.listBySessionId(session.id, 80);
+    const assistantHighlights = events
+      .filter((event) => event.type === "assistant.message")
+      .map((event) => String(event.payload?.message || event.payload?.content || "").trim())
+      .filter(Boolean)
+      .slice(-4);
+    const latestSummary = session.latestSummary?.trim() || "";
+
+    switch (style) {
+      case "public-radio":
+        return [
+          `This is your public-radio style recap for ${session.title}.`,
+          latestSummary || "Here is the latest update from the run.",
+          ...assistantHighlights,
+          "That concludes the recap.",
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+      case "study-guide":
+        return [
+          `Study guide for ${session.title}.`,
+          "Key takeaway:",
+          latestSummary || "No final summary was recorded yet.",
+          ...(assistantHighlights.length > 0 ? ["Supporting points:", ...assistantHighlights] : []),
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+      case "executive-briefing":
+      default:
+        return [
+          `Executive briefing for ${session.title}.`,
+          latestSummary || "No final summary was recorded yet.",
+          ...(assistantHighlights.length > 0 ? ["Key supporting details:", ...assistantHighlights] : []),
+          "Next recommended action: review the agent run and decide whether to continue, publish, or adjust the configuration.",
+        ]
+          .filter(Boolean)
+          .join("\n\n");
     }
   }
 }

--- a/src/electron/managed/__tests__/ManagedSessionService.test.ts
+++ b/src/electron/managed/__tests__/ManagedSessionService.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AgentRoleRepository } from "../../agents/AgentRoleRepository";
-import { TaskEventRepository, TaskRepository } from "../../database/repositories";
+import { ChannelRepository, TaskEventRepository, TaskRepository } from "../../database/repositories";
 import { DatabaseManager } from "../../database/schema";
 import { MCPSettingsManager } from "../../mcp/settings";
 import { ManagedSessionService } from "../ManagedSessionService";
@@ -31,6 +31,8 @@ describeWithSqlite("ManagedSessionService", () => {
   let db: ReturnType<DatabaseManager["getDatabase"]>;
   let taskRepo: TaskRepository;
   let taskEventRepo: TaskEventRepository;
+  let channelRepo: ChannelRepository;
+  let roleRepo: AgentRoleRepository;
   let service: ManagedSessionService;
   let daemon: Any;
 
@@ -67,6 +69,8 @@ describeWithSqlite("ManagedSessionService", () => {
     db = manager.getDatabase();
     taskRepo = new TaskRepository(db);
     taskEventRepo = new TaskEventRepository(db);
+    channelRepo = new ChannelRepository(db);
+    roleRepo = new AgentRoleRepository(db);
 
     daemon = {
       startTask: vi.fn(async (task: Any) => {
@@ -222,6 +226,46 @@ describeWithSqlite("ManagedSessionService", () => {
     });
   });
 
+  it("reuses the managed agent mirror when saved metadata omits the mirror link", () => {
+    const workspace = insertWorkspace("mirror-link-save");
+    const environment = service.createEnvironment({
+      name: "Mirror link env",
+      config: { workspaceId: workspace.id },
+    });
+    const created = service.createAgent({
+      name: "Mirror Link Agent",
+      systemPrompt: "Version one.",
+      executionMode: "solo",
+      metadata: {
+        studio: {
+          defaultEnvironmentId: environment.id,
+          workflowBrief: "Handle mirrored work.",
+        },
+      },
+    });
+    const originalStudio = created.version.metadata?.studio as Any;
+    const { legacyMirror: _legacyMirror, ...studioWithoutLegacyMirror } = originalStudio;
+
+    const updated = service.updateAgent(created.agent.id, {
+      systemPrompt: "Version two.",
+      metadata: {
+        studio: {
+          ...studioWithoutLegacyMirror,
+          workflowBrief: "Handle updated mirrored work.",
+        },
+      },
+    });
+    const updatedStudio = updated.version.metadata?.studio as Any;
+    const mirroredRoles = roleRepo.findAll(true).filter((role) => {
+      const soul = JSON.parse(role.soul || "{}");
+      return soul.managedAgentId === created.agent.id;
+    });
+
+    expect(updatedStudio?.legacyMirror?.agentRoleId).toBe(originalStudio?.legacyMirror?.agentRoleId);
+    expect(mirroredRoles).toHaveLength(1);
+    expect(mirroredRoles[0]?.systemPrompt).toBe("Version two.");
+  });
+
   it("sanitizes bridged task event payloads before persisting managed session events", async () => {
     const workspace = insertWorkspace();
     const environment = service.createEnvironment({
@@ -347,5 +391,283 @@ describeWithSqlite("ManagedSessionService", () => {
       }),
     ).rejects.toThrow(/team-mode managed sessions/i);
     expect(daemon.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("enforces managed approval policy on direct sessions and mirrored agent roles", async () => {
+    const workspace = insertWorkspace("approval-session");
+    const environment = service.createEnvironment({
+      name: "Approval env",
+      config: { workspaceId: workspace.id },
+    });
+    const created = service.createAgent({
+      name: "Approval agent",
+      systemPrompt: "Handle approvals carefully.",
+      executionMode: "solo",
+      metadata: {
+        studio: {
+          approvalPolicy: {
+            autoApproveReadOnly: true,
+            requireApprovalFor: ["send email", "edit spreadsheet"],
+            escalationChannel: "#ops-approvals",
+          },
+        },
+      },
+    });
+
+    const session = await service.createSession({
+      agentId: created.agent.id,
+      environmentId: environment.id,
+      title: "Approval run",
+      initialEvent: {
+        type: "user.message",
+        content: [{ type: "text", text: "Run the workflow." }],
+      },
+    });
+
+    const backingTask = taskRepo.findById(session.backingTaskId!);
+    expect(backingTask?.agentConfig?.allowUserInput).toBe(true);
+    expect(backingTask?.agentConfig?.pauseForRequiredDecision).toBe(true);
+    expect(backingTask?.agentConfig?.autoApproveTypes).toEqual(["network_access"]);
+
+    const roleRepo = new AgentRoleRepository(db);
+    const mirroredRole = roleRepo.findAll(false).find((role) => role.displayName === "Approval agent");
+    expect(mirroredRole).toBeTruthy();
+    const soul = JSON.parse(mirroredRole!.soul || "{}");
+    expect(soul.autonomyPolicy).toMatchObject({
+      preset: "manual",
+      allowUserInput: true,
+      pauseForRequiredDecision: true,
+      autoApproveTypes: ["network_access"],
+    });
+  });
+
+  it("does not mint admin access for arbitrary principals when reading workspace permissions", () => {
+    const workspace = insertWorkspace("rbac");
+
+    const snapshot = service.getMyWorkspacePermissions(workspace.id, "attacker-user");
+    const attackerMembership = db
+      .prepare(
+        `SELECT role
+         FROM agent_workspace_memberships
+         WHERE workspace_id = ? AND principal_id = ?`,
+      )
+      .get(workspace.id, "attacker-user") as { role?: string } | undefined;
+
+    expect(snapshot.principalId).toBe("local-user");
+    expect(snapshot.role).toBe("admin");
+    expect(snapshot.canManageMemberships).toBe(true);
+    expect(attackerMembership).toBeUndefined();
+  });
+
+  it("preserves authored Slack targets when suspending an agent while removing live routing", () => {
+    const workspace = insertWorkspace("suspend-slack");
+    const environment = service.createEnvironment({
+      name: "Slack env",
+      config: { workspaceId: workspace.id },
+    });
+    const channel = channelRepo.create({
+      type: "slack",
+      name: "Support Slack",
+      enabled: true,
+      status: "connected",
+      config: {},
+      securityConfig: { mode: "pairing" },
+    });
+    const created = service.createAgent({
+      name: "Slacky",
+      systemPrompt: "Handle Slack work.",
+      executionMode: "solo",
+      metadata: {
+        studio: {
+          deployment: { surfaces: ["slack"] },
+          defaultEnvironmentId: environment.id,
+          channelTargets: [
+            {
+              channelType: "slack",
+              channelId: channel.id,
+              channelName: channel.name,
+              enabled: true,
+              progressRelayMode: "curated",
+              securityMode: "allowlist",
+            },
+          ],
+        },
+      },
+    });
+
+    service.publishAgent(created.agent.id);
+    service.suspendAgent(created.agent.id);
+
+    const suspended = service.getAgent(created.agent.id);
+    const studio = suspended?.currentVersion?.metadata?.studio as Any;
+    const updatedChannel = channelRepo.findById(channel.id);
+
+    expect(studio?.channelTargets).toHaveLength(1);
+    expect(studio?.channelTargets?.[0]?.channelId).toBe(channel.id);
+    expect(updatedChannel?.config?.defaultAgentRoleId).toBeUndefined();
+    expect(updatedChannel?.config?.allowedAgentRoleIds || []).not.toContain(
+      studio?.legacyMirror?.agentRoleId,
+    );
+  });
+
+  it("returns workpapers to viewers without requiring audit permission", async () => {
+    const workspace = insertWorkspace("viewer-workpaper");
+    const environment = service.createEnvironment({
+      name: "Viewer env",
+      config: { workspaceId: workspace.id },
+    });
+    const created = service.createAgent({
+      name: "Viewer agent",
+      systemPrompt: "Generate a workpaper.",
+      executionMode: "solo",
+      metadata: {
+        studio: {
+          defaultEnvironmentId: environment.id,
+        },
+      },
+    });
+    const session = await service.createSession({
+      agentId: created.agent.id,
+      environmentId: environment.id,
+      title: "Viewer session",
+    });
+
+    service.updateWorkspaceMembership({
+      workspaceId: workspace.id,
+      principalId: "local-user",
+      role: "viewer",
+    });
+
+    const workpaper = service.getSessionWorkpaper(session.id);
+
+    expect(workpaper.sessionId).toBe(session.id);
+    expect(workpaper.auditTrail).toEqual([]);
+  });
+
+  it("reuses the source agent role when converting personas into managed agents", () => {
+    const workspace = insertWorkspace("convert-role");
+    const role = roleRepo.create({
+      name: "support-pilot",
+      displayName: "Support Pilot",
+      description: "Answer support questions.",
+      roleKind: "custom",
+      capabilities: ["research", "communicate"],
+      systemPrompt: "Help customers.",
+    });
+
+    const converted = service.convertAgentRoleToManagedAgent({
+      agentRoleId: role.id,
+      workspaceId: workspace.id,
+    });
+    const detail = service.getAgent(converted.agent.id);
+    const studio = detail?.currentVersion?.metadata?.studio as Any;
+    const managedRoles = roleRepo.findAll(true).filter((candidate) => {
+      const soul = JSON.parse(candidate.soul || "{}");
+      return soul.managedAgentId === converted.agent.id;
+    });
+
+    expect(studio?.legacyMirror?.agentRoleId).toBe(role.id);
+    expect(managedRoles).toHaveLength(1);
+    expect(managedRoles[0]?.id).toBe(role.id);
+  });
+
+  it("only reports Slack deployment run health from Slack-backed routine runs", async () => {
+    const workspace = insertWorkspace("slack-health");
+    const environment = service.createEnvironment({
+      name: "Slack health env",
+      config: { workspaceId: workspace.id },
+    });
+    const channel = channelRepo.create({
+      type: "slack",
+      name: "Ops Slack",
+      enabled: true,
+      status: "connected",
+      config: {},
+      securityConfig: { mode: "pairing" },
+    });
+    const created = service.createAgent({
+      name: "Health agent",
+      systemPrompt: "Do health checks.",
+      executionMode: "solo",
+      metadata: {
+        studio: {
+          deployment: { surfaces: ["slack"] },
+          defaultEnvironmentId: environment.id,
+          channelTargets: [
+            {
+              channelType: "slack",
+              channelId: channel.id,
+              channelName: channel.name,
+              enabled: true,
+            },
+          ],
+        },
+      },
+    });
+    service.publishAgent(created.agent.id);
+
+    const manualSession = await service.createSession({
+      agentId: created.agent.id,
+      environmentId: environment.id,
+      title: "Manual run",
+    });
+    db.prepare("UPDATE managed_sessions SET status = ?, completed_at = ?, updated_at = ? WHERE id = ?").run(
+      "completed",
+      Date.now(),
+      Date.now(),
+      manualSession.id,
+    );
+
+    const health = service.getSlackDeploymentHealth(created.agent.id);
+
+    expect(health.lastSuccessfulRoutedRunId).toBeUndefined();
+    expect(health.lastSuccessfulRoutedRunAt).toBeUndefined();
+    expect(health.lastDeploymentError).toBeUndefined();
+  });
+
+  it("derives unique agent users from recorded requester identities instead of hard-coding one", async () => {
+    const workspace = insertWorkspace("agent-insights");
+    const environment = service.createEnvironment({
+      name: "Insights env",
+      config: { workspaceId: workspace.id },
+    });
+    const created = service.createAgent({
+      name: "Insights agent",
+      systemPrompt: "Track usage.",
+      executionMode: "solo",
+      metadata: {
+        studio: {
+          defaultEnvironmentId: environment.id,
+        },
+      },
+    });
+
+    const first = await service.createSession({
+      agentId: created.agent.id,
+      environmentId: environment.id,
+      title: "First run",
+    });
+    taskEventRepo.create({
+      taskId: first.backingTaskId!,
+      timestamp: Date.now(),
+      type: "task_status",
+      payload: { requestingUserId: "alice" },
+    });
+
+    const second = await service.createSession({
+      agentId: created.agent.id,
+      environmentId: environment.id,
+      title: "Second run",
+    });
+    taskEventRepo.create({
+      taskId: second.backingTaskId!,
+      timestamp: Date.now(),
+      type: "task_status",
+      payload: { requestingUserId: "bob" },
+    });
+
+    const insights = service.getAgentInsights(created.agent.id);
+
+    expect(insights.uniqueUsers).toBe(2);
   });
 });

--- a/src/electron/managed/agent-templates.ts
+++ b/src/electron/managed/agent-templates.ts
@@ -1,0 +1,235 @@
+import type {
+  AgentTemplate,
+  ManagedAgentStudioConfig,
+  ManagedEnvironmentConfig,
+} from "../../shared/types";
+
+function makeStudio(
+  studio: Partial<ManagedAgentStudioConfig>,
+): Partial<ManagedAgentStudioConfig> {
+  return studio;
+}
+
+function makeEnvironment(
+  environment: Partial<ManagedEnvironmentConfig>,
+): Partial<ManagedEnvironmentConfig> {
+  return environment;
+}
+
+export const BUILTIN_AGENT_TEMPLATES: AgentTemplate[] = [
+  {
+    id: "team-chat-qna",
+    name: "Team Chat Q&A",
+    description: "Answer common team questions in Slack using approved docs, files, and skills.",
+    tagline: "Build agents that reply in Slack",
+    icon: "💬",
+    color: "#1570ef",
+    category: "support",
+    systemPrompt:
+      "You answer team questions with concise, source-grounded responses. Prefer attached files, configured skills, and workspace context over guessing. If the answer is uncertain, say what is missing.",
+    executionMode: "solo",
+    skills: ["summarize", "github", "notion"],
+    studio: makeStudio({
+      skills: ["summarize", "github", "notion"],
+      apps: {
+        allowedToolFamilies: ["communication", "files", "search", "documents"],
+      },
+      memoryConfig: { mode: "focused", sources: ["workspace", "memory"] },
+      channelTargets: [],
+      scheduleConfig: { enabled: false, mode: "manual" },
+      audioSummaryConfig: { enabled: false, style: "executive-briefing" },
+    }),
+    environmentConfig: makeEnvironment({
+      enableShell: false,
+      enableBrowser: true,
+      enableComputerUse: false,
+      allowedToolFamilies: ["communication", "files", "search", "documents"],
+    }),
+  },
+  {
+    id: "morning-planner",
+    name: "Morning Planner",
+    description: "Turn calendar, open tasks, and inbox context into a clear daily plan.",
+    tagline: "Start with a proven workflow",
+    icon: "📅",
+    color: "#0ea5e9",
+    category: "planning",
+    featured: true,
+    systemPrompt:
+      "You prepare crisp morning plans. Synthesize calendar, inbox, and open work into a prioritized agenda with explicit next actions and blockers.",
+    executionMode: "solo",
+    runtimeDefaults: {
+      autonomousMode: true,
+      allowUserInput: true,
+    },
+    skills: ["calendly", "summarize"],
+    studio: makeStudio({
+      skills: ["calendly", "summarize"],
+      apps: {
+        allowedToolFamilies: ["communication", "files", "search"],
+      },
+      memoryConfig: { mode: "default", sources: ["memory", "workspace", "sessions"] },
+      scheduleConfig: {
+        enabled: true,
+        mode: "routine",
+        label: "Every morning",
+        cadenceMinutes: 24 * 60,
+      },
+      audioSummaryConfig: { enabled: true, style: "executive-briefing" },
+    }),
+    environmentConfig: makeEnvironment({
+      enableBrowser: true,
+      enableShell: false,
+      allowedToolFamilies: ["communication", "files", "search"],
+    }),
+  },
+  {
+    id: "bug-triage",
+    name: "Bug Triage",
+    description: "Review incoming bugs, prioritize them, and prepare a grounded triage summary.",
+    icon: "🐞",
+    color: "#f97316",
+    category: "engineering",
+    systemPrompt:
+      "You triage bugs. Classify severity, extract repro details, note likely owners, and produce a concise action-ready summary without inventing evidence.",
+    executionMode: "solo",
+    runtimeDefaults: {
+      autonomousMode: true,
+      allowUserInput: true,
+      requireWorktree: true,
+    },
+    skills: ["github", "code-review", "debug-error"],
+    studio: makeStudio({
+      skills: ["github", "code-review", "debug-error"],
+      apps: {
+        allowedToolFamilies: ["files", "search", "shell", "documents"],
+      },
+      memoryConfig: { mode: "focused", sources: ["workspace", "sessions"] },
+      scheduleConfig: { enabled: false, mode: "manual" },
+      audioSummaryConfig: { enabled: false, style: "study-guide" },
+    }),
+    environmentConfig: makeEnvironment({
+      enableShell: true,
+      enableBrowser: true,
+      allowedToolFamilies: ["files", "search", "shell", "documents"],
+    }),
+  },
+  {
+    id: "chief-of-staff",
+    name: "Chief of Staff",
+    description: "Prepare executive-style briefs from inbox, calendar, chats, and workspace context.",
+    icon: "🧳",
+    color: "#14b8a6",
+    category: "operations",
+    systemPrompt:
+      "You operate like a chief of staff. Build high-signal executive briefs, surface priorities, and recommend the next actions with a bias for clarity and leverage.",
+    executionMode: "solo",
+    runtimeDefaults: {
+      autonomousMode: true,
+      allowUserInput: true,
+    },
+    skills: ["usecase-chief-of-staff-briefing", "summarize"],
+    studio: makeStudio({
+      skills: ["usecase-chief-of-staff-briefing", "summarize"],
+      apps: {
+        allowedToolFamilies: ["communication", "files", "documents", "search"],
+      },
+      memoryConfig: { mode: "default", sources: ["memory", "workspace", "sessions"] },
+      scheduleConfig: { enabled: false, mode: "manual" },
+      audioSummaryConfig: { enabled: true, style: "public-radio" },
+    }),
+    environmentConfig: makeEnvironment({
+      enableBrowser: true,
+      allowedToolFamilies: ["communication", "files", "documents", "search"],
+    }),
+  },
+  {
+    id: "customer-reply-drafter",
+    name: "Customer Reply Drafter",
+    description: "Draft grounded replies from tickets, accounts, policy, and saved context.",
+    icon: "✉️",
+    color: "#8b5cf6",
+    category: "support",
+    systemPrompt:
+      "You draft customer replies. Stay grounded in the available context, keep the tone calm and clear, and flag missing evidence instead of guessing.",
+    executionMode: "solo",
+    skills: ["usecase-draft-reply", "summarize"],
+    studio: makeStudio({
+      skills: ["usecase-draft-reply", "summarize"],
+      apps: {
+        allowedToolFamilies: ["communication", "files", "documents"],
+      },
+      memoryConfig: { mode: "focused", sources: ["workspace", "memory"] },
+      scheduleConfig: { enabled: false, mode: "manual" },
+      channelTargets: [],
+    }),
+    environmentConfig: makeEnvironment({
+      enableBrowser: true,
+      allowedToolFamilies: ["communication", "files", "documents"],
+    }),
+  },
+  {
+    id: "research-analyst",
+    name: "Research Analyst",
+    description: "Investigate topics, synthesize findings, and maintain a concise answer trail.",
+    icon: "🔎",
+    color: "#2563eb",
+    category: "research",
+    systemPrompt:
+      "You are a research analyst. Find the highest-signal information, compare sources, and present a concise evidence-backed synthesis with explicit uncertainty when needed.",
+    executionMode: "solo",
+    runtimeDefaults: {
+      autonomousMode: true,
+      allowUserInput: true,
+      webSearchMode: "live",
+    },
+    skills: ["competitive-research", "research-last-days", "summarize"],
+    studio: makeStudio({
+      skills: ["competitive-research", "research-last-days", "summarize"],
+      apps: {
+        allowedToolFamilies: ["search", "files", "documents", "memory"],
+      },
+      memoryConfig: { mode: "default", sources: ["memory", "workspace", "sessions"] },
+      scheduleConfig: { enabled: false, mode: "manual" },
+      audioSummaryConfig: { enabled: true, style: "study-guide" },
+    }),
+    environmentConfig: makeEnvironment({
+      enableBrowser: true,
+      allowedToolFamilies: ["search", "files", "documents", "memory"],
+    }),
+  },
+  {
+    id: "inbox-follow-up-assistant",
+    name: "Inbox Follow-up Assistant",
+    description: "Track stale threads, draft follow-ups, and keep the inbox moving.",
+    icon: "📥",
+    color: "#22c55e",
+    category: "operations",
+    systemPrompt:
+      "You monitor inbox follow-ups. Find stale conversations, suggest the next reply, and keep the user moving without over-automating sensitive conversations.",
+    executionMode: "solo",
+    runtimeDefaults: {
+      autonomousMode: true,
+      allowUserInput: true,
+    },
+    skills: ["usecase-inbox-manager", "summarize"],
+    studio: makeStudio({
+      skills: ["usecase-inbox-manager", "summarize"],
+      apps: {
+        allowedToolFamilies: ["communication", "documents", "files"],
+      },
+      memoryConfig: { mode: "focused", sources: ["workspace", "sessions"] },
+      scheduleConfig: {
+        enabled: true,
+        mode: "recurring",
+        label: "Check for follow-ups",
+        cadenceMinutes: 180,
+      },
+      audioSummaryConfig: { enabled: false, style: "executive-briefing" },
+    }),
+    environmentConfig: makeEnvironment({
+      enableBrowser: true,
+      allowedToolFamilies: ["communication", "documents", "files"],
+    }),
+  },
+];

--- a/src/electron/managed/repositories.ts
+++ b/src/electron/managed/repositories.ts
@@ -181,6 +181,23 @@ export class ManagedAgentVersionRepository {
     return rows.map((row) => this.mapRow(row));
   }
 
+  updateMetadata(
+    agentId: string,
+    version: number,
+    metadata: Record<string, unknown> | undefined,
+  ): ManagedAgentVersion | undefined {
+    this.db
+      .prepare(
+        `
+        UPDATE managed_agent_versions
+        SET metadata_json = ?
+        WHERE agent_id = ? AND version = ?
+      `,
+      )
+      .run(metadata ? JSON.stringify(metadata) : null, agentId, version);
+    return this.find(agentId, version);
+  }
+
   private mapRow(row: Any): ManagedAgentVersion {
     return {
       agentId: String(row.agent_id ?? ""),

--- a/src/electron/routines/__tests__/service.test.ts
+++ b/src/electron/routines/__tests__/service.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HooksConfig } from "../../hooks/types";
+
+const nativeSqliteAvailable = await import("better-sqlite3")
+  .then((module) => {
+    try {
+      const Database = module.default;
+      const probe = new Database(":memory:");
+      probe.close();
+      return true;
+    } catch {
+      return false;
+    }
+  })
+  .catch(() => false);
+
+const describeWithSqlite = nativeSqliteAvailable ? describe : describe.skip;
+
+describeWithSqlite("RoutineService", () => {
+  let db: import("better-sqlite3").Database;
+  let RoutineServiceCtor: typeof import("../service").RoutineService;
+  let EventTriggerServiceCtor: typeof import("../../triggers/EventTriggerService").EventTriggerService;
+  let routineService: import("../service").RoutineService;
+  let eventTriggerService: import("../../triggers/EventTriggerService").EventTriggerService;
+  let hooksSettings: HooksConfig;
+  let cronService: {
+    add: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    const Database = (await import("better-sqlite3")).default;
+    db = new Database(":memory:");
+
+    ({ RoutineService: RoutineServiceCtor } = await import("../service"));
+    ({ EventTriggerService: EventTriggerServiceCtor } = await import(
+      "../../triggers/EventTriggerService"
+    ));
+
+    hooksSettings = {
+      enabled: true,
+      token: "global-token",
+      path: "/hooks",
+      maxBodyBytes: 256 * 1024,
+      presets: [],
+      mappings: [],
+    };
+
+    cronService = {
+      add: vi.fn().mockImplementation(async (job) => ({
+        ok: true,
+        job: { id: "cron-1", ...job, state: {} },
+      })),
+      update: vi.fn().mockImplementation(async (_id, patch) => ({
+        ok: true,
+        job: { id: "cron-1", ...patch, state: {} },
+      })),
+      remove: vi.fn().mockResolvedValue({ ok: true, removed: true }),
+    };
+
+    eventTriggerService = new EventTriggerServiceCtor({
+      createTask: vi.fn().mockResolvedValue({ id: "task-1" }),
+      getDefaultWorkspaceId: () => "ws-default",
+      log: vi.fn(),
+    });
+    eventTriggerService.start();
+
+    routineService = new RoutineServiceCtor({
+      db,
+      getCronService: () => cronService as Any,
+      getEventTriggerService: () => eventTriggerService,
+      loadHooksSettings: () => hooksSettings,
+      saveHooksSettings: (settings) => {
+        hooksSettings = settings;
+      },
+    });
+  });
+
+  it("creates managed schedule, api, and connector-event triggers", async () => {
+    const routine = await routineService.create({
+      name: "PR Triage",
+      enabled: true,
+      workspaceId: "ws-1",
+      prompt: "Review the incoming signal and draft the next action.",
+      connectors: ["github", "linear"],
+      triggers: [
+        {
+          id: "schedule-1",
+          type: "schedule",
+          enabled: true,
+          schedule: { kind: "cron", expr: "0 2 * * *" },
+        },
+        {
+          id: "api-1",
+          type: "api",
+          enabled: true,
+        },
+        {
+          id: "connector-1",
+          type: "connector_event",
+          enabled: true,
+          connectorId: "github",
+          changeType: "resource_updated",
+        },
+      ],
+    });
+
+    expect(cronService.add).toHaveBeenCalledTimes(1);
+    expect(hooksSettings.mappings).toHaveLength(1);
+    expect(hooksSettings.mappings[0]?.match?.path).toContain(`routines/${routine.id}/api-1`);
+    expect(hooksSettings.mappings[0]?.token).toBeTruthy();
+    expect(eventTriggerService.listTriggers()).toHaveLength(1);
+    expect(
+      routine.triggers.find((trigger) => trigger.type === "schedule" && trigger.managedCronJobId),
+    ).toBeTruthy();
+    expect(
+      routine.triggers.find((trigger) => trigger.type === "api" && trigger.token),
+    ).toBeTruthy();
+    expect(
+      routine.triggers.find(
+        (trigger) => trigger.type === "connector_event" && trigger.managedEventTriggerId,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("removes managed resources when a routine is deleted", async () => {
+    const routine = await routineService.create({
+      name: "Deploy Alerts",
+      enabled: true,
+      workspaceId: "ws-1",
+      prompt: "Triage deployment alerts.",
+      connectors: [],
+      triggers: [
+        {
+          id: "schedule-1",
+          type: "schedule",
+          enabled: true,
+          schedule: { kind: "cron", expr: "*/15 * * * *" },
+        },
+        {
+          id: "api-1",
+          type: "api",
+          enabled: true,
+        },
+        {
+          id: "connector-1",
+          type: "connector_event",
+          enabled: true,
+          connectorId: "github",
+        },
+      ],
+    });
+
+    const removed = await routineService.remove(routine.id);
+
+    expect(removed).toBe(true);
+    expect(cronService.remove).toHaveBeenCalledTimes(1);
+    expect(hooksSettings.mappings).toHaveLength(0);
+    expect(eventTriggerService.listTriggers()).toHaveLength(0);
+  });
+});

--- a/src/electron/routines/service.ts
+++ b/src/electron/routines/service.ts
@@ -1,0 +1,1579 @@
+import { randomUUID } from "crypto";
+import type { AgentConfig } from "../../shared/types";
+import { MCPSettingsManager } from "../mcp/settings";
+import { generateHookToken } from "../hooks/settings";
+import type { HookMappingConfig, HooksConfig } from "../hooks/types";
+import type { CronDeliveryConfig, CronEvent } from "../cron/types";
+import { CHANNEL_TYPES, type ChannelType } from "../gateway/channels/types";
+import type { EventTriggerService } from "../triggers/EventTriggerService";
+import type { EventTrigger, TriggerCondition, TriggerEvent, TriggerHistoryEntry } from "../triggers/types";
+import type {
+  Routine,
+  RoutineApiTrigger,
+  RoutineChannelEventTrigger,
+  RoutineConnectorEventTrigger,
+  RoutineCreate,
+  RoutineDefinition,
+  RoutineGithubEventTrigger,
+  RoutineMailboxEventTrigger,
+  RoutineManualTrigger,
+  RoutineOutput,
+  RoutinePatch,
+  RoutineRun,
+  RoutineRunStatus,
+  RoutineScheduleTrigger,
+  RoutineServiceDeps,
+  RoutineTrigger,
+  RoutineWebhookResponseOutput,
+} from "./types";
+
+const DEFAULT_EVENT_COOLDOWN_MS = 60_000;
+const DEFAULT_RUN_LIST_LIMIT = 50;
+
+type RoutineRunRecord = RoutineRun & {
+  runKey?: string;
+};
+
+export class RoutineService {
+  private readonly deps: Required<
+    Pick<
+      RoutineServiceDeps,
+      "db" | "getCronService" | "getEventTriggerService" | "loadHooksSettings" | "saveHooksSettings" | "now"
+    >
+  > &
+    Pick<
+      RoutineServiceDeps,
+      | "createTask"
+      | "createManagedSession"
+      | "runTaskOnDevice"
+      | "getTaskSnapshot"
+      | "getManagedSessionSnapshot"
+      | "onHooksConfigChanged"
+      | "onTriggerMutation"
+    >;
+
+  constructor(deps: RoutineServiceDeps) {
+    this.deps = {
+      ...deps,
+      now: deps.now ?? (() => Date.now()),
+    };
+    this.ensureSchema();
+  }
+
+  list(): Routine[] {
+    const rows = this.deps.db
+      .prepare("SELECT * FROM automation_routines ORDER BY updated_at DESC")
+      .all() as Any[];
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  get(id: string): Routine | null {
+    const row = this.deps.db
+      .prepare("SELECT * FROM automation_routines WHERE id = ?")
+      .get(id) as Any | undefined;
+    return row ? this.mapRow(row) : null;
+  }
+
+  async listRuns(routineId?: string, limit = DEFAULT_RUN_LIST_LIMIT): Promise<RoutineRun[]> {
+    await this.refreshRunStatuses(routineId);
+    const rows = (routineId
+      ? this.deps.db
+          .prepare(
+            `SELECT * FROM routine_runs
+             WHERE routine_id = ?
+             ORDER BY started_at DESC, created_at DESC
+             LIMIT ?`,
+          )
+          .all(routineId, limit)
+      : this.deps.db
+          .prepare(
+            `SELECT * FROM routine_runs
+             ORDER BY started_at DESC, created_at DESC
+             LIMIT ?`,
+          )
+          .all(limit)) as Any[];
+    return rows.map((row) => this.mapRunRow(row));
+  }
+
+  async create(input: RoutineCreate): Promise<Routine> {
+    const now = this.deps.now();
+    const routine = toCompatibilityRoutine({
+      id: randomUUID(),
+      name: input.name.trim(),
+      description: clean(input.description),
+      enabled: input.enabled ?? true,
+      workspaceId: input.workspaceId.trim(),
+      instructions: normalizeInstructions(input.instructions ?? input.prompt),
+      executionTarget: normalizeExecutionTarget(input.executionTarget),
+      contextBindings: normalizeContextBindings(input.contextBindings),
+      triggers: normalizeTriggers(input.triggers || []),
+      outputs: normalizeOutputs(input.outputs || []),
+      approvalPolicy: normalizeApprovalPolicy(input.approvalPolicy),
+      connectorPolicy: normalizeConnectorPolicy(input.connectorPolicy, input.connectors),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const synced = await this.syncRoutine(routine, null);
+    this.persist(synced);
+    return synced;
+  }
+
+  async update(id: string, patch: RoutinePatch): Promise<Routine | null> {
+    const existing = this.get(id);
+    if (!existing) return null;
+
+    const updated = toCompatibilityRoutine({
+      ...existing,
+      name: patch.name !== undefined ? patch.name.trim() : existing.name,
+      description:
+        patch.description !== undefined ? clean(patch.description) : existing.description,
+      enabled: patch.enabled ?? existing.enabled,
+      workspaceId: patch.workspaceId !== undefined ? patch.workspaceId.trim() : existing.workspaceId,
+      instructions:
+        patch.instructions !== undefined || patch.prompt !== undefined
+          ? normalizeInstructions(patch.instructions ?? patch.prompt)
+          : existing.instructions,
+      executionTarget:
+        patch.executionTarget !== undefined
+          ? normalizeExecutionTarget(patch.executionTarget)
+          : existing.executionTarget,
+      contextBindings:
+        patch.contextBindings !== undefined
+          ? normalizeContextBindings(patch.contextBindings)
+          : existing.contextBindings,
+      triggers: patch.triggers ? normalizeTriggers(patch.triggers) : existing.triggers,
+      outputs: patch.outputs ? normalizeOutputs(patch.outputs) : existing.outputs,
+      approvalPolicy:
+        patch.approvalPolicy !== undefined
+          ? normalizeApprovalPolicy(patch.approvalPolicy)
+          : existing.approvalPolicy,
+      connectorPolicy:
+        patch.connectorPolicy !== undefined || patch.connectors !== undefined
+          ? normalizeConnectorPolicy(patch.connectorPolicy, patch.connectors)
+          : existing.connectorPolicy,
+      updatedAt: this.deps.now(),
+    });
+
+    const synced = await this.syncRoutine(updated, existing);
+    this.persist(synced);
+    return synced;
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const routine = this.get(id);
+    if (!routine) return false;
+
+    let hooksTouched = false;
+    let eventTriggersTouched = false;
+    for (const trigger of routine.triggers) {
+      await this.teardownTrigger(trigger);
+      if (trigger.type === "api") hooksTouched = true;
+      if (isManagedEventRoutineTrigger(trigger)) eventTriggersTouched = true;
+    }
+
+    this.deps.db.prepare("DELETE FROM automation_routines WHERE id = ?").run(id);
+    this.deps.db.prepare("DELETE FROM routine_runs WHERE routine_id = ?").run(id);
+    if (hooksTouched) {
+      this.deps.onHooksConfigChanged?.(this.deps.loadHooksSettings());
+    }
+    if (eventTriggersTouched) {
+      await this.deps.onTriggerMutation?.();
+    }
+    return true;
+  }
+
+  async regenerateApiToken(routineId: string, triggerId: string): Promise<RoutineApiTrigger | null> {
+    const routine = this.get(routineId);
+    if (!routine) return null;
+
+    let changed = false;
+    const triggers = routine.triggers.map((trigger) => {
+      if (trigger.id !== triggerId || trigger.type !== "api") return trigger;
+      changed = true;
+      return {
+        ...trigger,
+        token: generateHookToken(),
+      };
+    });
+    if (!changed) return null;
+
+    const updated = await this.update(routineId, { triggers });
+    if (!updated) return null;
+    const trigger = updated.triggers.find((candidate) => candidate.id === triggerId);
+    return trigger?.type === "api" ? trigger : null;
+  }
+
+  async runNow(routineId: string): Promise<RoutineRun | null> {
+    const routine = this.get(routineId);
+    if (!routine || !routine.enabled) return null;
+
+    const manualTrigger =
+      routine.triggers.find((trigger): trigger is RoutineManualTrigger => trigger.type === "manual") ||
+      ({
+        id: `manual:${routine.id}`,
+        type: "manual",
+        enabled: true,
+      } satisfies RoutineManualTrigger);
+
+    const execution = await this.dispatchRoutineExecution(routine, manualTrigger, {
+      prompt: buildRoutinePrompt(routine, "manual", [
+        "Manual trigger context:",
+        "- Triggered from the Routines settings panel.",
+      ]),
+      sourceSummary: "Manual run",
+      source: "manual",
+    });
+
+    const run = this.upsertRun({
+      runKey: `manual:${routine.id}:${this.deps.now()}`,
+      routineId: routine.id,
+      triggerId: manualTrigger.id,
+      triggerType: manualTrigger.type,
+      startedAt: this.deps.now(),
+      finishedAt: execution.finishedAt,
+      sourceEventSummary: "Manual run",
+      backingTaskId: execution.taskId,
+      backingManagedSessionId: execution.managedSessionId,
+      outputStatus: execution.outputStatus,
+      status: execution.status,
+      errorSummary: execution.errorSummary,
+      artifactsSummary: execution.artifactsSummary,
+    });
+    await this.refreshRunStatuses(routine.id);
+    return run;
+  }
+
+  recordScheduledEvent(event: CronEvent): void {
+    if (event.action !== "started" && event.action !== "finished") return;
+    const routineMatch = this.findRoutineByManagedResource("managedCronJobId", event.jobId);
+    if (!routineMatch) return;
+
+    const runKey = `cron:${event.jobId}:${event.runAtMs ?? event.nextRunAtMs ?? this.deps.now()}`;
+    const existing = this.findRunByKey(runKey);
+    const startedAt = event.runAtMs ?? existing?.startedAt ?? this.deps.now();
+    const base = {
+      runKey,
+      routineId: routineMatch.routine.id,
+      triggerId: routineMatch.trigger.id,
+      triggerType: routineMatch.trigger.type,
+      startedAt,
+      sourceEventSummary: summarizeCronEvent(event),
+      backingTaskId: event.taskId ?? existing?.backingTaskId,
+      outputStatus: mapCronOutputStatus(event.status, Boolean(event.taskId)),
+    } as const;
+
+    if (event.action === "started") {
+      this.upsertRun({
+        ...base,
+        status: "running",
+      });
+      return;
+    }
+
+    this.upsertRun({
+      ...base,
+      finishedAt: this.deps.now(),
+      status: mapCronStatus(event.status),
+      errorSummary: event.error,
+    });
+  }
+
+  recordEventTriggerFire(payload: {
+    trigger: EventTrigger;
+    event: TriggerEvent;
+    historyEntry: TriggerHistoryEntry;
+  }): void {
+    const routineMatch = this.findRoutineByManagedResource(
+      "managedEventTriggerId",
+      payload.trigger.id,
+    );
+    if (!routineMatch) return;
+
+    this.upsertRun({
+      runKey: `event:${payload.historyEntry.id}`,
+      routineId: routineMatch.routine.id,
+      triggerId: routineMatch.trigger.id,
+      triggerType: routineMatch.trigger.type,
+      status: payload.historyEntry.taskId ? "queued" : "completed",
+      startedAt: payload.historyEntry.firedAt,
+      sourceEventSummary: summarizeTriggerEvent(payload.event),
+      backingTaskId: payload.historyEntry.taskId,
+      outputStatus: "none",
+      errorSummary: payload.historyEntry.actionResult?.startsWith("error:")
+        ? payload.historyEntry.actionResult
+        : undefined,
+      artifactsSummary: payload.historyEntry.actionResult,
+    });
+  }
+
+  recordApiTriggerDispatch(payload: {
+    mappingId?: string;
+    path?: string;
+    workspaceId?: string;
+    taskId?: string;
+    metadata?: Record<string, string>;
+    response?: { statusCode?: number; message?: string; includeTaskId?: boolean };
+  }): void {
+    const mappingId = payload.mappingId || payload.metadata?.mappingId;
+    const routineMatch = mappingId
+      ? this.findRoutineByManagedResource("managedHookMappingId", mappingId)
+      : this.findRoutineByApiPath(payload.path);
+    if (!routineMatch) return;
+
+    this.upsertRun({
+      runKey: `api:${mappingId || payload.path || routineMatch.trigger.id}:${this.deps.now()}`,
+      routineId: routineMatch.routine.id,
+      triggerId: routineMatch.trigger.id,
+      triggerType: routineMatch.trigger.type,
+      status: payload.taskId ? "queued" : "completed",
+      startedAt: this.deps.now(),
+      sourceEventSummary: payload.path ? `API request: ${payload.path}` : "API request",
+      backingTaskId: payload.taskId,
+      outputStatus: routineHasWebhookResponse(routineMatch.routine)
+        ? "responded"
+        : "none",
+      artifactsSummary: payload.response?.message,
+    });
+  }
+
+  private ensureSchema(): void {
+    this.deps.db.exec(`
+      CREATE TABLE IF NOT EXISTS automation_routines (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        workspace_id TEXT NOT NULL,
+        prompt TEXT NOT NULL,
+        connectors_json TEXT NOT NULL,
+        triggers_json TEXT NOT NULL,
+        definition_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_automation_routines_workspace
+      ON automation_routines(workspace_id, updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS routine_runs (
+        id TEXT PRIMARY KEY,
+        routine_id TEXT NOT NULL,
+        trigger_id TEXT NOT NULL,
+        trigger_type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        started_at INTEGER NOT NULL,
+        finished_at INTEGER,
+        source_event_summary TEXT,
+        backing_task_id TEXT,
+        backing_managed_session_id TEXT,
+        output_status TEXT NOT NULL DEFAULT 'none',
+        error_summary TEXT,
+        artifacts_summary TEXT,
+        run_key TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_routine_runs_routine
+      ON routine_runs(routine_id, started_at DESC, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_routine_runs_run_key
+      ON routine_runs(run_key);
+    `);
+
+    if (!columnExists(this.deps.db, "automation_routines", "definition_json")) {
+      this.deps.db.exec("ALTER TABLE automation_routines ADD COLUMN definition_json TEXT");
+    }
+    if (!columnExists(this.deps.db, "routine_runs", "run_key")) {
+      this.deps.db.exec("ALTER TABLE routine_runs ADD COLUMN run_key TEXT");
+    }
+  }
+
+  private mapRow(row: Any): Routine {
+    const createdAt = Number(row.created_at || this.deps.now());
+    const updatedAt = Number(row.updated_at || createdAt);
+    const definition = safeJsonParse<RoutineDefinition | null>(row.definition_json, null);
+    if (definition) {
+      return toCompatibilityRoutine(
+        normalizeRoutineDefinition({
+          ...definition,
+          id: String(row.id || definition.id),
+          name: String(row.name || definition.name),
+          description: row.description ? String(row.description) : definition.description,
+          enabled: row.enabled === undefined ? definition.enabled : Boolean(row.enabled),
+          workspaceId: String(row.workspace_id || definition.workspaceId),
+          createdAt,
+          updatedAt,
+        }),
+      );
+    }
+
+    return toCompatibilityRoutine(
+      normalizeRoutineDefinition({
+        id: String(row.id),
+        name: String(row.name),
+        description: row.description ? String(row.description) : undefined,
+        enabled: Boolean(row.enabled),
+        workspaceId: String(row.workspace_id),
+        instructions: normalizeInstructions(row.prompt),
+        executionTarget: { kind: "workspace" },
+        contextBindings: {},
+        triggers: normalizeTriggers(safeJsonParse<RoutineTrigger[]>(row.triggers_json, [])),
+        outputs: [{ kind: "task_only" }],
+        approvalPolicy: { mode: "inherit" },
+        connectorPolicy: {
+          mode: "prefer",
+          connectorIds: safeJsonParse<string[]>(row.connectors_json, []).filter(Boolean),
+        },
+        createdAt,
+        updatedAt,
+      }),
+    );
+  }
+
+  private mapRunRow(row: Any): RoutineRun {
+    return {
+      id: String(row.id),
+      routineId: String(row.routine_id),
+      triggerId: String(row.trigger_id),
+      triggerType: String(row.trigger_type) as RoutineTrigger["type"],
+      status: String(row.status) as RoutineRunStatus,
+      startedAt: Number(row.started_at),
+      finishedAt: row.finished_at ? Number(row.finished_at) : undefined,
+      sourceEventSummary: row.source_event_summary ? String(row.source_event_summary) : undefined,
+      backingTaskId: row.backing_task_id ? String(row.backing_task_id) : undefined,
+      backingManagedSessionId: row.backing_managed_session_id
+        ? String(row.backing_managed_session_id)
+        : undefined,
+      outputStatus: String(row.output_status || "none") as RoutineRun["outputStatus"],
+      errorSummary: row.error_summary ? String(row.error_summary) : undefined,
+      artifactsSummary: row.artifacts_summary ? String(row.artifacts_summary) : undefined,
+      createdAt: Number(row.created_at),
+      updatedAt: Number(row.updated_at),
+    };
+  }
+
+  private persist(routine: Routine): void {
+    this.deps.db
+      .prepare(
+        `INSERT OR REPLACE INTO automation_routines
+         (id, name, description, enabled, workspace_id, prompt, connectors_json, triggers_json, definition_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        routine.id,
+        routine.name,
+        routine.description || null,
+        routine.enabled ? 1 : 0,
+        routine.workspaceId,
+        routine.instructions,
+        JSON.stringify(routine.connectorPolicy.connectorIds),
+        JSON.stringify(routine.triggers),
+        JSON.stringify(stripCompatibilityFields(routine)),
+        routine.createdAt,
+        routine.updatedAt,
+      );
+  }
+
+  private async syncRoutine(routine: Routine, previous: Routine | null): Promise<Routine> {
+    const previousById = new Map((previous?.triggers || []).map((trigger) => [trigger.id, trigger]));
+    let hooksTouched = false;
+    let eventTriggersTouched = false;
+
+    const syncedTriggers: RoutineTrigger[] = [];
+    for (const trigger of routine.triggers) {
+      const previousTrigger = previousById.get(trigger.id);
+      switch (trigger.type) {
+        case "schedule":
+          syncedTriggers.push(await this.syncScheduleTrigger(routine, trigger));
+          break;
+        case "api":
+          syncedTriggers.push(await this.syncApiTrigger(routine, trigger));
+          hooksTouched = true;
+          break;
+        case "connector_event":
+        case "channel_event":
+        case "mailbox_event":
+        case "github_event":
+          syncedTriggers.push(await this.syncEventTrigger(routine, trigger, previousTrigger));
+          eventTriggersTouched = true;
+          break;
+        case "manual":
+          syncedTriggers.push(trigger);
+          break;
+      }
+      previousById.delete(trigger.id);
+    }
+
+    for (const staleTrigger of previousById.values()) {
+      await this.teardownTrigger(staleTrigger);
+      if (staleTrigger.type === "api") hooksTouched = true;
+      if (isManagedEventRoutineTrigger(staleTrigger)) eventTriggersTouched = true;
+    }
+
+    if (hooksTouched) {
+      this.deps.onHooksConfigChanged?.(this.deps.loadHooksSettings());
+    }
+    if (eventTriggersTouched) {
+      await this.deps.onTriggerMutation?.();
+    }
+
+    return toCompatibilityRoutine({
+      ...routine,
+      triggers: syncedTriggers,
+    });
+  }
+
+  private async syncScheduleTrigger(
+    routine: Routine,
+    trigger: RoutineScheduleTrigger,
+  ): Promise<RoutineScheduleTrigger> {
+    const cronService = this.deps.getCronService();
+    if (!cronService) {
+      throw new Error("Scheduled task service is not available");
+    }
+
+    const agentConfig = this.buildRoutineAgentConfig(routine);
+    const payload = {
+      name: `Routine: ${routine.name}`,
+      description: routine.description,
+      enabled: routine.enabled && trigger.enabled,
+      workspaceId: routine.workspaceId,
+      taskPrompt: buildRoutinePrompt(routine, "schedule"),
+      taskTitle: routine.name,
+      schedule: trigger.schedule,
+      allowUserInput: agentConfig?.allowUserInput ?? false,
+      taskAgentConfig: agentConfig,
+      chatContext: routine.contextBindings.chatContext,
+      delivery: buildScheduleDelivery(routine.outputs),
+    };
+
+    if (trigger.managedCronJobId) {
+      const updated = await cronService.update(trigger.managedCronJobId, payload);
+      if (updated.ok) {
+        return trigger;
+      }
+    }
+
+    const created = await cronService.add(payload);
+    if (!created.ok) {
+      throw new Error(created.error || "Failed to create scheduled routine trigger");
+    }
+    return {
+      ...trigger,
+      managedCronJobId: created.job.id,
+    };
+  }
+
+  private async syncApiTrigger(
+    routine: Routine,
+    trigger: RoutineApiTrigger,
+  ): Promise<RoutineApiTrigger> {
+    const managedHookMappingId =
+      trigger.managedHookMappingId || `routine:${routine.id}:api:${trigger.id}`;
+    const path = trigger.path || `routines/${routine.id}/${trigger.id}`;
+    const token = trigger.token?.trim() || generateHookToken();
+    const response = getWebhookResponseOutput(routine.outputs);
+
+    const nextTrigger: RoutineApiTrigger = {
+      ...trigger,
+      path,
+      token,
+      managedHookMappingId,
+    };
+
+    const settings = cloneHooksSettings(this.deps.loadHooksSettings());
+    settings.mappings = settings.mappings.filter((mapping) => mapping.id !== managedHookMappingId);
+
+    if (routine.enabled && trigger.enabled) {
+      const mapping: HookMappingConfig = {
+        id: managedHookMappingId,
+        token,
+        match: { path },
+        action: "agent",
+        name: routine.name,
+        workspaceId: routine.workspaceId,
+        messageTemplate: buildRoutinePrompt(routine, "api", [
+          "API request context:",
+          "- Source: {{source}}",
+          "- Type: {{type}}",
+          "- Request text: {{text}}",
+        ]),
+        agentConfig: this.buildRoutineAgentConfig(routine),
+        metadata: {
+          routineId: routine.id,
+          triggerId: trigger.id,
+          mappingId: managedHookMappingId,
+          hookPath: path,
+        },
+        response: response
+          ? {
+              statusCode: response.statusCode,
+              message: response.message,
+              includeTaskId: response.includeTaskId,
+            }
+          : undefined,
+      };
+      settings.mappings.push(mapping);
+    }
+
+    this.deps.saveHooksSettings(settings);
+    return nextTrigger;
+  }
+
+  private async syncEventTrigger(
+    routine: Routine,
+    trigger:
+      | RoutineConnectorEventTrigger
+      | RoutineChannelEventTrigger
+      | RoutineMailboxEventTrigger
+      | RoutineGithubEventTrigger,
+    _previous?: RoutineTrigger,
+  ): Promise<RoutineTrigger> {
+    const triggerService = this.deps.getEventTriggerService();
+    if (!triggerService) {
+      throw new Error("Event trigger service is not available");
+    }
+
+    const source = routineTriggerSource(trigger);
+    const nextTriggerId =
+      trigger.managedEventTriggerId || `routine:${routine.id}:${trigger.type}:${trigger.id}`;
+    const nextTrigger: EventTrigger = {
+      id: nextTriggerId,
+      name: `${routine.name} (${trigger.type.replace(/_/g, " ")})`,
+      description: routine.description,
+      enabled: routine.enabled && trigger.enabled,
+      source,
+      conditions: buildTriggerConditions(trigger),
+      conditionLogic: "all",
+      action: {
+        type: "create_task",
+        config: {
+          title: routine.name,
+          workspaceId: routine.workspaceId,
+          prompt: buildTriggeredPrompt(routine, trigger),
+          agentConfig: this.buildRoutineAgentConfig(routine),
+        },
+      },
+      workspaceId: routine.workspaceId,
+      cooldownMs: trigger.cooldownMs ?? DEFAULT_EVENT_COOLDOWN_MS,
+      fireCount: 0,
+      createdAt: this.deps.now(),
+      updatedAt: this.deps.now(),
+    };
+
+    const existing = triggerService.getTrigger(nextTriggerId);
+    if (existing) {
+      triggerService.updateTrigger(nextTriggerId, nextTrigger);
+      return {
+        ...trigger,
+        managedEventTriggerId: nextTriggerId,
+      };
+    }
+
+    const created = triggerService.addTrigger({
+      name: nextTrigger.name,
+      description: nextTrigger.description,
+      enabled: nextTrigger.enabled,
+      source: nextTrigger.source,
+      conditions: nextTrigger.conditions,
+      conditionLogic: nextTrigger.conditionLogic,
+      action: nextTrigger.action,
+      workspaceId: nextTrigger.workspaceId,
+      cooldownMs: nextTrigger.cooldownMs,
+    });
+
+    return {
+      ...trigger,
+      managedEventTriggerId: created.id,
+    };
+  }
+
+  private async teardownTrigger(trigger: RoutineTrigger): Promise<void> {
+    switch (trigger.type) {
+      case "schedule":
+        if (trigger.managedCronJobId) {
+          await this.deps.getCronService()?.remove(trigger.managedCronJobId);
+        }
+        return;
+      case "api":
+        if (!trigger.managedHookMappingId) return;
+        {
+          const settings = cloneHooksSettings(this.deps.loadHooksSettings());
+          settings.mappings = settings.mappings.filter(
+            (mapping) => mapping.id !== trigger.managedHookMappingId,
+          );
+          this.deps.saveHooksSettings(settings);
+        }
+        return;
+      case "connector_event":
+      case "channel_event":
+      case "mailbox_event":
+      case "github_event":
+        if (trigger.managedEventTriggerId) {
+          this.deps.getEventTriggerService()?.removeTrigger(trigger.managedEventTriggerId);
+        }
+        return;
+      case "manual":
+        return;
+    }
+  }
+
+  private buildRoutineAgentConfig(routine: Routine): AgentConfig | undefined {
+    const config: AgentConfig = {};
+
+    if (routine.connectorPolicy.mode === "allowlist" && routine.connectorPolicy.connectorIds.length > 0) {
+      config.allowedTools = resolveConnectorAllowedTools(routine.connectorPolicy.connectorIds);
+    }
+
+    switch (routine.approvalPolicy.mode) {
+      case "auto_safe":
+        config.autonomousMode = true;
+        config.allowUserInput = false;
+        config.pauseForRequiredDecision = true;
+        break;
+      case "confirm_external":
+      case "strict_confirm":
+        config.autonomousMode = false;
+        config.allowUserInput = true;
+        config.pauseForRequiredDecision = true;
+        break;
+      default:
+        break;
+    }
+
+    switch (routine.executionTarget.kind) {
+      case "worktree":
+        config.requireWorktree = true;
+        break;
+      case "device":
+      case "managed_environment":
+      case "workspace":
+        break;
+    }
+
+    return Object.keys(config).length > 0 ? config : undefined;
+  }
+
+  private async dispatchRoutineExecution(
+    routine: Routine,
+    trigger: RoutineTrigger,
+    params: {
+      prompt: string;
+      sourceSummary: string;
+      source: "manual" | "cron" | "hook" | "api";
+    },
+  ): Promise<{
+    taskId?: string;
+    managedSessionId?: string;
+    status: RoutineRunStatus;
+    outputStatus: RoutineRun["outputStatus"];
+    errorSummary?: string;
+    artifactsSummary?: string;
+    finishedAt?: number;
+  }> {
+    try {
+      const agentConfig = this.buildRoutineAgentConfig(routine);
+
+      if (routine.executionTarget.kind === "managed_environment") {
+        if (!routine.executionTarget.managedEnvironmentId || !this.deps.createManagedSession) {
+          throw new Error("Managed environment routines are not configured on this device");
+        }
+        const session = await this.deps.createManagedSession({
+          agentId:
+            typeof routine.contextBindings?.metadata?.managedAgentId === "string"
+              ? routine.contextBindings.metadata.managedAgentId
+              : undefined,
+          environmentId: routine.executionTarget.managedEnvironmentId,
+          title: routine.name,
+          prompt: params.prompt,
+        });
+        return {
+          taskId: session.backingTaskId,
+          managedSessionId: session.id,
+          status: session.backingTaskId ? "queued" : "running",
+          outputStatus: "none",
+        };
+      }
+
+      if (routine.executionTarget.kind === "device") {
+        if (!routine.executionTarget.deviceId || !this.deps.runTaskOnDevice) {
+          throw new Error("Remote device routines are not configured on this device");
+        }
+        const task = await this.deps.runTaskOnDevice({
+          deviceId: routine.executionTarget.deviceId,
+          title: routine.name,
+          prompt: params.prompt,
+          workspaceId: routine.workspaceId,
+          agentConfig,
+        });
+        return {
+          taskId: task.id,
+          status: "queued",
+          outputStatus: "none",
+        };
+      }
+
+      if (!this.deps.createTask) {
+        throw new Error(`Routine execution is unavailable for ${trigger.type} triggers`);
+      }
+
+      const task = await this.deps.createTask({
+        title: routine.name,
+        prompt: params.prompt,
+        workspaceId: routine.workspaceId,
+        agentConfig,
+        source: params.source,
+      });
+      return {
+        taskId: task.id,
+        status: "queued",
+        outputStatus: "none",
+      };
+    } catch (error) {
+      return {
+        status: "failed",
+        outputStatus: "failed",
+        errorSummary: error instanceof Error ? error.message : String(error),
+        finishedAt: this.deps.now(),
+      };
+    }
+  }
+
+  private async refreshRunStatuses(routineId?: string): Promise<void> {
+    const rows = (routineId
+      ? this.deps.db
+          .prepare(
+            `SELECT * FROM routine_runs
+             WHERE routine_id = ? AND status IN ('queued', 'running')
+             ORDER BY updated_at DESC`,
+          )
+          .all(routineId)
+      : this.deps.db
+          .prepare(
+            `SELECT * FROM routine_runs
+             WHERE status IN ('queued', 'running')
+             ORDER BY updated_at DESC`,
+          )
+          .all()) as Any[];
+
+    for (const row of rows) {
+      const run = this.mapRunRow(row);
+      if (run.backingManagedSessionId && this.deps.getManagedSessionSnapshot) {
+        const snapshot = await this.deps.getManagedSessionSnapshot(run.backingManagedSessionId);
+        if (!snapshot) continue;
+        const status =
+          snapshot.status === "completed"
+            ? "completed"
+            : snapshot.status === "failed" || snapshot.status === "cancelled"
+              ? "failed"
+              : "running";
+        this.upsertRun({
+          ...run,
+          status,
+          finishedAt:
+            status === "running" ? run.finishedAt : snapshot.completedAt || run.finishedAt || this.deps.now(),
+          backingTaskId: run.backingTaskId || snapshot.backingTaskId || undefined,
+          artifactsSummary: snapshot.latestSummary || run.artifactsSummary,
+        });
+        continue;
+      }
+
+      if (run.backingTaskId && this.deps.getTaskSnapshot) {
+        const snapshot = await this.deps.getTaskSnapshot(run.backingTaskId);
+        if (!snapshot) continue;
+        const status = mapTaskSnapshotStatus(snapshot.status, snapshot.terminalStatus);
+        this.upsertRun({
+          ...run,
+          status,
+          finishedAt:
+            status === "queued" || status === "running"
+              ? run.finishedAt
+              : snapshot.completedAt || run.finishedAt || this.deps.now(),
+          errorSummary: snapshot.error || run.errorSummary,
+          artifactsSummary: snapshot.resultSummary || run.artifactsSummary,
+        });
+      }
+    }
+  }
+
+  private upsertRun(input: {
+    runKey?: string;
+    routineId: string;
+    triggerId: string;
+    triggerType: RoutineTrigger["type"];
+    status: RoutineRunStatus;
+    startedAt: number;
+    finishedAt?: number;
+    sourceEventSummary?: string;
+    backingTaskId?: string;
+    backingManagedSessionId?: string;
+    outputStatus: RoutineRun["outputStatus"];
+    errorSummary?: string;
+    artifactsSummary?: string;
+  }): RoutineRun {
+    const now = this.deps.now();
+    const existing = input.runKey ? this.findRunByKey(input.runKey) : null;
+    const id = existing?.id || randomUUID();
+    const createdAt = existing?.createdAt || now;
+    this.deps.db
+      .prepare(
+        `INSERT OR REPLACE INTO routine_runs
+         (id, routine_id, trigger_id, trigger_type, status, started_at, finished_at, source_event_summary,
+          backing_task_id, backing_managed_session_id, output_status, error_summary, artifacts_summary,
+          run_key, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.routineId,
+        input.triggerId,
+        input.triggerType,
+        input.status,
+        input.startedAt,
+        input.finishedAt || null,
+        input.sourceEventSummary || null,
+        input.backingTaskId || null,
+        input.backingManagedSessionId || null,
+        input.outputStatus,
+        input.errorSummary || null,
+        input.artifactsSummary || null,
+        input.runKey || null,
+        createdAt,
+        now,
+      );
+
+    return {
+      id,
+      routineId: input.routineId,
+      triggerId: input.triggerId,
+      triggerType: input.triggerType,
+      status: input.status,
+      startedAt: input.startedAt,
+      finishedAt: input.finishedAt,
+      sourceEventSummary: input.sourceEventSummary,
+      backingTaskId: input.backingTaskId,
+      backingManagedSessionId: input.backingManagedSessionId,
+      outputStatus: input.outputStatus,
+      errorSummary: input.errorSummary,
+      artifactsSummary: input.artifactsSummary,
+      createdAt,
+      updatedAt: now,
+    };
+  }
+
+  private findRunByKey(runKey: string): RoutineRunRecord | null {
+    const row = this.deps.db
+      .prepare("SELECT * FROM routine_runs WHERE run_key = ? ORDER BY updated_at DESC LIMIT 1")
+      .get(runKey) as Any | undefined;
+    if (!row) return null;
+    return {
+      ...this.mapRunRow(row),
+      runKey: row.run_key ? String(row.run_key) : undefined,
+    };
+  }
+
+  private findRoutineByManagedResource(
+    field: "managedCronJobId" | "managedHookMappingId" | "managedEventTriggerId",
+    value: string,
+  ): { routine: Routine; trigger: RoutineTrigger } | null {
+    for (const routine of this.list()) {
+      const trigger = routine.triggers.find((candidate) => {
+        if (field === "managedCronJobId" && candidate.type === "schedule") {
+          return candidate.managedCronJobId === value;
+        }
+        if (field === "managedHookMappingId" && candidate.type === "api") {
+          return candidate.managedHookMappingId === value;
+        }
+        if (field === "managedEventTriggerId" && isManagedEventRoutineTrigger(candidate)) {
+          return candidate.managedEventTriggerId === value;
+        }
+        return false;
+      });
+      if (trigger) return { routine, trigger };
+    }
+    return null;
+  }
+
+  private findRoutineByApiPath(path?: string): { routine: Routine; trigger: RoutineApiTrigger } | null {
+    if (!path) return null;
+    const normalized = path.replace(/^\/+/, "").replace(/\/+$/, "");
+    for (const routine of this.list()) {
+      const trigger = routine.triggers.find(
+        (candidate): candidate is RoutineApiTrigger =>
+          candidate.type === "api" && candidate.path?.replace(/^\/+/, "").replace(/\/+$/, "") === normalized,
+      );
+      if (trigger) return { routine, trigger };
+    }
+    return null;
+  }
+}
+
+function columnExists(db: Any, tableName: string, columnName: string): boolean {
+  try {
+    const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name?: string }>;
+    return rows.some((row) => row.name === columnName);
+  } catch {
+    return false;
+  }
+}
+
+function stripCompatibilityFields(routine: Routine): RoutineDefinition {
+  const { prompt: _prompt, connectors: _connectors, ...definition } = routine;
+  return definition;
+}
+
+function toCompatibilityRoutine(routine: RoutineDefinition): Routine {
+  return {
+    ...routine,
+    prompt: routine.instructions,
+    connectors: routine.connectorPolicy.connectorIds,
+  };
+}
+
+function normalizeRoutineDefinition(input: RoutineDefinition): RoutineDefinition {
+  return {
+    ...input,
+    name: input.name.trim(),
+    description: clean(input.description),
+    workspaceId: input.workspaceId.trim(),
+    instructions: normalizeInstructions(input.instructions),
+    executionTarget: normalizeExecutionTarget(input.executionTarget),
+    contextBindings: normalizeContextBindings(input.contextBindings),
+    triggers: normalizeTriggers(input.triggers || []),
+    outputs: normalizeOutputs(input.outputs || []),
+    approvalPolicy: normalizeApprovalPolicy(input.approvalPolicy),
+    connectorPolicy: normalizeConnectorPolicy(input.connectorPolicy),
+  };
+}
+
+function normalizeExecutionTarget(target?: RoutineDefinition["executionTarget"]): RoutineDefinition["executionTarget"] {
+  return {
+    kind: target?.kind || "workspace",
+    deviceId: clean(target?.deviceId),
+    managedEnvironmentId: clean(target?.managedEnvironmentId),
+  };
+}
+
+function normalizeContextBindings(
+  bindings?: RoutineDefinition["contextBindings"],
+): RoutineDefinition["contextBindings"] {
+  const rawChannelType = bindings?.chatContext?.channelType?.trim();
+  const normalizedChannelType = rawChannelType && CHANNEL_TYPES.includes(rawChannelType as ChannelType)
+    ? (rawChannelType as ChannelType)
+    : undefined;
+  const chatContext =
+    normalizedChannelType && bindings?.chatContext?.channelId
+      ? {
+          channelType: normalizedChannelType,
+          channelId: bindings.chatContext.channelId.trim(),
+        }
+      : undefined;
+  const metadata = Object.fromEntries(
+    Object.entries(bindings?.metadata || {})
+      .map(([key, value]) => [key.trim(), String(value).trim()])
+      .filter(([key, value]) => key && value),
+  );
+  return {
+    chatContext,
+    metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+  };
+}
+
+function normalizeConnectorPolicy(
+  policy?: Partial<RoutineDefinition["connectorPolicy"]>,
+  compatibilityConnectors?: string[],
+): RoutineDefinition["connectorPolicy"] {
+  const connectorIds = Array.from(
+    new Set(
+      (policy?.connectorIds || compatibilityConnectors || [])
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  );
+  return {
+    mode: policy?.mode === "allowlist" ? "allowlist" : "prefer",
+    connectorIds,
+  };
+}
+
+function normalizeApprovalPolicy(
+  policy?: Partial<RoutineDefinition["approvalPolicy"]>,
+): RoutineDefinition["approvalPolicy"] {
+  switch (policy?.mode) {
+    case "auto_safe":
+    case "confirm_external":
+    case "strict_confirm":
+      return { mode: policy.mode };
+    default:
+      return { mode: "inherit" };
+  }
+}
+
+function normalizeOutputs(outputs: RoutineOutput[]): RoutineOutput[] {
+  const normalized = outputs.map((output): RoutineOutput => {
+      switch (output.kind) {
+        case "channel_message":
+          return {
+            kind: "channel_message",
+            channelType: clean(output.channelType),
+            channelDbId: clean(output.channelDbId),
+            channelId: clean(output.channelId),
+            deliverOnSuccess: output.deliverOnSuccess ?? true,
+            deliverOnError: output.deliverOnError ?? true,
+            summaryOnly: output.summaryOnly ?? false,
+          };
+        case "webhook_response":
+          return {
+            kind: "webhook_response",
+            statusCode: output.statusCode ?? 202,
+            message: clean(output.message),
+            includeTaskId: output.includeTaskId ?? true,
+          };
+        case "email":
+          return {
+            kind: "email",
+            to: clean(output.to),
+            subject: clean(output.subject),
+          };
+        case "github_comment":
+          return {
+            kind: "github_comment",
+            repository: clean(output.repository),
+            issueNumber: output.issueNumber,
+          };
+        case "issue_or_pr":
+          {
+            const mode: "issue" | "pr" | undefined =
+              output.mode === "pr" ? "pr" : output.mode === "issue" ? "issue" : undefined;
+          return {
+            kind: "issue_or_pr",
+            repository: clean(output.repository),
+            mode,
+          };
+          }
+        case "task_only":
+        default:
+          return { kind: "task_only" } satisfies RoutineOutput;
+      }
+    });
+  return normalized.length > 0 ? normalized : [{ kind: "task_only" }];
+}
+
+function normalizeTriggers(triggers: RoutineTrigger[]): RoutineTrigger[] {
+  return triggers.map((trigger) => {
+    const base = {
+      ...trigger,
+      id: trigger.id || randomUUID(),
+      enabled: trigger.enabled ?? true,
+    } as RoutineTrigger;
+
+    switch (base.type) {
+      case "schedule":
+        return {
+          ...base,
+          schedule:
+            base.schedule.kind === "at"
+              ? { kind: "at", atMs: Number(base.schedule.atMs) }
+              : base.schedule.kind === "every"
+                ? {
+                    kind: "every",
+                    everyMs: Number(base.schedule.everyMs),
+                    anchorMs: base.schedule.anchorMs ? Number(base.schedule.anchorMs) : undefined,
+                  }
+                : {
+                    kind: "cron",
+                    expr: base.schedule.expr.trim(),
+                    tz: clean(base.schedule.tz),
+                  },
+        };
+      case "api":
+        return {
+          ...base,
+          path: clean(base.path),
+          token: clean(base.token),
+        };
+      case "connector_event":
+        return {
+          ...base,
+          connectorId: base.connectorId.trim(),
+          changeType: clean(base.changeType),
+          resourceUriContains: clean(base.resourceUriContains),
+          conditions: normalizeConditions(base.conditions),
+        };
+      case "channel_event":
+        return {
+          ...base,
+          channelType: clean(base.channelType),
+          chatId: clean(base.chatId),
+          textContains: clean(base.textContains),
+          senderContains: clean(base.senderContains),
+          conditions: normalizeConditions(base.conditions),
+        };
+      case "mailbox_event":
+        return {
+          ...base,
+          eventType: clean(base.eventType),
+          subjectContains: clean(base.subjectContains),
+          provider: clean(base.provider),
+          labelContains: clean(base.labelContains),
+          conditions: normalizeConditions(base.conditions),
+        };
+      case "github_event":
+        return {
+          ...base,
+          eventName: clean(base.eventName),
+          repository: clean(base.repository),
+          action: clean(base.action),
+          ref: clean(base.ref),
+          conditions: normalizeConditions(base.conditions),
+        };
+      case "manual":
+      default:
+        return base;
+    }
+  });
+}
+
+function normalizeConditions(conditions?: TriggerCondition[]): TriggerCondition[] {
+  return (conditions || [])
+    .map((condition) => ({
+      field: condition.field.trim(),
+      operator: condition.operator,
+      value: condition.value.trim(),
+    }))
+    .filter((condition) => condition.field && condition.value);
+}
+
+function cloneHooksSettings(settings: HooksConfig): HooksConfig {
+  return {
+    ...settings,
+    presets: [...(settings.presets || [])],
+    mappings: [...(settings.mappings || [])],
+    gmail: settings.gmail ? { ...settings.gmail } : undefined,
+    resend: settings.resend ? { ...settings.resend } : undefined,
+  };
+}
+
+function buildRoutinePrompt(routine: Routine, triggerLabel: string, extraLines: string[] = []): string {
+  const sections = [
+    "You are running a saved CoWork Routine.",
+    `Routine: ${routine.name}`,
+    routine.description ? `Description: ${routine.description}` : null,
+    `Trigger: ${triggerLabel}`,
+    `Workspace ID: ${routine.workspaceId}`,
+    routine.connectorPolicy.mode === "prefer" && routine.connectorPolicy.connectorIds.length > 0
+      ? `Preferred connectors: ${routine.connectorPolicy.connectorIds.join(", ")}`
+      : null,
+    "",
+    "Saved instructions:",
+    routine.instructions,
+  ];
+
+  if (routine.contextBindings.metadata && Object.keys(routine.contextBindings.metadata).length > 0) {
+    sections.push(
+      "",
+      "Context bindings:",
+      ...Object.entries(routine.contextBindings.metadata).map(([key, value]) => `- ${key}: ${value}`),
+    );
+  }
+
+  if (extraLines.length > 0) {
+    sections.push("", ...extraLines);
+  }
+
+  return sections.filter(Boolean).join("\n");
+}
+
+function buildTriggeredPrompt(
+  routine: Routine,
+  trigger:
+    | RoutineConnectorEventTrigger
+    | RoutineChannelEventTrigger
+    | RoutineMailboxEventTrigger
+    | RoutineGithubEventTrigger,
+): string {
+  switch (trigger.type) {
+    case "connector_event":
+      return buildRoutinePrompt(routine, "connector event", [
+        "Connector event context:",
+        "- Connector ID: {{event.connectorId}}",
+        "- Change type: {{event.changeType}}",
+        "- Resource URI: {{event.resourceUri}}",
+        "- Payload: {{event.payload}}",
+      ]);
+    case "channel_event":
+      return buildRoutinePrompt(routine, "channel event", [
+        "Channel event context:",
+        "- Channel type: {{event.channelType}}",
+        "- Chat ID: {{event.chatId}}",
+        "- Sender: {{event.senderName}}",
+        "- Text: {{event.text}}",
+      ]);
+    case "mailbox_event":
+      return buildRoutinePrompt(routine, "mailbox event", [
+        "Mailbox event context:",
+        "- Event type: {{event.eventType}}",
+        "- Provider: {{event.provider}}",
+        "- Thread ID: {{event.threadId}}",
+        "- Subject: {{event.subject}}",
+        "- Summary: {{event.summary}}",
+      ]);
+    case "github_event":
+      return buildRoutinePrompt(routine, "github event", [
+        "GitHub event context:",
+        "- Event name: {{event.eventName}}",
+        "- Action: {{event.action}}",
+        "- Repository: {{event.repository}}",
+        "- Ref: {{event.ref}}",
+        "- Resource URI: {{event.resourceUri}}",
+      ]);
+  }
+}
+
+function buildTriggerConditions(
+  trigger:
+    | RoutineConnectorEventTrigger
+    | RoutineChannelEventTrigger
+    | RoutineMailboxEventTrigger
+    | RoutineGithubEventTrigger,
+): TriggerCondition[] {
+  const conditions: TriggerCondition[] = [...normalizeConditions(trigger.conditions)];
+  switch (trigger.type) {
+    case "connector_event":
+      conditions.push({ field: "connectorId", operator: "equals", value: trigger.connectorId });
+      if (trigger.changeType) {
+        conditions.push({ field: "changeType", operator: "equals", value: trigger.changeType });
+      }
+      if (trigger.resourceUriContains) {
+        conditions.push({
+          field: "resourceUri",
+          operator: "contains",
+          value: trigger.resourceUriContains,
+        });
+      }
+      break;
+    case "channel_event":
+      if (trigger.channelType) {
+        conditions.push({ field: "channelType", operator: "equals", value: trigger.channelType });
+      }
+      if (trigger.chatId) {
+        conditions.push({ field: "chatId", operator: "equals", value: trigger.chatId });
+      }
+      if (trigger.textContains) {
+        conditions.push({ field: "text", operator: "contains", value: trigger.textContains });
+      }
+      if (trigger.senderContains) {
+        conditions.push({
+          field: "senderName",
+          operator: "contains",
+          value: trigger.senderContains,
+        });
+      }
+      break;
+    case "mailbox_event":
+      if (trigger.eventType) {
+        conditions.push({ field: "eventType", operator: "equals", value: trigger.eventType });
+      }
+      if (trigger.provider) {
+        conditions.push({ field: "provider", operator: "equals", value: trigger.provider });
+      }
+      if (trigger.subjectContains) {
+        conditions.push({
+          field: "subject",
+          operator: "contains",
+          value: trigger.subjectContains,
+        });
+      }
+      if (trigger.labelContains) {
+        conditions.push({
+          field: "labels",
+          operator: "contains",
+          value: trigger.labelContains,
+        });
+      }
+      break;
+    case "github_event":
+      conditions.push({ field: "connectorId", operator: "equals", value: "github" });
+      if (trigger.eventName) {
+        conditions.push({ field: "eventName", operator: "equals", value: trigger.eventName });
+      }
+      if (trigger.repository) {
+        conditions.push({ field: "repository", operator: "equals", value: trigger.repository });
+      }
+      if (trigger.action) {
+        conditions.push({ field: "action", operator: "equals", value: trigger.action });
+      }
+      if (trigger.ref) {
+        conditions.push({ field: "ref", operator: "equals", value: trigger.ref });
+      }
+      break;
+  }
+  return conditions;
+}
+
+function buildScheduleDelivery(outputs: RoutineOutput[]): CronDeliveryConfig | undefined {
+  const channel = outputs.find((output): output is Extract<RoutineOutput, { kind: "channel_message" }> => output.kind === "channel_message");
+  if (!channel?.channelType || !channel.channelId) return undefined;
+  return {
+    enabled: true,
+    channelType: channel.channelType as CronDeliveryConfig["channelType"],
+    channelDbId: channel.channelDbId,
+    channelId: channel.channelId,
+    deliverOnSuccess: channel.deliverOnSuccess,
+    deliverOnError: channel.deliverOnError,
+    summaryOnly: channel.summaryOnly,
+  };
+}
+
+function getWebhookResponseOutput(outputs: RoutineOutput[]): RoutineWebhookResponseOutput | undefined {
+  return outputs.find(
+    (output): output is RoutineWebhookResponseOutput => output.kind === "webhook_response",
+  );
+}
+
+function routineHasWebhookResponse(routine: Routine): boolean {
+  return Boolean(getWebhookResponseOutput(routine.outputs));
+}
+
+function routineTriggerSource(
+  trigger:
+    | RoutineConnectorEventTrigger
+    | RoutineChannelEventTrigger
+    | RoutineMailboxEventTrigger
+    | RoutineGithubEventTrigger,
+): EventTrigger["source"] {
+  switch (trigger.type) {
+    case "channel_event":
+      return "channel_message";
+    case "mailbox_event":
+      return "mailbox_event";
+    case "github_event":
+      return "github_event";
+    case "connector_event":
+    default:
+      return "connector_event";
+  }
+}
+
+function isManagedEventRoutineTrigger(
+  trigger: RoutineTrigger,
+): trigger is
+  | RoutineConnectorEventTrigger
+  | RoutineChannelEventTrigger
+  | RoutineMailboxEventTrigger
+  | RoutineGithubEventTrigger {
+  return (
+    trigger.type === "connector_event" ||
+    trigger.type === "channel_event" ||
+    trigger.type === "mailbox_event" ||
+    trigger.type === "github_event"
+  );
+}
+
+function resolveConnectorAllowedTools(connectorIds: string[]): string[] {
+  const ids = connectorIds.map((id) => id.trim()).filter(Boolean);
+  if (ids.length === 0) return [];
+  const settings = MCPSettingsManager.loadSettings();
+  const prefix = settings.toolNamePrefix || "mcp_";
+  const out = new Set<string>();
+  for (const connectorId of ids) {
+    const server = MCPSettingsManager.getServer(connectorId);
+    if (!server) {
+      throw new Error(`Routine references unknown connector "${connectorId}"`);
+    }
+    if (!Array.isArray(server.tools) || server.tools.length === 0) {
+      throw new Error(`Routine connector "${connectorId}" does not expose any tool metadata`);
+    }
+    for (const tool of server.tools) {
+      if (tool?.name) out.add(`${prefix}${tool.name}`);
+    }
+  }
+  if (out.size === 0) {
+    throw new Error("Routine connector allowlist resolved to zero tools");
+  }
+  return Array.from(out);
+}
+
+function mapCronStatus(status?: CronEvent["status"]): RoutineRunStatus {
+  switch (status) {
+    case "ok":
+      return "completed";
+    case "partial_success":
+      return "partial_success";
+    case "needs_user_action":
+      return "needs_user_action";
+    case "error":
+    case "timeout":
+      return "failed";
+    case "skipped":
+      return "completed";
+    default:
+      return "running";
+  }
+}
+
+function mapCronOutputStatus(
+  status: CronEvent["status"] | undefined,
+  hasTaskId: boolean,
+): RoutineRun["outputStatus"] {
+  if (!hasTaskId) return "none";
+  if (status === "error" || status === "timeout") return "failed";
+  return "queued";
+}
+
+function summarizeCronEvent(event: CronEvent): string {
+  if (event.status) {
+    return `Scheduled run ${event.action}: ${event.status}`;
+  }
+  return `Scheduled run ${event.action}`;
+}
+
+function summarizeTriggerEvent(event: TriggerEvent): string {
+  switch (event.source) {
+    case "channel_message":
+      return `Channel event: ${String(event.fields.channelType || "")} ${String(event.fields.chatId || "")}`.trim();
+    case "mailbox_event":
+      return `Mailbox event: ${String(event.fields.eventType || "")}`.trim();
+    case "github_event":
+      return `GitHub event: ${String(event.fields.eventName || "")}`.trim();
+    case "connector_event":
+      return `Connector event: ${String(event.fields.connectorId || "")}`.trim();
+    default:
+      return event.source;
+  }
+}
+
+function mapTaskSnapshotStatus(
+  status: string,
+  terminalStatus?: string | null,
+): RoutineRunStatus {
+  if (status === "pending" || status === "queued") return "queued";
+  if (status === "planning" || status === "executing") return "running";
+  if (status === "paused" || terminalStatus === "needs_user_action") return "needs_user_action";
+  if (status === "failed" || terminalStatus === "failed") return "failed";
+  if (terminalStatus === "partial_success") return "partial_success";
+  if (status === "completed" || terminalStatus === "ok") return "completed";
+  return "running";
+}
+
+function normalizeInstructions(value: unknown): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) {
+    throw new Error("Routine instructions are required");
+  }
+  return text;
+}
+
+function clean(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}

--- a/src/electron/routines/types.ts
+++ b/src/electron/routines/types.ts
@@ -1,0 +1,298 @@
+import type { AgentConfig } from "../../shared/types";
+import type { ChannelType } from "../gateway/channels/types";
+import type { CronDeliveryConfig, CronSchedule } from "../cron/types";
+import type { CronService } from "../cron";
+import type { EventTriggerService } from "../triggers/EventTriggerService";
+import type { TriggerCondition } from "../triggers/types";
+import type { HooksConfig } from "../hooks/types";
+
+export type RoutineExecutionTargetKind =
+  | "workspace"
+  | "worktree"
+  | "device"
+  | "managed_environment";
+
+export interface RoutineExecutionTarget {
+  kind: RoutineExecutionTargetKind;
+  deviceId?: string;
+  managedEnvironmentId?: string;
+}
+
+export interface RoutineContextBindings {
+  chatContext?: {
+    channelType: ChannelType;
+    channelId: string;
+  };
+  metadata?: Record<string, string>;
+}
+
+export interface RoutineConnectorPolicy {
+  mode: "prefer" | "allowlist";
+  connectorIds: string[];
+}
+
+export interface RoutineApprovalPolicy {
+  mode: "inherit" | "auto_safe" | "confirm_external" | "strict_confirm";
+}
+
+export type RoutineOutput =
+  | RoutineTaskOnlyOutput
+  | RoutineChannelMessageOutput
+  | RoutineWebhookResponseOutput
+  | RoutineEmailOutput
+  | RoutineGithubCommentOutput
+  | RoutineIssueOrPrOutput;
+
+export interface RoutineTaskOnlyOutput {
+  kind: "task_only";
+}
+
+export interface RoutineChannelMessageOutput {
+  kind: "channel_message";
+  channelType?: string;
+  channelDbId?: string;
+  channelId?: string;
+  summaryOnly?: boolean;
+  deliverOnSuccess?: boolean;
+  deliverOnError?: boolean;
+}
+
+export interface RoutineWebhookResponseOutput {
+  kind: "webhook_response";
+  statusCode?: number;
+  message?: string;
+  includeTaskId?: boolean;
+}
+
+export interface RoutineEmailOutput {
+  kind: "email";
+  to?: string;
+  subject?: string;
+}
+
+export interface RoutineGithubCommentOutput {
+  kind: "github_comment";
+  repository?: string;
+  issueNumber?: number;
+}
+
+export interface RoutineIssueOrPrOutput {
+  kind: "issue_or_pr";
+  repository?: string;
+  mode?: "issue" | "pr";
+}
+
+export type RoutineTrigger =
+  | RoutineScheduleTrigger
+  | RoutineApiTrigger
+  | RoutineConnectorEventTrigger
+  | RoutineChannelEventTrigger
+  | RoutineMailboxEventTrigger
+  | RoutineGithubEventTrigger
+  | RoutineManualTrigger;
+
+export interface RoutineBaseTrigger {
+  id: string;
+  enabled: boolean;
+}
+
+export interface RoutineEventBaseTrigger extends RoutineBaseTrigger {
+  cooldownMs?: number;
+  conditions?: TriggerCondition[];
+  managedEventTriggerId?: string;
+}
+
+export interface RoutineScheduleTrigger extends RoutineBaseTrigger {
+  type: "schedule";
+  schedule: CronSchedule;
+  managedCronJobId?: string;
+}
+
+export interface RoutineApiTrigger extends RoutineBaseTrigger {
+  type: "api";
+  path?: string;
+  token?: string;
+  managedHookMappingId?: string;
+}
+
+export interface RoutineConnectorEventTrigger extends RoutineEventBaseTrigger {
+  type: "connector_event";
+  connectorId: string;
+  changeType?: string;
+  resourceUriContains?: string;
+}
+
+export interface RoutineChannelEventTrigger extends RoutineEventBaseTrigger {
+  type: "channel_event";
+  channelType?: string;
+  chatId?: string;
+  textContains?: string;
+  senderContains?: string;
+}
+
+export interface RoutineMailboxEventTrigger extends RoutineEventBaseTrigger {
+  type: "mailbox_event";
+  eventType?: string;
+  subjectContains?: string;
+  provider?: string;
+  labelContains?: string;
+}
+
+export interface RoutineGithubEventTrigger extends RoutineEventBaseTrigger {
+  type: "github_event";
+  eventName?: string;
+  repository?: string;
+  action?: string;
+  ref?: string;
+}
+
+export interface RoutineManualTrigger extends RoutineBaseTrigger {
+  type: "manual";
+}
+
+export interface RoutineDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  workspaceId: string;
+  instructions: string;
+  executionTarget: RoutineExecutionTarget;
+  contextBindings: RoutineContextBindings;
+  triggers: RoutineTrigger[];
+  outputs: RoutineOutput[];
+  approvalPolicy: RoutineApprovalPolicy;
+  connectorPolicy: RoutineConnectorPolicy;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Compatibility shape used by the existing renderer and older routine payloads.
+ * `prompt` mirrors `instructions`, and `connectors` mirrors `connectorPolicy.connectorIds`.
+ */
+export interface Routine extends RoutineDefinition {
+  prompt: string;
+  connectors: string[];
+}
+
+export interface RoutineCreate
+  extends Omit<
+    RoutineDefinition,
+    "id" | "createdAt" | "updatedAt" | "instructions" | "connectorPolicy" | "triggers" | "outputs"
+  > {
+  triggers?: RoutineTrigger[];
+  outputs?: RoutineOutput[];
+  instructions?: string;
+  prompt?: string;
+  connectorPolicy?: Partial<RoutineConnectorPolicy>;
+  connectors?: string[];
+}
+
+export type RoutinePatch = Partial<
+  Omit<
+    RoutineDefinition,
+    "id" | "createdAt" | "updatedAt" | "instructions" | "connectorPolicy" | "triggers" | "outputs"
+  >
+> & {
+  triggers?: RoutineTrigger[];
+  outputs?: RoutineOutput[];
+  instructions?: string;
+  prompt?: string;
+  connectorPolicy?: Partial<RoutineConnectorPolicy>;
+  connectors?: string[];
+};
+
+export type RoutineRunStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "partial_success"
+  | "needs_user_action"
+  | "failed";
+
+export type RoutineOutputStatus =
+  | "none"
+  | "queued"
+  | "sent"
+  | "responded"
+  | "failed";
+
+export interface RoutineRun {
+  id: string;
+  routineId: string;
+  triggerId: string;
+  triggerType: RoutineTrigger["type"];
+  status: RoutineRunStatus;
+  startedAt: number;
+  finishedAt?: number;
+  sourceEventSummary?: string;
+  backingTaskId?: string;
+  backingManagedSessionId?: string;
+  outputStatus: RoutineOutputStatus;
+  errorSummary?: string;
+  artifactsSummary?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RoutineTaskSnapshot {
+  status: string;
+  error?: string | null;
+  resultSummary?: string | null;
+  terminalStatus?: string | null;
+  completedAt?: number | null;
+}
+
+export interface RoutineManagedSessionSnapshot {
+  status: string;
+  latestSummary?: string | null;
+  completedAt?: number | null;
+  backingTaskId?: string | null;
+}
+
+export interface RoutineServiceDeps {
+  db: Any;
+  getCronService: () => CronService | null;
+  getEventTriggerService: () => EventTriggerService | null;
+  loadHooksSettings: () => HooksConfig;
+  saveHooksSettings: (settings: HooksConfig) => void;
+  createTask?: (params: {
+    title: string;
+    prompt: string;
+    workspaceId: string;
+    agentConfig?: AgentConfig;
+    source?: "manual" | "cron" | "hook" | "api";
+  }) => Promise<{ id: string }>;
+  onHooksConfigChanged?: (settings: HooksConfig) => void;
+  onTriggerMutation?: () => Promise<void> | void;
+  now?: () => number;
+  getTaskSnapshot?: (taskId: string) => Promise<RoutineTaskSnapshot | null> | RoutineTaskSnapshot | null;
+  createManagedSession?: (params: {
+    agentId?: string;
+    environmentId: string;
+    title: string;
+    prompt: string;
+  }) => Promise<{ id: string; backingTaskId?: string; workspaceId?: string }>;
+  runTaskOnDevice?: (params: {
+    deviceId: string;
+    title: string;
+    prompt: string;
+    workspaceId: string;
+    agentConfig?: AgentConfig;
+  }) => Promise<{ id: string }>;
+  getManagedSessionSnapshot?: (
+    sessionId: string,
+  ) => Promise<RoutineManagedSessionSnapshot | null> | RoutineManagedSessionSnapshot | null;
+}
+
+export interface CompiledRoutineTarget {
+  workspaceId: string;
+  agentConfig?: AgentConfig;
+  chatContext?: RoutineContextBindings["chatContext"];
+}
+
+export interface CompiledRoutineOutputs {
+  cronDelivery?: CronDeliveryConfig;
+  webhookResponse?: RoutineWebhookResponseOutput;
+}

--- a/src/electron/triggers/EventTriggerService.ts
+++ b/src/electron/triggers/EventTriggerService.ts
@@ -166,6 +166,7 @@ export class EventTriggerService {
             prompt,
             workspaceId:
               cfg.workspaceId || trigger.workspaceId || this.deps.getDefaultWorkspaceId(),
+            agentConfig: cfg.agentConfig,
           });
           historyEntry.taskId = result.id;
           historyEntry.actionResult = "task_created";

--- a/src/electron/triggers/types.ts
+++ b/src/electron/triggers/types.ts
@@ -5,12 +5,15 @@
  * webhooks, and other events to auto-create tasks or send messages.
  */
 
+import type { AgentConfig } from "../../shared/types";
+
 export type TriggerSource =
   | "channel_message"
   | "email"
   | "mailbox_event"
   | "webhook"
   | "connector_event"
+  | "github_event"
   | "file_change"
   | "cron_event";
 
@@ -53,6 +56,8 @@ export interface TriggerAction {
     agentRoleId?: string;
     /** Workspace to create task in */
     workspaceId?: string;
+    /** Optional per-task agent restrictions or routing hints */
+    agentConfig?: AgentConfig;
   };
 }
 
@@ -96,6 +101,7 @@ export interface EventTriggerServiceDeps {
     title: string;
     prompt: string;
     workspaceId: string;
+    agentConfig?: AgentConfig;
   }) => Promise<{ id: string }>;
   deliverToChannel?: (params: {
     channelType: string;

--- a/src/renderer/components/AgentsHubPanel.tsx
+++ b/src/renderer/components/AgentsHubPanel.tsx
@@ -1,0 +1,5003 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ArrowLeft,
+  ArrowUp,
+  BarChart3,
+  Bot,
+  Briefcase,
+  Bug,
+  CalendarDays,
+  ChevronLeft,
+  FileText,
+  Image as ImageIcon,
+  Inbox,
+  Library,
+  MessageSquare,
+  Play,
+  Plus,
+  Save,
+  Search,
+  Send,
+  ShieldCheck,
+  Slack,
+  Volume2,
+  Wrench,
+} from "lucide-react";
+import type {
+  AgentTemplate,
+  AgentWorkspaceMembership,
+  AgentWorkspacePermissionSnapshot,
+  ApprovalType,
+  AudioSummaryResult,
+  ChannelData,
+  ImageGenProfile,
+  ManagedAgent,
+  ManagedAgentAuditEntry,
+  ManagedAgentInsights,
+  ManagedAgentApprovalPolicy,
+  ManagedAgentChannelTarget,
+  ManagedAgentDeploymentConfig,
+  ManagedAgentFileRef,
+  ManagedAgentMemoryConfig,
+  ManagedAgentRoutineRecord,
+  ManagedAgentRoutineTriggerConfig,
+  ManagedAgentSlackDeploymentHealth,
+  ManagedAgentRuntimeToolCatalog,
+  ManagedAgentRuntimeToolCatalogEntry,
+  ManagedAgentScheduleConfig,
+  ManagedAgentSharingConfig,
+  ManagedAgentStudioConfig,
+  ManagedAgentToolFamily,
+  ManagedAgentVersion,
+  ManagedEnvironment,
+  ManagedSession,
+  ManagedSessionEvent,
+  ManagedSessionWorkpaper,
+  SecurityMode,
+  Workspace,
+} from "../../shared/types";
+
+type SkillLite = {
+  id: string;
+  name: string;
+  description?: string;
+};
+
+type AgentsLibraryTab = "library" | "recent" | "shared" | "scheduled" | "templates";
+
+type AgentDraft = {
+  agentId?: string;
+  status?: ManagedAgent["status"];
+  templateId?: string;
+  workflowBrief: string;
+  name: string;
+  description: string;
+  icon: string;
+  systemPrompt: string;
+  operatingNotes: string;
+  executionMode: ManagedAgentVersion["executionMode"];
+  selectedSkills: string[];
+  selectedMcpServers: string[];
+  selectedToolFamilies: ManagedAgentToolFamily[];
+  fileRefs: ManagedAgentFileRef[];
+  memoryConfig: ManagedAgentMemoryConfig;
+  scheduleConfig: ManagedAgentScheduleConfig;
+  channelTargets: ManagedAgentChannelTarget[];
+  audioSummaryEnabled: boolean;
+  audioSummaryStyle: "public-radio" | "executive-briefing" | "study-guide";
+  imageGenProfileId?: string;
+  sharing: ManagedAgentSharingConfig;
+  approvalPolicy: ManagedAgentApprovalPolicy;
+  deployment: ManagedAgentDeploymentConfig;
+  workspaceId: string;
+  enableShell: boolean;
+  enableBrowser: boolean;
+  enableComputerUse: boolean;
+  defaultEnvironmentId?: string;
+  routines: Array<{
+    id?: string;
+    name: string;
+    description?: string;
+    enabled: boolean;
+    trigger: ManagedAgentRoutineTriggerConfig;
+  }>;
+};
+
+type ConversionPanel = "agent-role" | "automation-profile" | null;
+
+type PersistStudioDraftResult = {
+  agentId: string;
+  environmentId: string;
+};
+
+interface AgentsHubPanelProps {
+  onOpenMissionControl?: () => void;
+  onOpenAgentPersonas?: () => void;
+  onOpenSlackSettings?: () => void;
+}
+
+const TOOL_FAMILY_OPTIONS: Array<{ id: ManagedAgentToolFamily; label: string }> = [
+  { id: "communication", label: "Communication" },
+  { id: "search", label: "Search" },
+  { id: "files", label: "Files" },
+  { id: "documents", label: "Documents" },
+  { id: "memory", label: "Memory" },
+  { id: "shell", label: "Shell" },
+  { id: "browser", label: "Browser" },
+  { id: "computer-use", label: "Computer Use" },
+  { id: "images", label: "Images" },
+];
+
+const APPROVAL_ACTION_OPTIONS = [
+  "send email",
+  "post message",
+  "edit spreadsheet",
+  "create calendar event",
+  "file external ticket",
+] as const;
+
+const APPROVAL_ACTION_RUNTIME_TYPE: Record<
+  (typeof APPROVAL_ACTION_OPTIONS)[number],
+  ApprovalType
+> = {
+  "send email": "external_service",
+  "post message": "external_service",
+  "edit spreadsheet": "data_export",
+  "create calendar event": "external_service",
+  "file external ticket": "external_service",
+};
+
+const APPROVAL_TYPE_LABELS: Record<ApprovalType, string> = {
+  delete_file: "Delete file",
+  delete_multiple: "Delete multiple",
+  bulk_rename: "Bulk rename",
+  network_access: "Network access",
+  data_export: "Data export",
+  external_service: "External service",
+  run_command: "Run command",
+  risk_gate: "Risk gate",
+  computer_use: "Computer use",
+};
+
+const RUNTIME_APPROVAL_KIND_LABELS = {
+  none: "No runtime gate",
+  workspace_policy: "Workspace policy",
+  external_service: "External service",
+  data_export: "Data export",
+  destructive: "Destructive",
+  shell_sensitive: "Shell sensitive",
+} as const;
+
+const TOOL_APPROVAL_BEHAVIOR_ORDER: Record<
+  ManagedAgentRuntimeToolCatalogEntry["approvalBehavior"],
+  number
+> = {
+  require_approval: 0,
+  workspace_policy: 1,
+  auto_approve: 2,
+  no_approval: 3,
+};
+
+function normalizeWorkflowText(value: string): string {
+  return value.toLocaleLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function titleizeWorkflowName(value: string): string {
+  return normalizeWorkflowText(value)
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 5)
+    .map((word) => word[0]?.toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function suggestTemplateFromWorkflowBrief(
+  workflowBrief: string,
+  templates: AgentTemplate[],
+): AgentTemplate | undefined {
+  const normalized = normalizeWorkflowText(workflowBrief);
+  if (!normalized) return templates[0];
+
+  const scored = templates
+    .map((template) => {
+      const haystack = normalizeWorkflowText(
+        [
+          template.name,
+          template.description,
+          template.tagline || "",
+          template.category,
+          template.systemPrompt,
+        ].join(" "),
+      );
+      let score = 0;
+      for (const token of normalized.split(/\s+/)) {
+        if (token.length < 3) continue;
+        if (haystack.includes(token)) score += 1;
+      }
+      return { template, score };
+    })
+    .sort((left, right) => right.score - left.score);
+
+  return scored[0]?.score ? scored[0].template : templates[0];
+}
+
+function getStudioConfig(version?: ManagedAgentVersion): ManagedAgentStudioConfig | undefined {
+  const metadata = version?.metadata;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return undefined;
+  const studio = (metadata as Record<string, unknown>).studio;
+  if (!studio || typeof studio !== "object" || Array.isArray(studio)) return undefined;
+  return studio as ManagedAgentStudioConfig;
+}
+
+function sessionStatusLabel(session: ManagedSession): string {
+  return session.status.replace(/_/g, " ");
+}
+
+function formatRelative(timestamp?: number): string {
+  if (!timestamp) return "";
+  const diffMs = Date.now() - timestamp;
+  const diffMinutes = Math.max(1, Math.round(diffMs / 60000));
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.round(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+function isTerminalManagedSessionStatus(status?: ManagedSession["status"]): boolean {
+  return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+function getManagedSessionEventText(event: ManagedSessionEvent): string {
+  const payload = event.payload as Record<string, unknown> | undefined;
+  const fromMessage = typeof payload?.message === "string" ? payload.message : undefined;
+  const fromContent = typeof payload?.content === "string" ? payload.content : undefined;
+  const fromSummary = typeof payload?.summary === "string" ? payload.summary : undefined;
+  return fromMessage || fromContent || fromSummary || event.type.replace(/\./g, " ");
+}
+
+export function buildDraftFromTemplate(template: AgentTemplate, workspaces: Workspace[]): AgentDraft {
+  const defaultWorkspaceId = workspaces[0]?.id || "";
+  return {
+    templateId: template.id,
+    workflowBrief: template.description,
+    name: template.name,
+    description: template.description,
+    icon: template.icon,
+    systemPrompt: template.systemPrompt,
+    operatingNotes: template.studio?.instructions?.operatingNotes || "",
+    executionMode: template.executionMode,
+    selectedSkills: template.skills || template.studio?.skills || [],
+    selectedMcpServers: template.mcpServers || template.studio?.apps?.mcpServers || [],
+    selectedToolFamilies: template.studio?.apps?.allowedToolFamilies || [],
+    fileRefs: template.studio?.fileRefs || [],
+    memoryConfig: template.studio?.memoryConfig || { mode: "default", sources: ["workspace"] },
+    scheduleConfig:
+      template.studio?.scheduleConfig || {
+        enabled: false,
+        mode: "manual",
+      },
+    channelTargets: template.studio?.channelTargets || [],
+    audioSummaryEnabled: template.studio?.audioSummaryConfig?.enabled || false,
+    audioSummaryStyle: template.studio?.audioSummaryConfig?.style || "executive-briefing",
+    imageGenProfileId: template.studio?.imageGenProfileId,
+    sharing: template.studio?.sharing || { visibility: "team" },
+    approvalPolicy:
+      template.studio?.approvalPolicy || {
+        autoApproveReadOnly: true,
+        requireApprovalFor: [],
+      },
+    deployment: template.studio?.deployment || { surfaces: ["chatgpt"] },
+    workspaceId: defaultWorkspaceId,
+    enableShell: !!template.environmentConfig?.enableShell,
+    enableBrowser: template.environmentConfig?.enableBrowser !== false,
+    enableComputerUse: !!template.environmentConfig?.enableComputerUse,
+    defaultEnvironmentId: template.studio?.defaultEnvironmentId,
+    routines: [
+      {
+        name: `${template.name} manual run`,
+        description: template.description,
+        enabled: true,
+        trigger: { type: "manual", enabled: true },
+      },
+    ],
+  };
+}
+
+export function buildDraftFromAgent(
+  agent: ManagedAgent,
+  version: ManagedAgentVersion | undefined,
+  environments: ManagedEnvironment[],
+  workspaces: Workspace[],
+  routines: ManagedAgentRoutineRecord[] = [],
+): AgentDraft {
+  const studio = getStudioConfig(version);
+  const environment = environments.find((entry) => entry.id === studio?.defaultEnvironmentId);
+  return {
+    agentId: agent.id,
+    status: agent.status,
+    templateId: studio?.templateId,
+    workflowBrief: studio?.workflowBrief || agent.description || "",
+    name: agent.name,
+    description: agent.description || "",
+    icon: studio?.templateId ? "🤖" : "🤖",
+    systemPrompt: version?.systemPrompt || "",
+    operatingNotes: studio?.instructions?.operatingNotes || "",
+    executionMode: version?.executionMode || "solo",
+    selectedSkills: studio?.skills || version?.skills || [],
+    selectedMcpServers: studio?.apps?.mcpServers || version?.mcpServers || [],
+    selectedToolFamilies: studio?.apps?.allowedToolFamilies || [],
+    fileRefs: studio?.fileRefs || [],
+    memoryConfig: studio?.memoryConfig || { mode: "default", sources: ["workspace"] },
+    scheduleConfig:
+      studio?.scheduleConfig || {
+        enabled: false,
+        mode: "manual",
+      },
+    channelTargets: studio?.channelTargets || [],
+    audioSummaryEnabled: studio?.audioSummaryConfig?.enabled || false,
+    audioSummaryStyle: studio?.audioSummaryConfig?.style || "executive-briefing",
+    imageGenProfileId: studio?.imageGenProfileId,
+    sharing: studio?.sharing || { visibility: "team" },
+    approvalPolicy:
+      studio?.approvalPolicy || {
+        autoApproveReadOnly: true,
+        requireApprovalFor: [],
+      },
+    deployment: studio?.deployment || {
+      surfaces: (studio?.channelTargets?.length || 0) > 0 ? ["chatgpt", "slack"] : ["chatgpt"],
+    },
+    workspaceId: environment?.config.workspaceId || workspaces[0]?.id || "",
+    enableShell: !!environment?.config.enableShell,
+    enableBrowser: environment?.config.enableBrowser !== false,
+    enableComputerUse: !!environment?.config.enableComputerUse,
+    defaultEnvironmentId: studio?.defaultEnvironmentId,
+    routines: routines.map((routine) => ({
+      id: routine.id,
+      name: routine.name,
+      description: routine.description,
+      enabled: routine.enabled,
+      trigger: routine.trigger,
+    })),
+  };
+}
+
+export function makeBlankDraft(workspaces: Workspace[]): AgentDraft {
+  return {
+    workflowBrief: "",
+    name: "New Agent",
+    description: "",
+    icon: "🤖",
+    systemPrompt: "You are a focused CoWork OS agent.",
+    operatingNotes: "",
+    executionMode: "solo",
+    selectedSkills: [],
+    selectedMcpServers: [],
+    selectedToolFamilies: ["communication", "search", "files"],
+    fileRefs: [],
+    memoryConfig: { mode: "default", sources: ["workspace"] },
+    scheduleConfig: { enabled: false, mode: "manual" },
+    channelTargets: [],
+    audioSummaryEnabled: false,
+    audioSummaryStyle: "executive-briefing",
+    sharing: { visibility: "team" },
+    approvalPolicy: {
+      autoApproveReadOnly: true,
+      requireApprovalFor: [],
+    },
+    deployment: { surfaces: ["chatgpt"] },
+    workspaceId: workspaces[0]?.id || "",
+    enableShell: false,
+    enableBrowser: true,
+    enableComputerUse: false,
+    routines: [
+      {
+        name: "Manual run",
+        enabled: true,
+        trigger: { type: "manual", enabled: true },
+      },
+    ],
+  };
+}
+
+export function buildDraftFromWorkflowBrief(
+  workflowBrief: string,
+  templates: AgentTemplate[],
+  workspaces: Workspace[],
+): AgentDraft {
+  const suggestedTemplate = suggestTemplateFromWorkflowBrief(workflowBrief, templates);
+  const baseDraft = suggestedTemplate
+    ? buildDraftFromTemplate(suggestedTemplate, workspaces)
+    : makeBlankDraft(workspaces);
+  const trimmed = workflowBrief.trim();
+  const derivedName = titleizeWorkflowName(trimmed) || baseDraft.name;
+
+  return {
+    ...baseDraft,
+    workflowBrief: trimmed,
+    name: derivedName,
+    description: trimmed || baseDraft.description,
+    systemPrompt: trimmed
+      ? `${baseDraft.systemPrompt}\n\nPrimary workflow:\n${trimmed}\n\nFollow the team process, ask for approval when required, and leave reviewable outputs.`
+      : baseDraft.systemPrompt,
+  };
+}
+
+export function getEffectiveApprovalPreview(
+  approvalPolicy?: ManagedAgentApprovalPolicy,
+  deployment?: ManagedAgentDeploymentConfig,
+) {
+  const autoApproveReadOnly = approvalPolicy?.autoApproveReadOnly !== false;
+  const requiredActions = approvalPolicy?.requireApprovalFor || [];
+  const surfaces = deployment?.surfaces || ["chatgpt"];
+  const autoApproved = autoApproveReadOnly ? ["read-only web and knowledge lookups"] : [];
+  const gatedActions =
+    requiredActions.length > 0
+      ? requiredActions
+      : ["send email", "post message", "edit spreadsheet", "create calendar event"];
+
+  const sharedSummary = autoApproveReadOnly
+    ? "Read-only lookup work can keep moving without a prompt."
+    : "Even read-only lookup work will wait when the runtime marks it as approval-worthy.";
+
+  return {
+    autoApproved,
+    gatedActions,
+    sharedSummary,
+    chatgptSummary: autoApproveReadOnly
+      ? "In CoWork OS, the agent can research and gather context on its own, then pause for sensitive follow-through."
+      : "In CoWork OS, the agent will pause more often and rely on explicit approvals before continuing.",
+    slackSummary: surfaces.includes("slack")
+      ? autoApproveReadOnly
+        ? "In Slack, the agent can answer quickly from trusted context, but sensitive follow-through still pauses for approval."
+        : "In Slack, the agent can respond, but actions remain tightly gated and will pause for approval."
+      : "Slack deployment is off, so approvals only affect direct managed runs for now.",
+  };
+}
+
+export function getApprovalRuntimeMatrix(
+  approvalPolicy?: ManagedAgentApprovalPolicy,
+): Array<{
+  semanticAction: string;
+  runtimeType: ApprovalType;
+  runtimeLabel: string;
+  behavior: "auto_approve" | "require_approval";
+}> {
+  const rows: Array<{
+    semanticAction: string;
+    runtimeType: ApprovalType;
+    runtimeLabel: string;
+    behavior: "auto_approve" | "require_approval";
+  }> = [];
+  const requiredActions = new Set(approvalPolicy?.requireApprovalFor || []);
+  const autoApproveReadOnly = approvalPolicy?.autoApproveReadOnly !== false;
+
+  rows.push({
+    semanticAction: "Read-only research and documentation lookup",
+    runtimeType: "network_access",
+    runtimeLabel: APPROVAL_TYPE_LABELS.network_access,
+    behavior: autoApproveReadOnly ? "auto_approve" : "require_approval",
+  });
+
+  for (const action of APPROVAL_ACTION_OPTIONS) {
+    const runtimeType = APPROVAL_ACTION_RUNTIME_TYPE[action];
+    rows.push({
+      semanticAction: action,
+      runtimeType,
+      runtimeLabel: APPROVAL_TYPE_LABELS[runtimeType],
+      behavior: requiredActions.has(action) ? "require_approval" : "auto_approve",
+    });
+  }
+
+  return rows;
+}
+
+export function sortRuntimeToolCatalogEntries(
+  entries: ManagedAgentRuntimeToolCatalogEntry[],
+): ManagedAgentRuntimeToolCatalogEntry[] {
+  return [...entries].sort((left, right) => {
+    const behaviorDelta =
+      TOOL_APPROVAL_BEHAVIOR_ORDER[left.approvalBehavior] -
+      TOOL_APPROVAL_BEHAVIOR_ORDER[right.approvalBehavior];
+    if (behaviorDelta !== 0) return behaviorDelta;
+    if (left.sideEffectLevel !== right.sideEffectLevel) {
+      const sideEffectOrder = { high: 0, medium: 1, low: 2, none: 3 } as const;
+      return sideEffectOrder[left.sideEffectLevel] - sideEffectOrder[right.sideEffectLevel];
+    }
+    return left.name.localeCompare(right.name);
+  });
+}
+
+function getAgentAnalytics(
+  agent: ManagedAgent,
+  sessions: ManagedSession[],
+  studio: ManagedAgentStudioConfig | undefined,
+) {
+  const agentSessions = sessions.filter((session) => session.agentId === agent.id);
+  const completedRuns = agentSessions.filter((session) => session.status === "completed").length;
+  const activeRuns = agentSessions.filter(
+    (session) => session.status === "pending" || session.status === "running",
+  ).length;
+  const latestRunAt = agentSessions[0]?.updatedAt;
+
+  return {
+    totalRuns: agentSessions.length,
+    completedRuns,
+    activeRuns,
+    successRate:
+      agentSessions.length > 0 ? Math.round((completedRuns / agentSessions.length) * 100) : 0,
+    latestRunAt,
+    slackTargets: studio?.channelTargets?.length || 0,
+    approvalActions: studio?.approvalPolicy?.requireApprovalFor?.length || 0,
+    surfaces: studio?.deployment?.surfaces || ["chatgpt"],
+  };
+}
+
+function makeBlankRoutine(
+  type: ManagedAgentRoutineTriggerConfig["type"] = "manual",
+): AgentDraft["routines"][number] {
+  return {
+    name:
+      type === "schedule"
+        ? "Scheduled run"
+        : type === "api"
+          ? "API trigger"
+          : type === "channel_event"
+            ? "Channel event"
+            : type === "mailbox_event"
+              ? "Mailbox event"
+              : type === "github_event"
+                ? "GitHub event"
+                : type === "connector_event"
+                  ? "Connector event"
+                  : "Manual run",
+    enabled: true,
+    trigger:
+      type === "schedule"
+        ? { type, enabled: true, cadenceMinutes: 60 }
+        : type === "api"
+          ? { type, enabled: true, path: "/agents/run" }
+          : type === "channel_event"
+            ? { type, enabled: true, channelType: "slack" }
+            : type === "mailbox_event"
+              ? { type, enabled: true, provider: "gmail" }
+              : type === "github_event"
+                ? { type, enabled: true }
+                : type === "connector_event"
+                  ? { type, enabled: true, connectorId: "github" }
+                  : { type: "manual", enabled: true },
+  };
+}
+
+export function getSlackDeploymentHealth(
+  studio: ManagedAgentStudioConfig | undefined,
+  slackChannels: ChannelData[],
+  agentId = "",
+): ManagedAgentSlackDeploymentHealth {
+  const healthTargets = (studio?.channelTargets || [])
+    .filter((target) => target.channelType === "slack")
+    .map((target) => {
+      const channel = slackChannels.find((entry) => entry.id === target.channelId);
+      const status = channel?.status || "disconnected";
+      return {
+        channelId: target.channelId,
+        channelName: target.channelName || channel?.name || target.channelId,
+        status,
+        connected: status === "connected" && !channel?.configReadError,
+        misconfigured: status !== "connected" || Boolean(channel?.configReadError),
+        securityMode: target.securityMode,
+        progressRelayMode: target.progressRelayMode,
+        configReadError: channel?.configReadError,
+      };
+    });
+  return {
+    agentId,
+    connectedCount: healthTargets.filter((target) => target.connected).length,
+    misconfiguredCount: healthTargets.filter((target) => target.misconfigured).length,
+    targets: healthTargets,
+    updatedAt: Date.now(),
+  };
+}
+
+export function normalizeSlackDeploymentHealth(
+  health: ManagedAgentSlackDeploymentHealth | null | undefined,
+  fallback: ManagedAgentSlackDeploymentHealth,
+): ManagedAgentSlackDeploymentHealth {
+  if (!health) return fallback;
+  const targets = Array.isArray(health.targets) ? health.targets : fallback.targets;
+  return {
+    ...fallback,
+    ...health,
+    targets,
+    connectedCount:
+      typeof health.connectedCount === "number"
+        ? health.connectedCount
+        : targets.filter((target) => target.connected).length,
+    misconfiguredCount:
+      typeof health.misconfiguredCount === "number"
+        ? health.misconfiguredCount
+        : targets.filter((target) => target.misconfigured).length,
+    updatedAt: typeof health.updatedAt === "number" ? health.updatedAt : fallback.updatedAt,
+  };
+}
+
+function getTemplateGlyph(template: AgentTemplate) {
+  switch (template.id) {
+    case "team-chat-qna":
+      return MessageSquare;
+    case "morning-planner":
+      return CalendarDays;
+    case "bug-triage":
+      return Bug;
+    case "chief-of-staff":
+      return Briefcase;
+    case "customer-reply-drafter":
+      return Send;
+    case "research-analyst":
+      return Search;
+    case "inbox-follow-up-assistant":
+      return Inbox;
+    default:
+      switch (template.category) {
+        case "support":
+          return MessageSquare;
+        case "planning":
+          return CalendarDays;
+        case "engineering":
+          return Bug;
+        case "operations":
+          return Briefcase;
+        case "research":
+          return Search;
+        default:
+          return Bot;
+      }
+  }
+}
+
+export function AgentsHubPanel({
+  onOpenMissionControl,
+  onOpenAgentPersonas,
+  onOpenSlackSettings,
+}: AgentsHubPanelProps) {
+  void onOpenMissionControl;
+  void onOpenSlackSettings;
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [agents, setAgents] = useState<ManagedAgent[]>([]);
+  const [agentDetails, setAgentDetails] = useState<Record<string, ManagedAgentVersion | undefined>>({});
+  const [sessions, setSessions] = useState<ManagedSession[]>([]);
+  const [templates, setTemplates] = useState<AgentTemplate[]>([]);
+  const [skills, setSkills] = useState<SkillLite[]>([]);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [environments, setEnvironments] = useState<ManagedEnvironment[]>([]);
+  const [slackChannels, setSlackChannels] = useState<ChannelData[]>([]);
+  const [mcpServerIds, setMcpServerIds] = useState<Array<{ id: string; name: string }>>([]);
+  const [imageProfiles, setImageProfiles] = useState<ImageGenProfile[]>([]);
+  const [studioDraft, setStudioDraft] = useState<AgentDraft | null>(null);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [audioResults, setAudioResults] = useState<Record<string, AudioSummaryResult>>({});
+  const [agentRoutines, setAgentRoutines] = useState<Record<string, ManagedAgentRoutineRecord[]>>({});
+  const [agentInsights, setAgentInsights] = useState<Record<string, ManagedAgentInsights>>({});
+  const [agentAudit, setAgentAudit] = useState<Record<string, ManagedAgentAuditEntry[]>>({});
+  const [slackHealth, setSlackHealth] = useState<Record<string, ManagedAgentSlackDeploymentHealth>>({});
+  const [sessionWorkpapers, setSessionWorkpapers] = useState<Record<string, ManagedSessionWorkpaper>>(
+    {},
+  );
+  const [runtimeCatalogs, setRuntimeCatalogs] = useState<
+    Record<string, ManagedAgentRuntimeToolCatalog | null | undefined>
+  >({});
+  const [runtimeCatalogErrors, setRuntimeCatalogErrors] = useState<Record<string, string>>({});
+  const [runtimeCatalogLoadingId, setRuntimeCatalogLoadingId] = useState<string | null>(null);
+  const [libraryTab, setLibraryTab] = useState<AgentsLibraryTab>("library");
+  const [workflowComposer, setWorkflowComposer] = useState("");
+  const [newProfileName, setNewProfileName] = useState("");
+  const [newProfileDescription, setNewProfileDescription] = useState("");
+  const [workspaceMemberships, setWorkspaceMemberships] = useState<AgentWorkspaceMembership[]>([]);
+  const [workspacePermissions, setWorkspacePermissions] = useState<
+    Record<string, AgentWorkspacePermissionSnapshot>
+  >({});
+  const [agentRoles, setAgentRoles] = useState<Any[]>([]);
+  const [automationProfiles, setAutomationProfiles] = useState<Any[]>([]);
+  const [conversionPanel, setConversionPanel] = useState<ConversionPanel>(null);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [showcaseIndex, setShowcaseIndex] = useState(0);
+  const [isCreateComposerOpen, setIsCreateComposerOpen] = useState(false);
+  const [studioTestPrompt, setStudioTestPrompt] = useState("");
+  const [studioTestSessionId, setStudioTestSessionId] = useState<string | null>(null);
+  const [studioSessionEvents, setStudioSessionEvents] = useState<Record<string, ManagedSessionEvent[]>>({});
+  const [studioTestRunning, setStudioTestRunning] = useState(false);
+  const [studioTestError, setStudioTestError] = useState<string | null>(null);
+
+  const loadData = async () => {
+    try {
+      setLoading(true);
+      const [
+        managedAgents,
+        managedSessions,
+        agentTemplates,
+        availableSkills,
+        availableWorkspaces,
+        gatewayChannels,
+        imageGenProfiles,
+        managedEnvironments,
+        mcpSettings,
+        legacyAgentRoles,
+        legacyAutomationProfiles,
+        memberships,
+      ] = await Promise.all([
+        window.electronAPI.listManagedAgents(),
+        window.electronAPI.listManagedSessions({ limit: 40 }),
+        window.electronAPI.listAgentTemplates(),
+        window.electronAPI.listSkills(),
+        window.electronAPI.listWorkspaces(),
+        window.electronAPI.getGatewayChannels(),
+        window.electronAPI.listImageGenProfiles(),
+        window.electronAPI.listManagedEnvironments(),
+        window.electronAPI.getMCPSettings(),
+        window.electronAPI.getAgentRoles(true),
+        window.electronAPI.listAutomationProfiles(),
+        window.electronAPI.listAgentWorkspaceMemberships(),
+      ]);
+      const detailEntries = await Promise.all(
+        managedAgents.map(async (agent) => {
+          const detail = await window.electronAPI.getManagedAgent(agent.id);
+          return [agent.id, detail?.currentVersion] as const;
+        }),
+      );
+      const routineEntries = await Promise.all(
+        managedAgents.map(async (agent) => {
+          const routines = await window.electronAPI.listManagedAgentRoutines(agent.id);
+          return [agent.id, routines] as const;
+        }),
+      );
+      setAgents(managedAgents);
+      setSessions(managedSessions);
+      setTemplates(agentTemplates);
+      setSkills((availableSkills || []) as SkillLite[]);
+      setWorkspaces(availableWorkspaces);
+      setEnvironments(managedEnvironments);
+      setSlackChannels((gatewayChannels || []).filter((channel) => channel.type === "slack"));
+      setImageProfiles(imageGenProfiles);
+      setAgentDetails(Object.fromEntries(detailEntries));
+      setAgentRoutines(Object.fromEntries(routineEntries));
+      setSelectedAgentId((current) => current || managedAgents[0]?.id || null);
+      setRuntimeCatalogs({});
+      setRuntimeCatalogErrors({});
+      setRuntimeCatalogLoadingId(null);
+      setAgentRoles(legacyAgentRoles || []);
+      setAutomationProfiles(legacyAutomationProfiles || []);
+      setWorkspaceMemberships(memberships || []);
+
+      const serversRaw = (mcpSettings as Any)?.servers;
+      const serverList: Array<{ id: string; name: string }> = Array.isArray(serversRaw)
+        ? (serversRaw as Array<{ id?: string; name?: string }>)
+            .map((server) => {
+              const id = server.id || server.name || "";
+              const name = server.name || server.id || "";
+              return { id, name };
+            })
+            .filter((entry) => entry.id)
+        : Object.entries((serversRaw as Record<string, { name?: string }>) || {}).map(
+            ([id, server]) => ({ id, name: server?.name || id }),
+          );
+      setMcpServerIds(serverList);
+
+      if (studioDraft?.agentId) {
+        const existing = managedAgents.find((agent) => agent.id === studioDraft.agentId);
+        const version = existing ? detailEntries.find(([id]) => id === existing.id)?.[1] : undefined;
+        const routines = existing ? routineEntries.find(([id]) => id === existing.id)?.[1] || [] : [];
+        if (existing) {
+          setStudioDraft(
+            buildDraftFromAgent(
+              existing,
+              version,
+              managedEnvironments,
+              availableWorkspaces,
+              routines,
+            ),
+          );
+        }
+      }
+      setError(null);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Failed to load agents");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadData();
+  }, []);
+
+  useEffect(() => {
+    if (
+      !selectedAgentId ||
+      runtimeCatalogs[selectedAgentId] !== undefined ||
+      runtimeCatalogLoadingId === selectedAgentId
+    ) {
+      return;
+    }
+    let cancelled = false;
+    setRuntimeCatalogLoadingId(selectedAgentId);
+    void window.electronAPI
+      .getManagedAgentRuntimeToolCatalog(selectedAgentId)
+      .then((catalog) => {
+        if (cancelled) return;
+        setRuntimeCatalogs((current) => ({ ...current, [selectedAgentId]: catalog }));
+        setRuntimeCatalogErrors((current) => {
+          const next = { ...current };
+          delete next[selectedAgentId];
+          return next;
+        });
+      })
+      .catch((catalogError) => {
+        if (cancelled) return;
+        setRuntimeCatalogs((current) => ({ ...current, [selectedAgentId]: null }));
+        setRuntimeCatalogErrors((current) => ({
+          ...current,
+          [selectedAgentId]:
+            catalogError instanceof Error ? catalogError.message : "Failed to load runtime tools",
+        }));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setRuntimeCatalogLoadingId((current) => (current === selectedAgentId ? null : current));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAgentId, runtimeCatalogLoadingId, runtimeCatalogs]);
+
+  useEffect(() => {
+    if (!selectedAgentId || agentInsights[selectedAgentId]) return;
+    void window.electronAPI
+      .getManagedAgentInsights(selectedAgentId)
+      .then((insights) =>
+        setAgentInsights((current) => ({
+          ...current,
+          [selectedAgentId]: insights,
+        })),
+      )
+      .catch(() => {});
+    void window.electronAPI
+      .listManagedAgentAuditEntries(selectedAgentId, 10)
+      .then((entries) =>
+        setAgentAudit((current) => ({
+          ...current,
+          [selectedAgentId]: entries,
+        })),
+      )
+      .catch(() => {});
+    void window.electronAPI
+      .getManagedAgentSlackDeploymentHealth(selectedAgentId)
+      .then((health) =>
+        setSlackHealth((current) => ({
+          ...current,
+          [selectedAgentId]: normalizeSlackDeploymentHealth(
+            health,
+            getSlackDeploymentHealth(
+              getStudioConfig(agentDetails[selectedAgentId]),
+              slackChannels,
+              selectedAgentId,
+            ),
+          ),
+        })),
+      )
+      .catch(() => {});
+  }, [agentInsights, selectedAgentId]);
+
+  useEffect(() => {
+    const workspaceId = studioDraft?.workspaceId;
+    if (!workspaceId || workspacePermissions[workspaceId]) return;
+    void window.electronAPI
+      .getMyAgentWorkspacePermissions(workspaceId)
+      .then((permissions) =>
+        setWorkspacePermissions((current) => ({ ...current, [workspaceId]: permissions })),
+      )
+      .catch(() => {});
+  }, [studioDraft, workspacePermissions]);
+
+  useEffect(() => {
+    const sessionId =
+      selectedSessionId ||
+      sessions.find((session) => session.agentId === selectedAgentId)?.id ||
+      null;
+    if (!sessionId || sessionWorkpapers[sessionId]) return;
+    setSelectedSessionId(sessionId);
+    void window.electronAPI
+      .getManagedSessionWorkpaper(sessionId)
+      .then((workpaper) =>
+        setSessionWorkpapers((current) => ({ ...current, [sessionId]: workpaper })),
+      )
+      .catch(() => {});
+  }, [selectedAgentId, selectedSessionId, sessionWorkpapers, sessions]);
+
+  useEffect(() => {
+    if (!studioTestSessionId) return;
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const refresh = async () => {
+      try {
+        const [session, events, workpaper] = await Promise.all([
+          window.electronAPI.getManagedSession(studioTestSessionId),
+          window.electronAPI.listManagedSessionEvents(studioTestSessionId, 120),
+          window.electronAPI.getManagedSessionWorkpaper(studioTestSessionId),
+        ]);
+        if (cancelled) return;
+        if (session) {
+          setSessions((current) => {
+            const next = current.filter((entry) => entry.id !== session.id);
+            return [session, ...next].sort((left, right) => right.updatedAt - left.updatedAt);
+          });
+          setSelectedSessionId(session.id);
+        }
+        setStudioSessionEvents((current) => ({
+          ...current,
+          [studioTestSessionId]: events,
+        }));
+        setSessionWorkpapers((current) => ({
+          ...current,
+          [studioTestSessionId]: workpaper,
+        }));
+        const currentSession = session || sessions.find((entry) => entry.id === studioTestSessionId);
+        if (!currentSession || isTerminalManagedSessionStatus(currentSession.status)) {
+          setStudioTestRunning(false);
+          return;
+        }
+        timeoutId = setTimeout(() => {
+          void refresh();
+        }, 1800);
+      } catch {
+        if (cancelled) return;
+        setStudioTestRunning(false);
+      }
+    };
+
+    void refresh();
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [studioTestSessionId, sessions]);
+
+  const recentAgentIds = useMemo(() => {
+    const ordered = sessions.map((session) => session.agentId);
+    return Array.from(new Set(ordered));
+  }, [sessions]);
+
+  const recentlyUsedAgents = recentAgentIds
+    .map((agentId) => agents.find((agent) => agent.id === agentId))
+    .filter((agent): agent is ManagedAgent => Boolean(agent));
+  const scheduledAgents = agents.filter((agent) => {
+    const studio = getStudioConfig(agentDetails[agent.id]);
+    return !!studio?.scheduleConfig?.enabled;
+  });
+  const sharedAgents = agents.filter((agent) => {
+    const visibility = getStudioConfig(agentDetails[agent.id])?.sharing?.visibility;
+    return visibility === "team" || visibility === "workspace";
+  });
+  const selectedAgent = agents.find((agent) => agent.id === selectedAgentId) || null;
+  const selectedAgentWorkspaceId = selectedAgent
+    ? environments.find(
+        (environment) =>
+          environment.id === getStudioConfig(agentDetails[selectedAgent.id])?.defaultEnvironmentId,
+      )?.config.workspaceId
+    : undefined;
+
+  useEffect(() => {
+    if (!selectedAgentWorkspaceId || workspacePermissions[selectedAgentWorkspaceId]) return;
+    void window.electronAPI
+      .getMyAgentWorkspacePermissions(selectedAgentWorkspaceId)
+      .then((permissions) =>
+        setWorkspacePermissions((current) => ({
+          ...current,
+          [selectedAgentWorkspaceId]: permissions,
+        })),
+      )
+      .catch(() => {});
+  }, [selectedAgentWorkspaceId, workspacePermissions]);
+  const libraryAgents = useMemo(() => {
+    switch (libraryTab) {
+      case "recent":
+        return recentlyUsedAgents;
+      case "shared":
+        return sharedAgents;
+      case "scheduled":
+        return scheduledAgents;
+      case "templates":
+        return [];
+      default:
+        return agents;
+    }
+  }, [agents, libraryTab, recentlyUsedAgents, scheduledAgents, sharedAgents]);
+
+  const featuredTemplates = useMemo(() => {
+    const preferred = templates.filter((template) => template.featured);
+    return (preferred.length > 0 ? preferred : templates).slice(0, 4);
+  }, [templates]);
+
+  const activeShowcaseTemplate =
+    featuredTemplates[showcaseIndex] || featuredTemplates[0] || templates[0] || null;
+  const showcaseSideTemplates = featuredTemplates
+    .filter((_, index) => index !== showcaseIndex)
+    .slice(0, 2);
+  const quickCreateTemplates = useMemo(
+    () =>
+      ["team-chat-qna", "morning-planner", "bug-triage"]
+        .map((id) => templates.find((template) => template.id === id))
+        .filter((template): template is AgentTemplate => Boolean(template)),
+    [templates],
+  );
+
+  useEffect(() => {
+    if (showcaseIndex < featuredTemplates.length) return;
+    setShowcaseIndex(0);
+  }, [featuredTemplates.length, showcaseIndex]);
+
+  useEffect(() => {
+    if (featuredTemplates.length <= 1) return;
+    const interval = window.setInterval(() => {
+      setShowcaseIndex((current) => (current + 1) % featuredTemplates.length);
+    }, 5600);
+    return () => window.clearInterval(interval);
+  }, [featuredTemplates.length]);
+
+  const toggleSkill = (skillId: string) => {
+    if (!studioDraft) return;
+    setStudioDraft({
+      ...studioDraft,
+      selectedSkills: studioDraft.selectedSkills.includes(skillId)
+        ? studioDraft.selectedSkills.filter((id) => id !== skillId)
+        : [...studioDraft.selectedSkills, skillId],
+    });
+  };
+
+  const toggleToolFamily = (toolFamily: ManagedAgentToolFamily) => {
+    if (!studioDraft) return;
+    setStudioDraft({
+      ...studioDraft,
+      selectedToolFamilies: studioDraft.selectedToolFamilies.includes(toolFamily)
+        ? studioDraft.selectedToolFamilies.filter((entry) => entry !== toolFamily)
+        : [...studioDraft.selectedToolFamilies, toolFamily],
+    });
+  };
+
+  const handleSelectFiles = async () => {
+    if (!studioDraft) return;
+    const selectedFiles = await window.electronAPI.selectFiles();
+    if (!Array.isArray(selectedFiles) || selectedFiles.length === 0) return;
+    const nextRefs = selectedFiles.map((file) => ({
+      id: crypto.randomUUID(),
+      path: file.path,
+      name: file.name || file.path.split(/[\\/]/).pop() || file.path,
+    }));
+    setStudioDraft({
+      ...studioDraft,
+      fileRefs: [...studioDraft.fileRefs, ...nextRefs],
+    });
+  };
+
+  const handleAddSlackTarget = () => {
+    if (!studioDraft || slackChannels.length === 0) return;
+    const channel = slackChannels[0];
+    setStudioDraft({
+      ...studioDraft,
+      channelTargets: [
+        ...studioDraft.channelTargets,
+        {
+          id: crypto.randomUUID(),
+          channelType: "slack",
+          channelId: channel.id,
+          channelName: channel.name,
+          enabled: true,
+          replyMode: "default",
+          securityMode: channel.securityMode || "pairing",
+          progressRelayMode: "minimal",
+        },
+      ],
+    });
+  };
+
+  const handleCreateImageProfile = async () => {
+    if (!newProfileName.trim()) return;
+    const files = await window.electronAPI.selectFiles();
+    const profile = await window.electronAPI.createImageGenProfile({
+      name: newProfileName.trim(),
+      description: newProfileDescription.trim() || undefined,
+      isDefault: imageProfiles.length === 0,
+      referencePhotoPaths: files.map((file) => file.path),
+    });
+    setImageProfiles((current) => [profile, ...current.filter((entry) => entry.id !== profile.id)]);
+    setNewProfileName("");
+    setNewProfileDescription("");
+    if (studioDraft && !studioDraft.imageGenProfileId) {
+      setStudioDraft({ ...studioDraft, imageGenProfileId: profile.id });
+    }
+  };
+
+  const handleDraftFromWorkflow = () => {
+    const trimmed = workflowComposer.trim();
+    if (!trimmed) return;
+    setIsCreateComposerOpen(false);
+    setStudioDraft(buildDraftFromWorkflowBrief(trimmed, templates, workspaces));
+  };
+
+  const handleOpenCreateComposer = () => {
+    setIsCreateComposerOpen(true);
+  };
+
+  const persistStudioDraft = async (): Promise<PersistStudioDraftResult | null> => {
+    if (!studioDraft) return null;
+    const environmentPayload = {
+      name: `${studioDraft.name} Environment`,
+      config: {
+        workspaceId: studioDraft.workspaceId,
+        enableShell: studioDraft.enableShell,
+        enableBrowser: studioDraft.enableBrowser,
+        enableComputerUse: studioDraft.enableComputerUse,
+        allowedMcpServerIds: studioDraft.selectedMcpServers,
+        filePaths: studioDraft.fileRefs.map((file) => file.path),
+        allowedToolFamilies: studioDraft.selectedToolFamilies,
+      },
+    };
+    const environment = studioDraft.defaultEnvironmentId
+      ? await window.electronAPI.updateManagedEnvironment({
+          environmentId: studioDraft.defaultEnvironmentId,
+          ...environmentPayload,
+        })
+      : await window.electronAPI.createManagedEnvironment(environmentPayload);
+    if (!environment) throw new Error("Failed to save managed environment");
+
+    const studioMetadata: ManagedAgentStudioConfig = {
+      templateId: studioDraft.templateId,
+      workflowBrief: studioDraft.workflowBrief,
+      instructions: {
+        operatingNotes: studioDraft.operatingNotes,
+      },
+      skills: studioDraft.selectedSkills,
+      apps: {
+        mcpServers: studioDraft.selectedMcpServers,
+        allowedToolFamilies: studioDraft.selectedToolFamilies,
+      },
+      fileRefs: studioDraft.fileRefs,
+      memoryConfig: studioDraft.memoryConfig,
+      channelTargets: studioDraft.channelTargets,
+      scheduleConfig: studioDraft.scheduleConfig,
+      audioSummaryConfig: {
+        enabled: studioDraft.audioSummaryEnabled,
+        style: studioDraft.audioSummaryStyle,
+      },
+      imageGenProfileId: studioDraft.imageGenProfileId,
+      approvalPolicy: studioDraft.approvalPolicy,
+      sharing: studioDraft.sharing,
+      deployment: studioDraft.deployment,
+      defaultEnvironmentId: environment.id,
+    };
+
+    let savedAgentId = studioDraft.agentId;
+    if (studioDraft.agentId) {
+      await window.electronAPI.updateManagedAgent({
+        agentId: studioDraft.agentId,
+        name: studioDraft.name,
+        description: studioDraft.description,
+        systemPrompt: studioDraft.systemPrompt,
+        executionMode: studioDraft.executionMode,
+        skills: studioDraft.selectedSkills,
+        mcpServers: studioDraft.selectedMcpServers,
+        runtimeDefaults: {
+          autonomousMode: true,
+          allowUserInput: true,
+          webSearchMode: "live",
+        },
+        metadata: { studio: studioMetadata },
+      });
+    } else {
+      const created = await window.electronAPI.createManagedAgent({
+        name: studioDraft.name,
+        description: studioDraft.description,
+        systemPrompt: studioDraft.systemPrompt,
+        executionMode: studioDraft.executionMode,
+        skills: studioDraft.selectedSkills,
+        mcpServers: studioDraft.selectedMcpServers,
+        runtimeDefaults: {
+          autonomousMode: true,
+          allowUserInput: true,
+          webSearchMode: "live",
+        },
+        metadata: { studio: studioMetadata },
+      });
+      savedAgentId = created.agent.id;
+      setSelectedAgentId(created.agent.id);
+    }
+
+    if (savedAgentId) {
+      const existingRoutines = agentRoutines[savedAgentId] || [];
+      const draftRoutineIds = new Set(
+        studioDraft.routines.map((routine) => routine.id).filter((id): id is string => Boolean(id)),
+      );
+      for (const routine of existingRoutines) {
+        if (!draftRoutineIds.has(routine.id)) {
+          await window.electronAPI.deleteManagedAgentRoutine(savedAgentId, routine.id);
+        }
+      }
+      for (const routine of studioDraft.routines) {
+        const payload = {
+          agentId: savedAgentId,
+          name: routine.name,
+          description: routine.description,
+          enabled: routine.enabled,
+          trigger: routine.trigger,
+        };
+        if (routine.id) {
+          await window.electronAPI.updateManagedAgentRoutine({
+            ...payload,
+            routineId: routine.id,
+          });
+        } else {
+          await window.electronAPI.createManagedAgentRoutine(payload);
+        }
+      }
+    }
+
+    if (!savedAgentId) {
+      throw new Error("Failed to save managed agent");
+    }
+
+    const [detail, refreshedRoutines, refreshedEnvironments, refreshedWorkspaces] = await Promise.all([
+      window.electronAPI.getManagedAgent(savedAgentId),
+      window.electronAPI.listManagedAgentRoutines(savedAgentId),
+      window.electronAPI.listManagedEnvironments(),
+      window.electronAPI.listWorkspaces(),
+    ]);
+    const refreshedDraft = buildDraftFromAgent(
+      detail?.agent || {
+        id: savedAgentId,
+        name: studioDraft.name,
+        description: studioDraft.description,
+        status: studioDraft.status || "draft",
+        currentVersion: detail?.agent.currentVersion || 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      detail?.currentVersion,
+      refreshedEnvironments,
+      refreshedWorkspaces,
+      refreshedRoutines,
+    );
+    setStudioDraft(refreshedDraft);
+    await loadData();
+    return { agentId: savedAgentId, environmentId: environment.id };
+  };
+
+  const handleSaveDraft = async () => {
+    if (!studioDraft) return;
+    try {
+      setSaving(true);
+      await persistStudioDraft();
+      setStudioDraft(null);
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "Failed to save agent");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTestDraft = async () => {
+    if (!studioDraft) return;
+    const prompt = studioTestPrompt.trim() || `Run the configured workflow for ${studioDraft.name}.`;
+    try {
+      setSaving(true);
+      setStudioTestRunning(true);
+      setStudioTestError(null);
+      const persisted = await persistStudioDraft();
+      if (!persisted) throw new Error("Failed to save the agent before testing");
+      const session = await window.electronAPI.createManagedSession({
+        agentId: persisted.agentId,
+        environmentId: persisted.environmentId,
+        title: `${studioDraft.name} preview`,
+        initialEvent: {
+          type: "user.message",
+          content: [{ type: "text", text: prompt }],
+        },
+      });
+      setStudioTestSessionId(session.id);
+      setSelectedAgentId(persisted.agentId);
+      setSelectedSessionId(session.id);
+      setSessions((current) => [session, ...current.filter((entry) => entry.id !== session.id)]);
+      const [events, workpaper] = await Promise.all([
+        window.electronAPI.listManagedSessionEvents(session.id, 120),
+        window.electronAPI.getManagedSessionWorkpaper(session.id),
+      ]);
+      setStudioSessionEvents((current) => ({ ...current, [session.id]: events }));
+      setSessionWorkpapers((current) => ({ ...current, [session.id]: workpaper }));
+    } catch (testError) {
+      setStudioTestError(testError instanceof Error ? testError.message : "Failed to test agent");
+      setStudioTestRunning(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRunAgent = async (agent: ManagedAgent) => {
+    if (agent.status === "suspended") {
+      setError("This agent is suspended. Publish it again before running.");
+      return;
+    }
+    const detail = await window.electronAPI.getManagedAgent(agent.id);
+    const studio = getStudioConfig(detail?.currentVersion);
+    const environmentId = studio?.defaultEnvironmentId;
+    if (!environmentId) {
+      setError("This agent does not have a default environment yet. Edit it and save first.");
+      return;
+    }
+    await window.electronAPI.createManagedSession({
+      agentId: agent.id,
+      environmentId,
+      title: `${agent.name} run`,
+      initialEvent: {
+        type: "user.message",
+        content: [{ type: "text", text: `Run the configured workflow for ${agent.name}.` }],
+      },
+    });
+    await loadData();
+  };
+
+  const handleGenerateAudio = async (session: ManagedSession) => {
+    try {
+      const result = await window.electronAPI.generateManagedSessionAudioSummary(session.id);
+      setAudioResults((current) => ({ ...current, [session.id]: result }));
+    } catch (audioError) {
+      setError(audioError instanceof Error ? audioError.message : "Failed to generate audio summary");
+    }
+  };
+
+  const handleConvertAgentRole = async (agentRoleId: string) => {
+    try {
+      const converted = await window.electronAPI.convertAgentRoleToManagedAgent({ agentRoleId });
+      setSelectedAgentId(converted.agent.id);
+      setConversionPanel(null);
+      await loadData();
+    } catch (conversionError) {
+      setError(
+        conversionError instanceof Error
+          ? conversionError.message
+          : "Failed to convert agent persona",
+      );
+    }
+  };
+
+  const handleConvertAutomationProfile = async (automationProfileId: string) => {
+    try {
+      const converted = await window.electronAPI.convertAutomationProfileToManagedAgent({
+        automationProfileId,
+      });
+      setSelectedAgentId(converted.agent.id);
+      setConversionPanel(null);
+      await loadData();
+    } catch (conversionError) {
+      setError(
+        conversionError instanceof Error
+          ? conversionError.message
+          : "Failed to convert automation profile",
+      );
+    }
+  };
+
+  const handlePublishAgent = async (agentId: string) => {
+    await window.electronAPI.publishManagedAgent(agentId);
+    await loadData();
+  };
+
+  const handleSuspendAgent = async (agentId: string) => {
+    await window.electronAPI.suspendManagedAgent(agentId);
+    await loadData();
+  };
+
+  if (loading) {
+    return <div className="agents-panel-loading">Loading agents...</div>;
+  }
+
+  if (studioDraft) {
+    const approvalPreview = getEffectiveApprovalPreview(
+      studioDraft.approvalPolicy,
+      studioDraft.deployment,
+    );
+    const approvalRuntimeMatrix = getApprovalRuntimeMatrix(studioDraft.approvalPolicy);
+    const draftPermissions = studioDraft.workspaceId
+      ? workspacePermissions[studioDraft.workspaceId]
+      : undefined;
+    const draftSlackHealth = getSlackDeploymentHealth(
+      { channelTargets: studioDraft.channelTargets },
+      slackChannels,
+      studioDraft.agentId,
+    );
+    const studioTestSession = studioTestSessionId
+      ? sessions.find((session) => session.id === studioTestSessionId) || null
+      : null;
+    const studioTestTranscript = studioTestSessionId
+      ? (studioSessionEvents[studioTestSessionId] || []).filter((event) =>
+          ["user.message", "assistant.message", "status.changed", "input.requested"].includes(event.type),
+        )
+      : [];
+    const studioTestWorkpaper = studioTestSessionId ? sessionWorkpapers[studioTestSessionId] : undefined;
+    return (
+      <div className="agents-studio">
+        <div className="agents-toolbar">
+          <button className="agents-link-btn" onClick={() => setStudioDraft(null)}>
+            <ChevronLeft size={16} />
+            Back to Agents
+          </button>
+          <button className="agents-primary-btn" onClick={handleSaveDraft} disabled={saving}>
+            <Save size={16} />
+            {saving ? "Saving..." : "Save Agent"}
+          </button>
+        </div>
+        {draftPermissions ? (
+          <div className="agents-inline-permission-note">
+            Your workspace role is <strong>{draftPermissions.role}</strong>. Builders can edit
+            drafts and environments; publishers can publish and manage triggers.
+          </div>
+        ) : null}
+
+        <div className="agents-studio-grid">
+          <section className="agents-section-card agents-studio-test-surface">
+            <div className="agents-section-head">
+              <div>
+                <h3>Preview & Test</h3>
+                <span>Run the agent from the studio before you publish it.</span>
+              </div>
+              {studioTestSession ? (
+                <span>
+                  {sessionStatusLabel(studioTestSession)} · {formatRelative(studioTestSession.updatedAt)}
+                </span>
+              ) : (
+                <span>Save-once preview from the current draft</span>
+              )}
+            </div>
+            <div className="agents-studio-test-grid">
+              <div className="agents-studio-test-chat">
+                <div className="agents-studio-test-suggestions">
+                  <button
+                    type="button"
+                    className="agents-link-btn"
+                    onClick={() => void handleTestDraft()}
+                    disabled={saving || studioTestRunning}
+                  >
+                    <Play size={16} />
+                    Test this agent
+                  </button>
+                  <button type="button" className="agents-link-btn" disabled>
+                    <Wrench size={16} />
+                    Add advanced logic
+                  </button>
+                  <button type="button" className="agents-link-btn" disabled>
+                    <Bot size={16} />
+                    Optimize this agent
+                  </button>
+                </div>
+                <div className="agents-studio-test-transcript">
+                  {studioTestTranscript.length > 0 ? (
+                    studioTestTranscript.map((event) => {
+                      const isAssistant = event.type === "assistant.message";
+                      const isUser = event.type === "user.message";
+                      return (
+                        <div
+                          key={event.id}
+                          className={`agents-studio-test-bubble ${
+                            isAssistant ? "assistant" : isUser ? "user" : "system"
+                          }`}
+                        >
+                          <span className="agents-studio-test-bubble-role">
+                            {isAssistant ? "Agent" : isUser ? "You" : event.type.replace(/\./g, " ")}
+                          </span>
+                          <p>{getManagedSessionEventText(event)}</p>
+                        </div>
+                      );
+                    })
+                  ) : (
+                    <div className="agents-studio-test-empty">
+                      <strong>Test the current draft</strong>
+                      <p>
+                        Save the agent and run a prompt here to verify instructions, tools, approvals,
+                        and deployment posture before publishing.
+                      </p>
+                    </div>
+                  )}
+                </div>
+                <div className="agents-studio-test-compose">
+                  <textarea
+                    rows={3}
+                    value={studioTestPrompt}
+                    placeholder="Ask the agent to handle a realistic request, for example: Review this software request, check policy, and draft the next step."
+                    onChange={(event) => setStudioTestPrompt(event.target.value)}
+                  />
+                  <button
+                    className="agents-primary-btn"
+                    onClick={() => void handleTestDraft()}
+                    disabled={saving || studioTestRunning}
+                  >
+                    <Play size={16} />
+                    {studioTestRunning ? "Running..." : "Run preview"}
+                  </button>
+                </div>
+                {studioTestError ? <div className="agents-error-banner">{studioTestError}</div> : null}
+              </div>
+              <div className="agents-studio-test-summary">
+                <div className="agents-studio-test-summary-card">
+                  <span>Channels</span>
+                  <strong>
+                    {(studioDraft.deployment.surfaces || ["chatgpt"])
+                      .map((surface) => (surface === "chatgpt" ? "CoWork OS" : "Slack"))
+                      .join(" · ")}
+                  </strong>
+                  <p>
+                    {studioDraft.channelTargets.length > 0
+                      ? `${studioDraft.channelTargets.length} Slack deployment target(s) configured.`
+                      : "No Slack deployment configured yet."}
+                  </p>
+                </div>
+                <div className="agents-studio-test-summary-card">
+                  <span>Tools & skills</span>
+                  <strong>
+                    {studioDraft.selectedToolFamilies.length} tool families · {studioDraft.selectedSkills.length} skills
+                  </strong>
+                  <p>
+                    {studioDraft.selectedToolFamilies.length > 0
+                      ? studioDraft.selectedToolFamilies.join(", ")
+                      : "No built-in tool families selected yet."}
+                  </p>
+                </div>
+                <div className="agents-studio-test-summary-card">
+                  <span>Memory & files</span>
+                  <strong>
+                    {studioDraft.memoryConfig.mode} memory · {studioDraft.fileRefs.length} files
+                  </strong>
+                  <p>
+                    {studioDraft.fileRefs.length > 0
+                      ? studioDraft.fileRefs.map((file) => file.name).slice(0, 3).join(", ")
+                      : "No reference files attached yet."}
+                  </p>
+                </div>
+                <div className="agents-studio-test-summary-card">
+                  <span>Instructions</span>
+                  <strong>{studioDraft.name || "Untitled agent"}</strong>
+                  <p>{studioDraft.description || studioDraft.workflowBrief || "No summary yet."}</p>
+                </div>
+                {studioTestWorkpaper ? (
+                  <div className="agents-studio-test-workpaper">
+                    <strong>Latest preview summary</strong>
+                    <p>{studioTestWorkpaper.summary}</p>
+                    <span>
+                      {studioTestWorkpaper.approvals.length} approvals ·{" "}
+                      {studioTestWorkpaper.artifacts.length} artifacts
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </section>
+
+          <section className="agents-section-card agents-hero-card">
+            <div className="agents-studio-badge">Agent Studio</div>
+            <h2>Turn a team workflow into a shared operator</h2>
+            <p>
+              Start from the workflow itself, then shape tools, approvals, deployment surfaces,
+              memory, and governance in one place. Mission Control and Agent Personas remain
+              available in parallel as legacy ops surfaces.
+            </p>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Workflow</h3>
+            <label>
+              <span>What job should this agent handle?</span>
+              <textarea
+                rows={5}
+                value={studioDraft.workflowBrief}
+                placeholder="Example: Triage software requests from Slack, check policy, ask for approval for paid tools, and file an IT ticket with next steps."
+                onChange={(event) =>
+                  setStudioDraft({ ...studioDraft, workflowBrief: event.target.value })
+                }
+              />
+            </label>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Identity</h3>
+            <div className="agents-field-grid">
+              <label>
+                <span>Name</span>
+                <input
+                  value={studioDraft.name}
+                  onChange={(event) => setStudioDraft({ ...studioDraft, name: event.target.value })}
+                />
+              </label>
+              <label>
+                <span>Icon</span>
+                <input
+                  value={studioDraft.icon}
+                  onChange={(event) => setStudioDraft({ ...studioDraft, icon: event.target.value })}
+                />
+              </label>
+            </div>
+            <label>
+              <span>Description</span>
+              <input
+                value={studioDraft.description}
+                onChange={(event) =>
+                  setStudioDraft({ ...studioDraft, description: event.target.value })
+                }
+              />
+            </label>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Instructions</h3>
+            <label>
+              <span>System prompt</span>
+              <textarea
+                rows={8}
+                value={studioDraft.systemPrompt}
+                onChange={(event) =>
+                  setStudioDraft({ ...studioDraft, systemPrompt: event.target.value })
+                }
+              />
+            </label>
+            <label>
+              <span>Operating notes</span>
+              <textarea
+                rows={4}
+                value={studioDraft.operatingNotes}
+                onChange={(event) =>
+                  setStudioDraft({ ...studioDraft, operatingNotes: event.target.value })
+                }
+              />
+            </label>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Skills</h3>
+            <div className="agents-chip-grid">
+              {skills.slice(0, 24).map((skill) => (
+                <button
+                  key={skill.id}
+                  type="button"
+                  className={`agents-chip ${
+                    studioDraft.selectedSkills.includes(skill.id) ? "active" : ""
+                  }`}
+                  onClick={() => toggleSkill(skill.id)}
+                >
+                  {skill.name || skill.id}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Apps & Tools</h3>
+            <label>
+              <span>MCP servers</span>
+              <div className="agents-chip-grid">
+                {mcpServerIds.map((server) => (
+                  <button
+                    key={server.id}
+                    type="button"
+                    title={server.id}
+                    className={`agents-chip ${
+                      studioDraft.selectedMcpServers.includes(server.id) ? "active" : ""
+                    }`}
+                    onClick={() =>
+                      setStudioDraft({
+                        ...studioDraft,
+                        selectedMcpServers: studioDraft.selectedMcpServers.includes(server.id)
+                          ? studioDraft.selectedMcpServers.filter((entry) => entry !== server.id)
+                          : [...studioDraft.selectedMcpServers, server.id],
+                      })
+                    }
+                  >
+                    {server.name}
+                  </button>
+                ))}
+              </div>
+            </label>
+            <label>
+              <span>Built-in tool families</span>
+              <div className="agents-chip-grid">
+                {TOOL_FAMILY_OPTIONS.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    className={`agents-chip ${
+                      studioDraft.selectedToolFamilies.includes(option.id) ? "active" : ""
+                    }`}
+                    onClick={() => toggleToolFamily(option.id)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </label>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Files</h3>
+            <button className="agents-secondary-btn" onClick={handleSelectFiles}>
+              <FileText size={16} />
+              Add files
+            </button>
+            <div className="agents-list">
+              {studioDraft.fileRefs.map((file) => (
+                <div key={file.id} className="agents-list-row">
+                  <span>{file.name}</span>
+                  <button
+                    className="agents-link-btn"
+                    onClick={() =>
+                      setStudioDraft({
+                        ...studioDraft,
+                        fileRefs: studioDraft.fileRefs.filter((entry) => entry.id !== file.id),
+                      })
+                    }
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              {studioDraft.fileRefs.length === 0 && <span className="agents-empty-note">No files attached yet.</span>}
+            </div>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Memory</h3>
+            <label>
+              <span>Memory mode</span>
+              <select
+                value={studioDraft.memoryConfig.mode}
+                onChange={(event) =>
+                  setStudioDraft({
+                    ...studioDraft,
+                    memoryConfig: {
+                      ...studioDraft.memoryConfig,
+                      mode: event.target.value as ManagedAgentMemoryConfig["mode"],
+                    },
+                  })
+                }
+              >
+                <option value="default">Default</option>
+                <option value="focused">Focused</option>
+                <option value="disabled">Disabled</option>
+              </select>
+            </label>
+            <label>
+              <span>Scoped sources (comma separated)</span>
+              <input
+                value={(studioDraft.memoryConfig.sources || []).join(", ")}
+                onChange={(event) =>
+                  setStudioDraft({
+                    ...studioDraft,
+                    memoryConfig: {
+                      ...studioDraft.memoryConfig,
+                      sources: event.target.value
+                        .split(",")
+                        .map((value) => value.trim())
+                        .filter(Boolean),
+                    },
+                  })
+                }
+              />
+            </label>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Triggers & Schedule</h3>
+            <div className="agents-chip-grid">
+              {[
+                ["manual", "Manual"],
+                ["schedule", "Schedule"],
+                ["api", "API"],
+                ["channel_event", "Channel"],
+                ["mailbox_event", "Mailbox"],
+                ["github_event", "GitHub"],
+                ["connector_event", "Connector"],
+              ].map(([id, label]) => (
+                <button
+                  key={id}
+                  type="button"
+                  className="agents-chip"
+                  onClick={() =>
+                    setStudioDraft({
+                      ...studioDraft,
+                      routines: [
+                        ...studioDraft.routines,
+                        makeBlankRoutine(id as ManagedAgentRoutineTriggerConfig["type"]),
+                      ],
+                    })
+                  }
+                >
+                  Add {label}
+                </button>
+              ))}
+            </div>
+            <div className="agents-list">
+              {studioDraft.routines.map((routine, index) => (
+                <div key={routine.id || `${routine.trigger.type}-${index}`} className="agents-routine-card">
+                  <div className="agents-field-grid">
+                    <label>
+                      <span>Name</span>
+                      <input
+                        value={routine.name}
+                        onChange={(event) =>
+                          setStudioDraft({
+                            ...studioDraft,
+                            routines: studioDraft.routines.map((entry, entryIndex) =>
+                              entryIndex === index ? { ...entry, name: event.target.value } : entry,
+                            ),
+                          })
+                        }
+                      />
+                    </label>
+                    <label>
+                      <span>Trigger type</span>
+                      <select
+                        value={routine.trigger.type}
+                        onChange={(event) =>
+                          setStudioDraft({
+                            ...studioDraft,
+                            routines: studioDraft.routines.map((entry, entryIndex) =>
+                              entryIndex === index
+                                ? {
+                                    ...makeBlankRoutine(
+                                      event.target.value as ManagedAgentRoutineTriggerConfig["type"],
+                                    ),
+                                    id: entry.id,
+                                    name: entry.name,
+                                  }
+                                : entry,
+                            ),
+                          })
+                        }
+                      >
+                        <option value="manual">Manual</option>
+                        <option value="schedule">Schedule</option>
+                        <option value="api">API</option>
+                        <option value="channel_event">Channel event</option>
+                        <option value="mailbox_event">Mailbox event</option>
+                        <option value="github_event">GitHub event</option>
+                        <option value="connector_event">Connector event</option>
+                      </select>
+                    </label>
+                  </div>
+                  <div className="agents-field-grid">
+                    {routine.trigger.type === "schedule" ? (
+                      <label>
+                        <span>Cadence minutes</span>
+                        <input
+                          type="number"
+                          min={15}
+                          value={routine.trigger.cadenceMinutes || 60}
+                          onChange={(event) =>
+                            setStudioDraft({
+                              ...studioDraft,
+                              routines: studioDraft.routines.map((entry, entryIndex) =>
+                                entryIndex === index
+                                  ? {
+                                      ...entry,
+                                      trigger: {
+                                        ...entry.trigger,
+                                        cadenceMinutes: Number(event.target.value) || 60,
+                                      },
+                                    }
+                                  : entry,
+                              ),
+                            })
+                          }
+                        />
+                      </label>
+                    ) : null}
+                    {routine.trigger.type === "api" ? (
+                      <label>
+                        <span>Path</span>
+                        <input
+                          value={routine.trigger.path || ""}
+                          onChange={(event) =>
+                            setStudioDraft({
+                              ...studioDraft,
+                              routines: studioDraft.routines.map((entry, entryIndex) =>
+                                entryIndex === index
+                                  ? {
+                                      ...entry,
+                                      trigger: { ...entry.trigger, path: event.target.value },
+                                    }
+                                  : entry,
+                              ),
+                            })
+                          }
+                        />
+                      </label>
+                    ) : null}
+                    {routine.trigger.type === "channel_event" ? (
+                      <label>
+                        <span>Channel type</span>
+                        <select
+                          value={routine.trigger.channelType || "slack"}
+                          onChange={(event) =>
+                            setStudioDraft({
+                              ...studioDraft,
+                              routines: studioDraft.routines.map((entry, entryIndex) =>
+                                entryIndex === index
+                                  ? {
+                                      ...entry,
+                                      trigger: { ...entry.trigger, channelType: event.target.value },
+                                    }
+                                  : entry,
+                              ),
+                            })
+                          }
+                        >
+                          <option value="slack">Slack</option>
+                          <option value="discord">Discord</option>
+                        </select>
+                      </label>
+                    ) : null}
+                    {routine.trigger.type === "mailbox_event" ? (
+                      <label>
+                        <span>Provider</span>
+                        <input
+                          value={routine.trigger.provider || ""}
+                          onChange={(event) =>
+                            setStudioDraft({
+                              ...studioDraft,
+                              routines: studioDraft.routines.map((entry, entryIndex) =>
+                                entryIndex === index
+                                  ? {
+                                      ...entry,
+                                      trigger: { ...entry.trigger, provider: event.target.value },
+                                    }
+                                  : entry,
+                              ),
+                            })
+                          }
+                        />
+                      </label>
+                    ) : null}
+                    {routine.trigger.type === "github_event" ? (
+                      <label>
+                        <span>Repository</span>
+                        <input
+                          value={routine.trigger.repository || ""}
+                          onChange={(event) =>
+                            setStudioDraft({
+                              ...studioDraft,
+                              routines: studioDraft.routines.map((entry, entryIndex) =>
+                                entryIndex === index
+                                  ? {
+                                      ...entry,
+                                      trigger: { ...entry.trigger, repository: event.target.value },
+                                    }
+                                  : entry,
+                              ),
+                            })
+                          }
+                        />
+                      </label>
+                    ) : null}
+                    {routine.trigger.type === "connector_event" ? (
+                      <label>
+                        <span>Connector</span>
+                        <input
+                          value={routine.trigger.connectorId || ""}
+                          onChange={(event) =>
+                            setStudioDraft({
+                              ...studioDraft,
+                              routines: studioDraft.routines.map((entry, entryIndex) =>
+                                entryIndex === index
+                                  ? {
+                                      ...entry,
+                                      trigger: { ...entry.trigger, connectorId: event.target.value },
+                                    }
+                                  : entry,
+                              ),
+                            })
+                          }
+                        />
+                      </label>
+                    ) : null}
+                  </div>
+                  <div className="agents-row-actions">
+                    <label className="agents-checkbox">
+                      <input
+                        type="checkbox"
+                        checked={routine.enabled}
+                        onChange={(event) =>
+                          setStudioDraft({
+                            ...studioDraft,
+                            routines: studioDraft.routines.map((entry, entryIndex) =>
+                              entryIndex === index
+                                ? {
+                                    ...entry,
+                                    enabled: event.target.checked,
+                                    trigger: { ...entry.trigger, enabled: event.target.checked },
+                                  }
+                                : entry,
+                            ),
+                          })
+                        }
+                      />
+                      <span>Enabled</span>
+                    </label>
+                    <button
+                      className="agents-link-btn"
+                      onClick={() =>
+                        setStudioDraft({
+                          ...studioDraft,
+                          routines: studioDraft.routines.filter((_, entryIndex) => entryIndex !== index),
+                        })
+                      }
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Deploy</h3>
+            <div className="agents-chip-grid">
+              {[
+                { id: "chatgpt", label: "CoWork OS" },
+                { id: "slack", label: "Slack" },
+              ].map((surface) => (
+                <button
+                  key={surface.id}
+                  type="button"
+                  className={`agents-chip ${
+                    (studioDraft.deployment.surfaces || []).includes(
+                      surface.id as "chatgpt" | "slack",
+                    )
+                      ? "active"
+                      : ""
+                  }`}
+                  onClick={() =>
+                    setStudioDraft({
+                      ...studioDraft,
+                      deployment: {
+                        surfaces: (studioDraft.deployment.surfaces || []).includes(
+                          surface.id as "chatgpt" | "slack",
+                        )
+                          ? (studioDraft.deployment.surfaces || []).filter(
+                              (entry) => entry !== surface.id,
+                            )
+                          : [...(studioDraft.deployment.surfaces || []), surface.id as "chatgpt" | "slack"],
+                      },
+                    })
+                  }
+                >
+                  {surface.label}
+                </button>
+              ))}
+            </div>
+            <button className="agents-secondary-btn" onClick={handleAddSlackTarget}>
+              <Slack size={16} />
+              Add Slack deployment
+            </button>
+            <div className="agents-list">
+              {studioDraft.channelTargets.map((target) => (
+                <div key={target.id} className="agents-slack-target">
+                  <select
+                    value={target.channelId}
+                    onChange={(event) =>
+                      setStudioDraft({
+                        ...studioDraft,
+                        channelTargets: studioDraft.channelTargets.map((entry) =>
+                          entry.id === target.id
+                            ? {
+                                ...entry,
+                                channelId: event.target.value,
+                                channelName:
+                                  slackChannels.find((channel) => channel.id === event.target.value)
+                                    ?.name || event.target.value,
+                              }
+                            : entry,
+                        ),
+                      })
+                    }
+                  >
+                    {slackChannels.map((channel) => (
+                      <option key={channel.id} value={channel.id}>
+                        {channel.name}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    value={target.securityMode || "pairing"}
+                    onChange={(event) =>
+                      setStudioDraft({
+                        ...studioDraft,
+                        channelTargets: studioDraft.channelTargets.map((entry) =>
+                          entry.id === target.id
+                            ? { ...entry, securityMode: event.target.value as SecurityMode }
+                            : entry,
+                        ),
+                      })
+                    }
+                  >
+                    <option value="pairing">Pairing</option>
+                    <option value="allowlist">Allowlist</option>
+                    <option value="open">Open</option>
+                  </select>
+                  <select
+                    value={target.progressRelayMode || "minimal"}
+                    onChange={(event) =>
+                      setStudioDraft({
+                        ...studioDraft,
+                        channelTargets: studioDraft.channelTargets.map((entry) =>
+                          entry.id === target.id
+                            ? {
+                                ...entry,
+                                progressRelayMode: event.target.value as "minimal" | "curated",
+                              }
+                            : entry,
+                        ),
+                      })
+                    }
+                  >
+                    <option value="minimal">Minimal</option>
+                    <option value="curated">Curated</option>
+                  </select>
+                  <button
+                    className="agents-link-btn"
+                    onClick={() =>
+                      setStudioDraft({
+                        ...studioDraft,
+                        channelTargets: studioDraft.channelTargets.filter((entry) => entry.id !== target.id),
+                      })
+                    }
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              {studioDraft.channelTargets.length === 0 && (
+                <span className="agents-empty-note">
+                  No Slack deployment configured. Add a workspace/channel to publish replies and
+                  progress where work already happens.
+                </span>
+              )}
+            </div>
+            <div className="agents-inline-permission-note">
+              Slack health: {draftSlackHealth.connectedCount} connected,{" "}
+              {draftSlackHealth.misconfiguredCount} misconfigured. Use Slack settings for advanced
+              connection tests and channel diagnostics.
+            </div>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Approvals</h3>
+            <label className="agents-checkbox">
+              <input
+                type="checkbox"
+                checked={studioDraft.approvalPolicy.autoApproveReadOnly !== false}
+                onChange={(event) =>
+                  setStudioDraft({
+                    ...studioDraft,
+                    approvalPolicy: {
+                      ...studioDraft.approvalPolicy,
+                      autoApproveReadOnly: event.target.checked,
+                    },
+                  })
+                }
+              />
+              <span>Auto-approve read-only and search actions</span>
+            </label>
+            <div className="agents-chip-grid">
+              {APPROVAL_ACTION_OPTIONS.map((action) => (
+                <button
+                  key={action}
+                  type="button"
+                  className={`agents-chip ${
+                    (studioDraft.approvalPolicy.requireApprovalFor || []).includes(action)
+                      ? "active"
+                      : ""
+                  }`}
+                  onClick={() =>
+                    setStudioDraft({
+                      ...studioDraft,
+                      approvalPolicy: {
+                        ...studioDraft.approvalPolicy,
+                        requireApprovalFor: (studioDraft.approvalPolicy.requireApprovalFor || []).includes(
+                          action,
+                        )
+                          ? (studioDraft.approvalPolicy.requireApprovalFor || []).filter(
+                              (entry) => entry !== action,
+                            )
+                          : [...(studioDraft.approvalPolicy.requireApprovalFor || []), action],
+                      },
+                    })
+                  }
+                >
+                  {action}
+                </button>
+              ))}
+            </div>
+            <label>
+              <span>Escalation channel or owner</span>
+              <input
+                value={studioDraft.approvalPolicy.escalationChannel || ""}
+                placeholder="e.g. #ops-approvals or Finance lead"
+                onChange={(event) =>
+                  setStudioDraft({
+                    ...studioDraft,
+                    approvalPolicy: {
+                      ...studioDraft.approvalPolicy,
+                      escalationChannel: event.target.value || undefined,
+                    },
+                  })
+                }
+              />
+            </label>
+            <div className="agents-approval-preview">
+              <div className="agents-approval-preview-card">
+                <strong>Effective posture</strong>
+                <p>{approvalPreview.sharedSummary}</p>
+                <div className="agents-approval-columns">
+                  <div>
+                    <span>Auto-approved</span>
+                    <ul>
+                      {approvalPreview.autoApproved.length > 0 ? (
+                        approvalPreview.autoApproved.map((item) => <li key={item}>{item}</li>)
+                      ) : (
+                        <li>Nothing auto-approves by policy</li>
+                      )}
+                    </ul>
+                  </div>
+                  <div>
+                    <span>Approval-gated</span>
+                    <ul>
+                      {approvalPreview.gatedActions.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+              <div className="agents-approval-preview-card agents-approval-matrix-card">
+                <strong>Runtime approval mapping</strong>
+                <div className="agents-approval-matrix">
+                  <div className="agents-approval-matrix-header">
+                    <div className="agents-approval-matrix-head">Action</div>
+                    <div className="agents-approval-matrix-head">Runtime class</div>
+                    <div className="agents-approval-matrix-head">Behavior</div>
+                  </div>
+                  {approvalRuntimeMatrix.map((row) => (
+                    <div key={row.semanticAction} className="agents-approval-matrix-row">
+                      <div className="agents-approval-matrix-cell">
+                        <span className="agents-approval-matrix-label">Action</span>
+                        <span>{row.semanticAction}</span>
+                      </div>
+                      <div className="agents-approval-matrix-cell">
+                        <span className="agents-approval-matrix-label">Runtime class</span>
+                        <code className="agents-approval-runtime-code">{row.runtimeType}</code>
+                      </div>
+                      <div
+                        className={`agents-approval-matrix-cell ${
+                          row.behavior === "require_approval" ? "danger" : "safe"
+                        }`}
+                      >
+                        <span className="agents-approval-matrix-label">Behavior</span>
+                        <span
+                          className={`agents-approval-behavior-pill ${
+                            row.behavior === "require_approval" ? "danger" : "safe"
+                          }`}
+                        >
+                          {row.behavior === "require_approval" ? "Requires approval" : "Auto-approves"}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Sharing & Governance</h3>
+            <label>
+              <span>Visibility</span>
+              <select
+                value={studioDraft.sharing.visibility || "team"}
+                onChange={(event) =>
+                  setStudioDraft({
+                    ...studioDraft,
+                    sharing: {
+                      ...studioDraft.sharing,
+                      visibility: event.target.value as ManagedAgentSharingConfig["visibility"],
+                    },
+                  })
+                }
+              >
+                <option value="private">Private draft</option>
+                <option value="team">Shared with team</option>
+                <option value="workspace">Workspace directory</option>
+              </select>
+            </label>
+            <label>
+              <span>Owner label</span>
+              <input
+                value={studioDraft.sharing.ownerLabel || ""}
+                placeholder="Revenue Ops, Engineering, Founder Office..."
+                onChange={(event) =>
+                  setStudioDraft({
+                    ...studioDraft,
+                    sharing: {
+                      ...studioDraft.sharing,
+                      ownerLabel: event.target.value || undefined,
+                    },
+                  })
+                }
+              />
+            </label>
+            <div className="agents-surface-preview-grid">
+              <div className="agents-surface-preview-card">
+                <strong>CoWork OS behavior</strong>
+                <p>{approvalPreview.chatgptSummary}</p>
+              </div>
+              <div className="agents-surface-preview-card">
+                <strong>Slack behavior</strong>
+                <p>{approvalPreview.slackSummary}</p>
+              </div>
+            </div>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Audio Summary</h3>
+            <label className="agents-checkbox">
+              <input
+                type="checkbox"
+                checked={studioDraft.audioSummaryEnabled}
+                onChange={(event) =>
+                  setStudioDraft({
+                    ...studioDraft,
+                    audioSummaryEnabled: event.target.checked,
+                  })
+                }
+              />
+              <span>Enable audio summaries</span>
+            </label>
+            <label>
+              <span>Style</span>
+              <select
+                value={studioDraft.audioSummaryStyle}
+                onChange={(event) =>
+                  setStudioDraft({
+                    ...studioDraft,
+                    audioSummaryStyle: event.target.value as AgentDraft["audioSummaryStyle"],
+                  })
+                }
+              >
+                <option value="public-radio">Public-radio recap</option>
+                <option value="executive-briefing">Executive briefing</option>
+                <option value="study-guide">Study guide</option>
+              </select>
+            </label>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>ImageGen likeness</h3>
+            <div className="agents-field-grid">
+              <label>
+                <span>Reference profile</span>
+                <select
+                  value={studioDraft.imageGenProfileId || ""}
+                  onChange={(event) =>
+                    setStudioDraft({
+                      ...studioDraft,
+                      imageGenProfileId: event.target.value || undefined,
+                    })
+                  }
+                >
+                  <option value="">None</option>
+                  {imageProfiles.map((profile) => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.name}
+                      {profile.isDefault ? " (Default)" : ""}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div className="agents-inline-create">
+              <input
+                placeholder="New profile name"
+                value={newProfileName}
+                onChange={(event) => setNewProfileName(event.target.value)}
+              />
+              <input
+                placeholder="Description"
+                value={newProfileDescription}
+                onChange={(event) => setNewProfileDescription(event.target.value)}
+              />
+              <button className="agents-secondary-btn" onClick={handleCreateImageProfile}>
+                <ImageIcon size={16} />
+                Add profile
+              </button>
+            </div>
+          </section>
+
+          <section className="agents-section-card">
+            <h3>Runtime</h3>
+            <label>
+              <span>Workspace</span>
+              <select
+                value={studioDraft.workspaceId}
+                onChange={(event) =>
+                  setStudioDraft({
+                    ...studioDraft,
+                    workspaceId: event.target.value,
+                  })
+                }
+              >
+                {workspaces.map((workspace) => (
+                  <option key={workspace.id} value={workspace.id}>
+                    {workspace.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="agents-checkbox-row">
+              <label className="agents-checkbox">
+                <input
+                  type="checkbox"
+                  checked={studioDraft.enableShell}
+                  onChange={(event) =>
+                    setStudioDraft({ ...studioDraft, enableShell: event.target.checked })
+                  }
+                />
+                <span>Shell</span>
+              </label>
+              <label className="agents-checkbox">
+                <input
+                  type="checkbox"
+                  checked={studioDraft.enableBrowser}
+                  onChange={(event) =>
+                    setStudioDraft({ ...studioDraft, enableBrowser: event.target.checked })
+                  }
+                />
+                <span>Browser</span>
+              </label>
+              <label className="agents-checkbox">
+                <input
+                  type="checkbox"
+                  checked={studioDraft.enableComputerUse}
+                  onChange={(event) =>
+                    setStudioDraft({ ...studioDraft, enableComputerUse: event.target.checked })
+                  }
+                />
+                <span>Computer Use</span>
+              </label>
+            </div>
+          </section>
+        </div>
+        {renderAgentsStyles()}
+      </div>
+    );
+  }
+
+  if (isCreateComposerOpen) {
+    return (
+      <div className="agents-panel agents-create-screen">
+        <div className="agents-create-screen-bar">
+          <button className="agents-link-btn agents-create-screen-back" onClick={() => setIsCreateComposerOpen(false)}>
+            <ArrowLeft size={18} />
+            Back
+          </button>
+          <button
+            className="agents-link-btn agents-create-screen-blank"
+            onClick={() => {
+              setIsCreateComposerOpen(false);
+              setStudioDraft(makeBlankDraft(workspaces));
+            }}
+          >
+            Start blank
+          </button>
+        </div>
+
+        <section className="agents-create-screen-hero">
+          <div className="agents-create-screen-icon">
+            <Bot size={34} />
+          </div>
+          <h1>Build a new agent</h1>
+          <div className="agents-create-screen-input">
+            <div className="agents-create-screen-input-leading">
+              <Plus size={18} />
+            </div>
+            <input
+              value={workflowComposer}
+              placeholder="Describe what it should do"
+              onChange={(event) => setWorkflowComposer(event.target.value)}
+            />
+            <button
+              className="agents-create-screen-submit"
+              onClick={handleDraftFromWorkflow}
+              disabled={!workflowComposer.trim()}
+              aria-label="Create agent draft"
+            >
+              <ArrowUp size={18} />
+            </button>
+          </div>
+
+          <div className="agents-create-screen-suggestions">
+            {quickCreateTemplates.map((template) => {
+              const TemplateGlyph = getTemplateGlyph(template);
+              return (
+                <button
+                  key={template.id}
+                  className="agents-create-screen-row"
+                  onClick={() => {
+                    setIsCreateComposerOpen(false);
+                    setStudioDraft(buildDraftFromTemplate(template, workspaces));
+                  }}
+                >
+                  <span className="agents-create-screen-row-icon">
+                    <TemplateGlyph size={18} />
+                  </span>
+                  <strong>{template.name}</strong>
+                  <span>{template.description}</span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+        {renderAgentsStyles()}
+      </div>
+    );
+  }
+
+  return (
+    <div className="agents-panel">
+      {activeShowcaseTemplate ? (
+        <section
+          className="agents-showcase"
+          style={{ ["--agents-showcase-accent" as string]: activeShowcaseTemplate.color }}
+        >
+          <div className="agents-showcase-copy">
+            <span className="agents-showcase-eyebrow">Featured workflow</span>
+            <h2>{activeShowcaseTemplate.tagline || "Start with a proven workflow"}</h2>
+            <p>{activeShowcaseTemplate.description}</p>
+            <div className="agents-showcase-actions">
+              <button className="agents-primary-btn" onClick={() => setLibraryTab("templates")}>
+                Browse templates
+              </button>
+              <button className="agents-secondary-btn" onClick={handleOpenCreateComposer}>
+                Create agent
+              </button>
+            </div>
+            {featuredTemplates.length > 1 ? (
+              <div className="agents-showcase-dots" aria-label="Featured workflow selector">
+                {featuredTemplates.map((template, index) => (
+                  <button
+                    key={template.id}
+                    className={`agents-showcase-dot ${index === showcaseIndex ? "active" : ""}`}
+                    onClick={() => setShowcaseIndex(index)}
+                    aria-label={`Show ${template.name}`}
+                  />
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <div className="agents-showcase-visual">
+            <div className="agents-showcase-message">{activeShowcaseTemplate.systemPrompt.split(".")[0]}</div>
+            <div className="agents-showcase-core-card">
+              {(() => {
+                const TemplateGlyph = getTemplateGlyph(activeShowcaseTemplate);
+                return (
+                  <>
+                    <div className="agents-showcase-core-icon">
+                      <TemplateGlyph size={26} />
+                    </div>
+                    <div>
+                      <strong>{activeShowcaseTemplate.name}</strong>
+                      <span>{activeShowcaseTemplate.category}</span>
+                    </div>
+                  </>
+                );
+              })()}
+            </div>
+            {showcaseSideTemplates[0] && (() => {
+              const template = showcaseSideTemplates[0];
+              const TemplateGlyph = getTemplateGlyph(template);
+              return (
+                <button
+                  key={template.id}
+                  className="agents-showcase-side-card"
+                  onClick={() => setStudioDraft(buildDraftFromTemplate(template, workspaces))}
+                >
+                  <div className="agents-showcase-side-icon">
+                    <TemplateGlyph size={18} />
+                  </div>
+                  <div>
+                    <strong>{template.name}</strong>
+                    <span>{template.description}</span>
+                  </div>
+                </button>
+              );
+            })()}
+            <div className="agents-showcase-status">
+              <span>Slack</span>
+              <span>{activeShowcaseTemplate.studio?.scheduleConfig?.enabled ? "Scheduled" : "On demand"}</span>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {conversionPanel ? (
+        <section className="agents-summary-card agents-conversion-card">
+          <div className="agents-section-head">
+            <h2>
+              {conversionPanel === "agent-role"
+                ? "Convert Agent Persona"
+                : "Convert automation/profile"}
+            </h2>
+            <span>Bring legacy assets into the managed-agent model without deleting the originals.</span>
+          </div>
+          <div className="agents-list">
+            {(conversionPanel === "agent-role" ? agentRoles : automationProfiles)
+              .slice(0, 8)
+              .map((entry) => (
+                <div key={entry.id} className="agents-list-row">
+                  <div>
+                    <strong>{entry.displayName || entry.id}</strong>
+                    <span>{entry.description || entry.profile || "Legacy configuration"}</span>
+                  </div>
+                  <button
+                    className="agents-link-btn"
+                    onClick={() =>
+                      conversionPanel === "agent-role"
+                        ? void handleConvertAgentRole(entry.id)
+                        : void handleConvertAutomationProfile(entry.id)
+                    }
+                  >
+                    Convert
+                  </button>
+                </div>
+              ))}
+          </div>
+          <div className="agents-row-actions">
+            <button className="agents-link-btn" onClick={() => setConversionPanel(null)}>
+              Close
+            </button>
+            <button className="agents-link-btn" onClick={onOpenAgentPersonas}>
+              Open legacy surface
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      {error && <div className="agents-error-banner">{error}</div>}
+
+      <section className="agents-metrics-strip">
+        <div className="agents-metric-pill">
+          <span>Total agents</span>
+          <strong>{agents.length}</strong>
+        </div>
+        <div className="agents-metric-pill">
+          <span>Total runs</span>
+          <strong>{sessions.length}</strong>
+        </div>
+        <div className="agents-metric-pill">
+          <span>Slack deployments</span>
+          <strong>
+            {agents.reduce(
+              (count, agent) => count + (getStudioConfig(agentDetails[agent.id])?.channelTargets?.length || 0),
+              0,
+            )}
+          </strong>
+        </div>
+        <div className="agents-metric-pill">
+          <span>Scheduled</span>
+          <strong>{scheduledAgents.length}</strong>
+        </div>
+      </section>
+
+      <section className="agents-library-surface">
+        <div className="agents-library-header">
+          <div className="agents-section-head agents-section-head-stack">
+            <h2>Shared workflow library</h2>
+            <span>Templates, recent runs, and reusable operators for the workspace.</span>
+          </div>
+          <div className="agents-tab-row agents-tab-row-primary">
+            {[
+              ["recent", "Recently used"],
+              ["library", "Built by me"],
+            ].map(([id, label]) => (
+              <button
+                key={id}
+                type="button"
+                className={`agents-tab ${libraryTab === id ? "active" : ""}`}
+                onClick={() => setLibraryTab(id as AgentsLibraryTab)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <div className="agents-tab-row agents-tab-row-secondary">
+            {[
+              ["shared", "Shared"],
+              ["scheduled", "Scheduled"],
+              ["templates", "Templates"],
+            ].map(([id, label]) => (
+              <button
+                key={id}
+                type="button"
+                className={`agents-tab subtle ${libraryTab === id ? "active" : ""}`}
+                onClick={() => setLibraryTab(id as AgentsLibraryTab)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {libraryTab === "templates" ? (
+          <div className="agents-template-grid">
+            {templates.map((template) => {
+              const TemplateGlyph = getTemplateGlyph(template);
+              return (
+                <button
+                  key={template.id}
+                  className="agents-template-card"
+                  style={{ ["--template-accent" as string]: template.color }}
+                  onClick={() => setStudioDraft(buildDraftFromTemplate(template, workspaces))}
+                >
+                  <span className="agents-template-icon">
+                    <TemplateGlyph size={22} />
+                  </span>
+                  <div>
+                    <strong>{template.name}</strong>
+                    <p>{template.description}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        ) : libraryAgents.length > 0 ? (
+          <div className="agents-library-grid">
+            {libraryAgents.slice(0, 6).map((agent, index) => {
+              const studio = getStudioConfig(agentDetails[agent.id]);
+              const analytics = getAgentAnalytics(agent, sessions, studio);
+              const TemplateGlyph = studio?.templateId
+                ? getTemplateGlyph(
+                    templates.find((entry) => entry.id === studio.templateId) || {
+                      id: studio.templateId,
+                      name: studio.templateId,
+                      description: "",
+                      icon: "",
+                      color: "#1570ef",
+                      category: "operations",
+                      systemPrompt: "",
+                      executionMode: "solo",
+                    },
+                  )
+                : Bot;
+              return (
+                <button
+                  key={agent.id}
+                  className={`agents-library-card ${index === 0 ? "feature" : ""}`}
+                  onClick={() => setSelectedAgentId(agent.id)}
+                >
+                  <div className="agents-library-card-top">
+                    <span className="agents-library-card-icon">
+                      <TemplateGlyph size={index === 0 ? 20 : 18} />
+                    </span>
+                    <span className="agents-library-card-status">{agent.status}</span>
+                  </div>
+                  <div className="agents-library-card-copy">
+                    <strong>{agent.name}</strong>
+                    <p>{agent.description || studio?.workflowBrief || "No description yet."}</p>
+                  </div>
+                  <div className="agents-library-card-meta">
+                    <span>{studio?.sharing?.ownerLabel || studio?.sharing?.visibility || "team"}</span>
+                    <span>{analytics.latestRunAt ? formatRelative(analytics.latestRunAt) : "No runs yet"}</span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="agents-empty-state">No agents in this view yet.</div>
+        )}
+      </section>
+
+      <section className="agents-governance-strip">
+        <div className="agents-governance-item">
+          <ShieldCheck size={16} />
+          <span>Approval rules for sensitive actions</span>
+        </div>
+        <div className="agents-governance-item">
+          <Library size={16} />
+          <span>Share privately, with a team, or workspace-wide</span>
+        </div>
+        <div className="agents-governance-item">
+          <Send size={16} />
+          <span>Deploy into Slack without a separate bot flow</span>
+        </div>
+        <div className="agents-governance-item">
+          <BarChart3 size={16} />
+          <span>{workspaceMemberships.length} workspace membership rules loaded</span>
+        </div>
+      </section>
+
+      <section className="agents-detail-surface">
+        <div className="agents-section-head">
+          <h2>Agent detail</h2>
+          <span>Deployment, controls, analytics, and recent runs.</span>
+        </div>
+        {selectedAgent ? (
+          <div className="agents-detail-grid">
+            <div className="agents-detail-card">
+              {(() => {
+                const studio = getStudioConfig(agentDetails[selectedAgent.id]);
+                const fallbackAnalytics = getAgentAnalytics(selectedAgent, sessions, studio);
+                const insights = agentInsights[selectedAgent.id];
+                const analytics = insights
+                  ? {
+                      ...fallbackAnalytics,
+                      totalRuns: insights.totalRuns,
+                      successRate:
+                        insights.totalRuns > 0
+                          ? Math.round((insights.successCount / insights.totalRuns) * 100)
+                          : 0,
+                    }
+                  : fallbackAnalytics;
+                const approvalPreview = getEffectiveApprovalPreview(
+                  studio?.approvalPolicy,
+                  studio?.deployment,
+                );
+                const approvalRuntimeMatrix = getApprovalRuntimeMatrix(studio?.approvalPolicy);
+                const runtimeCatalog = runtimeCatalogs[selectedAgent.id];
+                const runtimeCatalogError = runtimeCatalogErrors[selectedAgent.id];
+                const runtimeCatalogLoading = runtimeCatalogLoadingId === selectedAgent.id;
+                const chatgptTools = sortRuntimeToolCatalogEntries(runtimeCatalog?.chatgpt || []);
+                const slackTools = sortRuntimeToolCatalogEntries(runtimeCatalog?.slack || []);
+                const linkedRoutines = agentRoutines[selectedAgent.id] || [];
+                const deploymentHealth = normalizeSlackDeploymentHealth(
+                  slackHealth[selectedAgent.id],
+                  getSlackDeploymentHealth(studio, slackChannels, selectedAgent.id),
+                );
+                const permissions = selectedAgentWorkspaceId
+                  ? workspacePermissions[selectedAgentWorkspaceId]
+                  : undefined;
+                const memberships = selectedAgentWorkspaceId
+                  ? workspaceMemberships.filter(
+                      (membership) => membership.workspaceId === selectedAgentWorkspaceId,
+                    )
+                  : [];
+                return (
+                  <>
+              <div className="agents-detail-header">
+                <div>
+                  <h3>{selectedAgent.name}</h3>
+                  <p>{selectedAgent.description || "No description yet."}</p>
+                </div>
+                <div className="agents-row-actions">
+                  <button
+                    className="agents-secondary-btn"
+                    onClick={() =>
+                      setStudioDraft(
+                        buildDraftFromAgent(
+                          selectedAgent,
+                          agentDetails[selectedAgent.id],
+                          environments,
+                          workspaces,
+                          linkedRoutines,
+                        ),
+                      )
+                    }
+                    disabled={permissions ? !permissions.canEditDrafts : false}
+                  >
+                    <Wrench size={16} />
+                    Edit
+                  </button>
+                  <button
+                    className="agents-secondary-btn"
+                    onClick={() => void handlePublishAgent(selectedAgent.id)}
+                    disabled={
+                      selectedAgent.status === "active" || (permissions ? !permissions.canPublishAgents : false)
+                    }
+                  >
+                    Publish
+                  </button>
+                  <button
+                    className="agents-secondary-btn"
+                    onClick={() => void handleSuspendAgent(selectedAgent.id)}
+                    disabled={
+                      selectedAgent.status === "suspended" ||
+                      (permissions ? !permissions.canPublishAgents : false)
+                    }
+                  >
+                    Suspend
+                  </button>
+                  <button
+                    className="agents-primary-btn"
+                    onClick={() => handleRunAgent(selectedAgent)}
+                    disabled={
+                      selectedAgent.status === "suspended" || (permissions ? !permissions.canRunAgents : false)
+                    }
+                  >
+                    <Play size={16} />
+                    Run now
+                  </button>
+                </div>
+              </div>
+
+              {studio?.workflowBrief && (
+                <div className="agents-note-card">
+                  <strong>Workflow</strong>
+                  <p>{studio.workflowBrief}</p>
+                </div>
+              )}
+
+              <div className="agents-detail-meta">
+                <div>
+                  <span>Template</span>
+                  <strong>{studio?.templateId || "Blank"}</strong>
+                </div>
+                <div>
+                  <span>Status</span>
+                  <strong>{selectedAgent.status}</strong>
+                </div>
+                <div>
+                  <span>Total runs</span>
+                  <strong>{analytics.totalRuns}</strong>
+                </div>
+                <div>
+                  <span>Success rate</span>
+                  <strong>{analytics.successRate}%</strong>
+                </div>
+                <div>
+                  <span>Active runs</span>
+                  <strong>{analytics.activeRuns}</strong>
+                </div>
+              </div>
+
+              <div className="agents-detail-meta agents-detail-meta-secondary">
+                <div>
+                  <span>Deploys to</span>
+                  <strong>{analytics.surfaces.join(", ")}</strong>
+                </div>
+                <div>
+                  <span>Slack targets</span>
+                  <strong>{analytics.slackTargets}</strong>
+                </div>
+                <div>
+                  <span>Approvals</span>
+                  <strong>{analytics.approvalActions || 0}</strong>
+                </div>
+                <div>
+                  <span>Shared as</span>
+                  <strong>{studio?.sharing?.visibility || "team"}</strong>
+                </div>
+                <div>
+                  <span>Owner</span>
+                  <strong>{studio?.sharing?.ownerLabel || "Unassigned"}</strong>
+                </div>
+                <div>
+                  <span>Latest run</span>
+                  <strong>{analytics.latestRunAt ? formatRelative(analytics.latestRunAt) : "No runs yet"}</strong>
+                </div>
+                <div>
+                  <span>Approvals resolved</span>
+                  <strong>{insights ? `${insights.approvalRate}%` : "N/A"}</strong>
+                </div>
+                <div>
+                  <span>Audio summary</span>
+                  <strong>
+                    {studio?.audioSummaryConfig?.enabled ? "Enabled" : "Off"}
+                  </strong>
+                </div>
+                <div>
+                  <span>Auto-approve read-only</span>
+                  <strong>{studio?.approvalPolicy?.autoApproveReadOnly === false ? "No" : "Yes"}</strong>
+                </div>
+              </div>
+
+              <div className="agents-surface-preview-grid agents-surface-preview-grid-detail">
+                <div className="agents-surface-preview-card">
+                  <strong>Effective approvals</strong>
+                  <p>{approvalPreview.sharedSummary}</p>
+                  <p className="agents-surface-preview-foot">
+                    Auto-approved:{" "}
+                    {approvalPreview.autoApproved.length > 0
+                      ? approvalPreview.autoApproved.join(", ")
+                      : "none"}
+                  </p>
+                </div>
+                <div className="agents-surface-preview-card">
+                  <strong>CoWork OS</strong>
+                  <p>{approvalPreview.chatgptSummary}</p>
+                </div>
+                <div className="agents-surface-preview-card">
+                  <strong>Slack</strong>
+                  <p>{approvalPreview.slackSummary}</p>
+                </div>
+              </div>
+
+              <div className="agents-approval-preview-card agents-approval-matrix-card agents-approval-matrix-card-detail">
+                <strong>Runtime approval mapping</strong>
+                <div className="agents-approval-matrix">
+                  <div className="agents-approval-matrix-header">
+                    <div className="agents-approval-matrix-head">Action</div>
+                    <div className="agents-approval-matrix-head">Runtime class</div>
+                    <div className="agents-approval-matrix-head">Behavior</div>
+                  </div>
+                  {approvalRuntimeMatrix.map((row) => (
+                    <div key={row.semanticAction} className="agents-approval-matrix-row">
+                      <div className="agents-approval-matrix-cell">
+                        <span className="agents-approval-matrix-label">Action</span>
+                        <span>{row.semanticAction}</span>
+                      </div>
+                      <div className="agents-approval-matrix-cell">
+                        <span className="agents-approval-matrix-label">Runtime class</span>
+                        <code className="agents-approval-runtime-code">{row.runtimeType}</code>
+                      </div>
+                      <div
+                        className={`agents-approval-matrix-cell ${
+                          row.behavior === "require_approval" ? "danger" : "safe"
+                        }`}
+                      >
+                        <span className="agents-approval-matrix-label">Behavior</span>
+                        <span
+                          className={`agents-approval-behavior-pill ${
+                            row.behavior === "require_approval" ? "danger" : "safe"
+                          }`}
+                        >
+                          {row.behavior === "require_approval" ? "Requires approval" : "Auto-approves"}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="agents-note-card">
+                <strong>Governance and deployment</strong>
+                <p>
+                  Workspace role: {permissions?.role || "loading"} · Slack channels using agent:{" "}
+                  {deploymentHealth.targets.length} · Connected: {deploymentHealth.connectedCount} · Misconfigured:{" "}
+                  {deploymentHealth.misconfiguredCount}
+                </p>
+              </div>
+
+              <div className="agents-approval-preview-card">
+                <strong>Workspace access</strong>
+                <div className="agents-list">
+                  {memberships.map((membership) => (
+                    <div key={membership.id} className="agents-list-row">
+                      <div>
+                        <strong>{membership.principalId}</strong>
+                        <span>{membership.role}</span>
+                      </div>
+                      {permissions?.canManageMemberships ? (
+                        <select
+                          value={membership.role}
+                          onChange={(event) =>
+                            void window.electronAPI
+                              .updateAgentWorkspaceMembership({
+                                workspaceId: membership.workspaceId,
+                                principalId: membership.principalId,
+                                role: event.target.value as AgentWorkspaceMembership["role"],
+                              })
+                              .then((updated) =>
+                                setWorkspaceMemberships((current) =>
+                                  current.map((entry) => (entry.id === updated.id ? updated : entry)),
+                                ),
+                              )
+                          }
+                        >
+                          <option value="viewer">viewer</option>
+                          <option value="operator">operator</option>
+                          <option value="builder">builder</option>
+                          <option value="publisher">publisher</option>
+                          <option value="admin">admin</option>
+                        </select>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="agents-approval-preview-card">
+                <strong>Linked routines</strong>
+                <div className="agents-list">
+                  {linkedRoutines.map((routine) => (
+                    <div key={routine.id} className="agents-list-row">
+                      <div>
+                        <strong>{routine.name}</strong>
+                        <span>
+                          {routine.trigger.type.replace(/_/g, " ")} · {routine.enabled ? "enabled" : "disabled"}
+                        </span>
+                      </div>
+                      <code>{routine.trigger.type}</code>
+                    </div>
+                  ))}
+                  {linkedRoutines.length === 0 ? (
+                    <span className="agents-empty-note">No linked routines yet.</span>
+                  ) : null}
+                </div>
+              </div>
+
+              {insights ? (
+                <div className="agents-approval-preview-card">
+                  <strong>Insights</strong>
+                  <div className="agents-detail-meta agents-detail-meta-secondary">
+                    <div>
+                      <span>Unique users</span>
+                      <strong>{insights.uniqueUsers}</strong>
+                    </div>
+                    <div>
+                      <span>Failures</span>
+                      <strong>{insights.failureCount}</strong>
+                    </div>
+                    <div>
+                      <span>Avg completion</span>
+                      <strong>
+                        {insights.averageCompletionTimeMs > 0
+                          ? `${Math.round(insights.averageCompletionTimeMs / 60000)}m`
+                          : "N/A"}
+                      </strong>
+                    </div>
+                  </div>
+                  <div className="agents-surface-preview-grid agents-surface-preview-grid-detail">
+                    <div className="agents-surface-preview-card">
+                      <strong>Top tools</strong>
+                      <p>
+                        {insights.topTools.length > 0
+                          ? insights.topTools.map((tool) => `${tool.toolName} (${tool.count})`).join(", ")
+                          : "No tool usage yet."}
+                      </p>
+                    </div>
+                    <div className="agents-surface-preview-card">
+                      <strong>Trigger sources</strong>
+                      <p>
+                        {insights.triggerBreakdown.length > 0
+                          ? insights.triggerBreakdown.map((entry) => `${entry.key} (${entry.count})`).join(", ")
+                          : "No trigger history yet."}
+                      </p>
+                    </div>
+                    <div className="agents-surface-preview-card">
+                      <strong>Recent errors</strong>
+                      <p>
+                        {insights.recentErrors.length > 0
+                          ? insights.recentErrors.map((entry) => entry.message).join(" · ")
+                          : "No recent errors."}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="agents-approval-preview-card">
+                <strong>Slack deployment health</strong>
+                <p>
+                  {deploymentHealth.lastSuccessfulRoutedRunAt
+                    ? `Last successful routed run ${formatRelative(deploymentHealth.lastSuccessfulRoutedRunAt)}.`
+                    : "No successful routed Slack run recorded yet."}
+                </p>
+                <p>
+                  {deploymentHealth.lastDeploymentError
+                    ? `Latest deployment issue: ${deploymentHealth.lastDeploymentError}`
+                    : "No deployment errors currently recorded."}
+                </p>
+                <div className="agents-list">
+                  {deploymentHealth.targets.map((target) => (
+                    <div key={target.channelId} className="agents-list-row">
+                      <div>
+                        <strong>{target.channelName}</strong>
+                        <span>
+                          {target.status} · {target.securityMode || "pairing"} ·{" "}
+                          {target.progressRelayMode || "minimal"}
+                        </span>
+                      </div>
+                      <span>{target.misconfigured ? "Needs attention" : "Healthy"}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="agents-approval-preview-card agents-runtime-catalog-card">
+                <strong>Live runtime tool catalog</strong>
+                <p className="agents-runtime-catalog-copy">
+                  This list comes from the real runtime registry after workspace permissions,
+                  managed-environment limits, tool families, MCP allowlists, and deployment
+                  surface rules are applied.
+                </p>
+                {runtimeCatalogLoading ? (
+                  <div className="agents-empty-note">Loading runtime tools...</div>
+                ) : runtimeCatalogError ? (
+                  <div className="agents-empty-note">{runtimeCatalogError}</div>
+                ) : (
+                  <div className="agents-runtime-surface-grid">
+                    {[
+                      {
+                        key: "chatgpt",
+                        title: "CoWork OS surface",
+                        enabled: (studio?.deployment?.surfaces || ["chatgpt"]).includes("chatgpt"),
+                        tools: chatgptTools,
+                      },
+                      {
+                        key: "slack",
+                        title: "Slack surface",
+                        enabled: (studio?.deployment?.surfaces || []).includes("slack"),
+                        tools: slackTools,
+                      },
+                    ].map((surface) => (
+                      <div key={surface.key} className="agents-runtime-surface-card">
+                        <div className="agents-runtime-surface-head">
+                          <strong>{surface.title}</strong>
+                          <span>
+                            {surface.enabled ? `${surface.tools.length} tools` : "Deployment off"}
+                          </span>
+                        </div>
+                        {!surface.enabled ? (
+                          <div className="agents-empty-note">
+                            Enable this deployment surface to publish the agent there.
+                          </div>
+                        ) : surface.tools.length === 0 ? (
+                          <div className="agents-empty-note">
+                            No tools are currently exposed on this surface.
+                          </div>
+                        ) : (
+                          <div className="agents-runtime-tool-list">
+                            {surface.tools.slice(0, 18).map((tool) => (
+                              <div key={`${surface.key}:${tool.name}`} className="agents-runtime-tool-row">
+                                <div>
+                                  <div className="agents-runtime-tool-title">
+                                    <code>{tool.name}</code>
+                                    {tool.family ? <span>{tool.family}</span> : null}
+                                    {tool.mcpServerName ? <span>{tool.mcpServerName}</span> : null}
+                                  </div>
+                                  <p>{tool.description}</p>
+                                </div>
+                                <div className="agents-runtime-tool-meta">
+                                  <span
+                                    className={`agents-runtime-pill ${
+                                      tool.approvalBehavior === "require_approval"
+                                        ? "danger"
+                                        : tool.approvalBehavior === "auto_approve"
+                                          ? "safe"
+                                          : ""
+                                    }`}
+                                  >
+                                    {tool.approvalBehavior === "require_approval"
+                                      ? "Requires approval"
+                                      : tool.approvalBehavior === "auto_approve"
+                                        ? "Auto-approves"
+                                        : tool.approvalBehavior === "workspace_policy"
+                                          ? "Workspace policy"
+                                          : "No approval gate"}
+                                  </span>
+                                  <span className="agents-runtime-meta-line">
+                                    Runtime kind:{" "}
+                                    {RUNTIME_APPROVAL_KIND_LABELS[tool.approvalKind]}
+                                  </span>
+                                  <span className="agents-runtime-meta-line">
+                                    Approval type:{" "}
+                                    {tool.approvalType
+                                      ? APPROVAL_TYPE_LABELS[tool.approvalType]
+                                      : "None"}
+                                  </span>
+                                  <span className="agents-runtime-meta-line">
+                                    Side effects: {tool.sideEffectLevel}
+                                  </span>
+                                </div>
+                              </div>
+                            ))}
+                            {surface.tools.length > 18 ? (
+                              <div className="agents-empty-note">
+                                Showing the first 18 tools by approval severity.
+                              </div>
+                            ) : null}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+                  </>
+                );
+              })()}
+            </div>
+
+            <div className="agents-detail-card">
+              <div className="agents-section-head">
+                <h3>Recent runs</h3>
+                <span>Managed sessions for this agent</span>
+              </div>
+              <div className="agents-list">
+                {sessions
+                  .filter((session) => session.agentId === selectedAgent.id)
+                  .slice(0, 6)
+                  .map((session) => (
+                    <div key={session.id} className="agents-session-row">
+                      <div>
+                        <strong>{session.title}</strong>
+                        <span>
+                          {sessionStatusLabel(session)} · {formatRelative(session.updatedAt)}
+                        </span>
+                      </div>
+                      <div className="agents-row-actions">
+                        <button
+                          className="agents-link-btn"
+                          onClick={() => {
+                            setSelectedSessionId(session.id);
+                            void window.electronAPI
+                              .getManagedSessionWorkpaper(session.id)
+                              .then((workpaper) =>
+                                setSessionWorkpapers((current) => ({
+                                  ...current,
+                                  [session.id]: workpaper,
+                                })),
+                              );
+                          }}
+                        >
+                          Workpaper
+                        </button>
+                        <button
+                          className="agents-link-btn"
+                          onClick={() => handleGenerateAudio(session)}
+                        >
+                          <Volume2 size={16} />
+                          Audio
+                        </button>
+                        <button
+                          className="agents-link-btn"
+                          onClick={() => void window.electronAPI.resumeManagedSession(session.id)}
+                        >
+                          Resume
+                        </button>
+                      </div>
+                      {audioResults[session.id]?.playbackUrl && (
+                        <audio
+                          controls
+                          src={audioResults[session.id].playbackUrl}
+                          className="agents-audio-player"
+                        />
+                      )}
+                    </div>
+                  ))}
+              </div>
+              {selectedSessionId && sessionWorkpapers[selectedSessionId] ? (
+                <div className="agents-approval-preview-card">
+                  <strong>Run workpaper</strong>
+                  <p>{sessionWorkpapers[selectedSessionId].summary}</p>
+                  <div className="agents-list">
+                    <div className="agents-list-row">
+                      <div>
+                        <strong>Decisions</strong>
+                        <span>
+                          {sessionWorkpapers[selectedSessionId].decisions.length > 0
+                            ? sessionWorkpapers[selectedSessionId].decisions
+                                .map((entry) => entry.summary)
+                                .join(" · ")
+                            : "No decision trail yet."}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="agents-list-row">
+                      <div>
+                        <strong>Approvals</strong>
+                        <span>
+                          {sessionWorkpapers[selectedSessionId].approvals.length > 0
+                            ? sessionWorkpapers[selectedSessionId].approvals
+                                .map((entry) => `${entry.status}: ${entry.summary}`)
+                                .join(" · ")
+                            : "No approval requests."}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="agents-list-row">
+                      <div>
+                        <strong>Artifacts</strong>
+                        <span>
+                          {sessionWorkpapers[selectedSessionId].artifacts.length > 0
+                            ? sessionWorkpapers[selectedSessionId].artifacts
+                                .map((entry) => entry.label)
+                                .join(", ")
+                            : "No artifacts recorded."}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="agents-list-row">
+                      <div>
+                        <strong>Audit trail</strong>
+                        <span>
+                          {(agentAudit[selectedAgent.id] || []).length > 0
+                            ? (agentAudit[selectedAgent.id] || [])
+                                .map((entry) => entry.summary)
+                                .join(" · ")
+                            : "No audit history yet."}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <div className="agents-empty-state">Create or select an agent to see the detail view.</div>
+        )}
+      </section>
+      {renderAgentsStyles()}
+    </div>
+  );
+}
+
+function renderAgentsStyles() {
+  return (
+    <style>{`
+      .agents-panel,
+      .agents-studio {
+        --agents-bg: #f6f5f1;
+        --agents-surface: rgba(255, 255, 255, 0.82);
+        --agents-surface-strong: #ffffff;
+        --agents-border: rgba(15, 23, 42, 0.08);
+        --agents-border-strong: rgba(15, 23, 42, 0.12);
+        --agents-text: #101828;
+        --agents-muted: #667085;
+        --agents-subtle: #98a2b3;
+        --agents-accent: #1570ef;
+        --agents-accent-soft: rgba(21, 112, 239, 0.12);
+        --agents-shadow: 0 24px 64px -34px rgba(15, 23, 42, 0.22);
+        padding: 28px;
+        color: var(--agents-text);
+        height: 100%;
+        overflow-y: auto;
+        background:
+          radial-gradient(circle at top right, rgba(34, 197, 246, 0.14), transparent 24%),
+          linear-gradient(180deg, #fcfbf8 0%, var(--agents-bg) 100%);
+        font-family:
+          "SF Pro Display",
+          "SF Pro Text",
+          "Helvetica Neue",
+          Arial,
+          sans-serif;
+      }
+      .agents-create-screen {
+        min-height: 100%;
+      }
+      .agents-panel-loading,
+      .agents-empty-state {
+        padding: 32px;
+        color: var(--agents-muted);
+      }
+      .agents-create-screen-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+      }
+      .agents-create-screen-back,
+      .agents-create-screen-blank {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        color: var(--agents-text);
+        font-size: 1rem;
+      }
+      .agents-create-screen-blank {
+        color: var(--agents-muted);
+      }
+      .agents-create-screen-hero {
+        max-width: 1040px;
+        margin: 0 auto;
+        min-height: calc(100dvh - 140px);
+        display: grid;
+        justify-items: center;
+        align-content: start;
+        padding-top: clamp(64px, 10vh, 136px);
+      }
+      .agents-create-screen-icon {
+        width: 72px;
+        height: 72px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 24px;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.58)),
+          rgba(255, 255, 255, 0.8);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.94),
+          0 18px 38px -28px rgba(15, 23, 42, 0.28);
+        color: var(--agents-accent);
+      }
+      .agents-create-screen-hero h1 {
+        margin: 22px 0 0;
+        font-size: clamp(2.5rem, 2vw + 1.9rem, 3.35rem);
+        line-height: 1.04;
+        letter-spacing: -0.04em;
+        font-weight: 500;
+        text-align: center;
+      }
+      .agents-create-screen-input {
+        width: min(100%, 1020px);
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 14px;
+        align-items: center;
+        margin-top: 38px;
+        padding: 12px 12px 12px 22px;
+        border-radius: 999px;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        background: rgba(255, 255, 255, 0.96);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.94),
+          0 18px 40px -30px rgba(15, 23, 42, 0.22);
+      }
+      .agents-create-screen-input-leading {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--agents-text);
+      }
+      .agents-create-screen-input input {
+        width: 100%;
+        border: 0;
+        background: transparent;
+        color: var(--agents-text);
+        font: inherit;
+        font-size: 1.06rem;
+        line-height: 1.45;
+        padding: 10px 0;
+      }
+      .agents-create-screen-input input::placeholder {
+        color: var(--agents-subtle);
+      }
+      .agents-create-screen-input input:focus {
+        outline: none;
+      }
+      .agents-create-screen-submit {
+        width: 52px;
+        height: 52px;
+        border: 0;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: #111827;
+        color: #ffffff;
+        cursor: pointer;
+        box-shadow: 0 12px 24px -18px rgba(17, 24, 39, 0.42);
+      }
+      .agents-create-screen-suggestions {
+        width: min(100%, 1020px);
+        display: grid;
+        gap: 8px;
+        margin-top: 44px;
+      }
+      .agents-create-screen-row {
+        display: grid;
+        grid-template-columns: auto auto minmax(0, 1fr);
+        align-items: center;
+        gap: 16px;
+        padding: 10px 18px;
+        border: 0;
+        border-radius: 18px;
+        background: transparent;
+        color: inherit;
+        text-align: left;
+        cursor: pointer;
+      }
+      .agents-create-screen-row:hover {
+        background: rgba(255, 255, 255, 0.42);
+      }
+      .agents-create-screen-row-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--agents-text);
+      }
+      .agents-create-screen-row strong {
+        font-size: 1rem;
+        font-weight: 500;
+        color: var(--agents-text);
+      }
+      .agents-create-screen-row span:last-child {
+        color: var(--agents-subtle);
+        font-size: 0.98rem;
+        line-height: 1.45;
+      }
+      .agents-empty-state {
+        border: 1px dashed var(--agents-border-strong);
+        border-radius: 28px;
+        background: rgba(255, 255, 255, 0.48);
+      }
+      .agents-inline-permission-note {
+        margin: 0 0 16px;
+        padding: 12px 16px;
+        border-radius: 18px;
+        border: 1px solid var(--agents-border);
+        background: var(--agents-surface);
+        color: var(--agents-muted);
+      }
+      .agents-shell-header {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: end;
+        gap: 20px;
+        margin-bottom: 22px;
+      }
+      .agents-shell-copy h1 {
+        margin: 0;
+        font-size: 3.1rem;
+        line-height: 0.98;
+        letter-spacing: -0.04em;
+        font-weight: 500;
+      }
+      .agents-shell-copy p {
+        margin: 12px 0 0;
+        color: var(--agents-subtle);
+        font-size: 1.06rem;
+      }
+      .agents-shell-actions {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 10px;
+      }
+      .agents-create-surface,
+      .agents-showcase,
+      .agents-hero-card {
+        border-radius: 32px;
+        border: 1px solid var(--agents-border);
+        background: var(--agents-surface);
+        box-shadow: var(--agents-shadow);
+      }
+      .agents-create-surface {
+        padding: 30px;
+        margin-bottom: 22px;
+      }
+      .agents-create-heading {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        margin-bottom: 18px;
+      }
+      .agents-create-badge,
+      .agents-showcase-core-icon,
+      .agents-template-icon,
+      .agents-library-card-icon,
+      .agents-showcase-side-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 22px;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.55)),
+          rgba(255, 255, 255, 0.76);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.88),
+          0 14px 34px -24px rgba(15, 23, 42, 0.35);
+        color: var(--agents-accent);
+      }
+      .agents-create-badge {
+        width: 68px;
+        height: 68px;
+      }
+      .agents-create-heading h2,
+      .agents-showcase-copy h2 {
+        margin: 0;
+        font-size: 1.05rem;
+        line-height: 1.1;
+        letter-spacing: -0.02em;
+        font-weight: 500;
+      }
+      .agents-create-heading h2 {
+        font-size: 2rem;
+      }
+      .agents-create-heading p,
+      .agents-showcase-copy p,
+      .agents-hero-card p {
+        margin: 8px 0 0;
+        color: var(--agents-muted);
+        max-width: 54ch;
+        line-height: 1.6;
+      }
+      .agents-create-bar {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 14px;
+        align-items: center;
+        min-height: 80px;
+        padding: 10px 12px 10px 18px;
+        border-radius: 999px;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        background: rgba(255, 255, 255, 0.94);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.92),
+          0 16px 36px -28px rgba(15, 23, 42, 0.22);
+      }
+      .agents-create-leading {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--agents-text);
+      }
+      .agents-create-bar textarea {
+        width: 100%;
+        min-height: 44px;
+        max-height: 132px;
+        resize: vertical;
+        border: 0;
+        background: transparent;
+        color: var(--agents-text);
+        padding: 10px 0;
+        font: inherit;
+        font-size: 1.02rem;
+        line-height: 1.45;
+      }
+      .agents-create-bar textarea::placeholder {
+        color: var(--agents-subtle);
+      }
+      .agents-create-bar textarea:focus {
+        outline: none;
+      }
+      .agents-create-presets {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 16px;
+      }
+      .agents-preset-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        border: 1px solid var(--agents-border);
+        border-radius: 999px;
+        padding: 12px 16px;
+        background: rgba(255, 255, 255, 0.88);
+        color: var(--agents-text);
+        cursor: pointer;
+        transition:
+          transform 0.28s cubic-bezier(0.16, 1, 0.3, 1),
+          border-color 0.28s cubic-bezier(0.16, 1, 0.3, 1),
+          background 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+      }
+      .agents-preset-chip.ghost {
+        color: var(--agents-muted);
+      }
+      .agents-preset-chip:hover {
+        transform: translateY(-1px);
+        border-color: rgba(21, 112, 239, 0.22);
+        background: rgba(255, 255, 255, 0.96);
+      }
+      .agents-showcase {
+        position: relative;
+        display: grid;
+        grid-template-columns: minmax(0, 1.04fr) minmax(340px, 0.96fr);
+        gap: 32px;
+        padding: 44px;
+        min-height: 480px;
+        margin-bottom: 22px;
+        overflow: hidden;
+        border-color: rgba(125, 211, 252, 0.26);
+        background:
+          radial-gradient(circle at 18% 22%, rgba(255, 255, 255, 0.26), transparent 26%),
+          radial-gradient(circle at 78% 18%, rgba(255, 255, 255, 0.24), transparent 32%),
+          linear-gradient(135deg, #1e8df6, #3dbcf5 48%, #7ed8f6 100%);
+        color: #ffffff;
+      }
+      .agents-showcase::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background:
+          radial-gradient(circle at 60% 58%, rgba(255, 255, 255, 0.18), transparent 24%),
+          radial-gradient(circle at 72% 32%, rgba(255, 255, 255, 0.14), transparent 20%);
+        mix-blend-mode: screen;
+        animation: agentsShowcaseGlow 12s ease-in-out infinite alternate;
+        pointer-events: none;
+      }
+      .agents-showcase > * {
+        position: relative;
+      }
+      .agents-showcase-copy {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 16px;
+        height: 100%;
+      }
+      .agents-showcase-eyebrow,
+      .agents-eyebrow,
+      .agents-studio-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        width: fit-content;
+        padding: 8px 12px;
+        border-radius: 999px;
+        font-size: 0.72rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(255, 255, 255, 0.9);
+        background: rgba(255, 255, 255, 0.16);
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+      }
+      .agents-showcase-copy h2 {
+        margin: 0;
+        font-size: clamp(2rem, 1.6vw + 1.4rem, 2.9rem);
+        line-height: 1.08;
+        max-width: 14ch;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      .agents-showcase-copy p {
+        margin: 0;
+        color: rgba(255, 255, 255, 0.88);
+        max-width: 38ch;
+        line-height: 1.5;
+      }
+      .agents-showcase-actions,
+      .agents-hero-actions,
+      .agents-toolbar,
+      .agents-row-actions,
+      .agents-inline-create {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .agents-showcase-actions {
+        margin-top: 8px;
+      }
+      .agents-showcase-dots {
+        display: flex;
+        gap: 10px;
+        margin-top: 8px;
+      }
+      .agents-showcase-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 999px;
+        border: 0;
+        cursor: pointer;
+        background: rgba(255, 255, 255, 0.28);
+      }
+      .agents-showcase-dot.active {
+        background: rgba(255, 255, 255, 0.96);
+      }
+      .agents-showcase-visual {
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: stretch;
+        gap: 16px;
+        padding-left: 4%;
+        height: 100%;
+      }
+      .agents-showcase-message {
+        align-self: flex-end;
+        padding: 14px 22px;
+        border-radius: 22px;
+        background: rgba(247, 251, 255, 0.96);
+        color: #111827;
+        box-shadow: 0 14px 32px -24px rgba(15, 23, 42, 0.42);
+        max-width: 360px;
+        font-size: 1rem;
+        line-height: 1.4;
+      }
+      .agents-showcase-core-card,
+      .agents-showcase-side-card {
+        border: 1px solid rgba(255, 255, 255, 0.28);
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.88)),
+          rgba(255, 255, 255, 0.9);
+        color: var(--agents-text);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.4),
+          0 28px 48px -32px rgba(15, 23, 42, 0.42);
+      }
+      .agents-showcase-core-card {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        width: 100%;
+        max-width: 400px;
+        align-self: flex-end;
+        padding: 20px 24px;
+        border-radius: 24px;
+        animation: agentsFloatCard 6.8s ease-in-out infinite;
+      }
+      .agents-showcase-core-card strong,
+      .agents-showcase-side-card strong {
+        display: block;
+        font-size: 1.12rem;
+        font-weight: 500;
+      }
+      .agents-showcase-core-card span,
+      .agents-showcase-side-card span {
+        display: block;
+        color: var(--agents-muted);
+        margin-top: 6px;
+        line-height: 1.45;
+      }
+      .agents-showcase-core-icon {
+        width: 62px;
+        height: 62px;
+      }
+      .agents-showcase-side-card {
+        width: 100%;
+        max-width: 360px;
+        display: flex;
+        align-items: flex-start;
+        gap: 14px;
+        text-align: left;
+        padding: 18px 20px;
+        border-radius: 22px;
+        cursor: pointer;
+        align-self: flex-end;
+        transition:
+          transform 0.28s cubic-bezier(0.16, 1, 0.3, 1),
+          box-shadow 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+      }
+      .agents-showcase-side-card.top {
+        margin-right: 8%;
+      }
+      .agents-showcase-side-card.bottom {
+        margin-right: 0;
+      }
+      .agents-showcase-side-card:hover {
+        transform: translateY(-2px);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.4),
+          0 32px 56px -30px rgba(15, 23, 42, 0.5);
+      }
+      .agents-showcase-side-icon,
+      .agents-template-icon,
+      .agents-library-card-icon {
+        width: 48px;
+        height: 48px;
+        flex-shrink: 0;
+      }
+      .agents-showcase-status {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+      .agents-showcase-status span {
+        padding: 8px 12px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.18);
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        color: rgba(255, 255, 255, 0.94);
+        font-size: 0.8rem;
+      }
+      .agents-toolbar {
+        justify-content: space-between;
+        margin-bottom: 20px;
+      }
+      .agents-primary-btn,
+      .agents-create-submit,
+      .agents-secondary-btn,
+      .agents-link-btn,
+      .agents-link-card,
+      .agents-chip,
+      .agents-preset-chip,
+      .agents-template-card {
+        border: 0;
+        cursor: pointer;
+      }
+      .agents-primary-btn,
+      .agents-create-submit,
+      .agents-secondary-btn,
+      .agents-link-btn,
+      .agents-link-card {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        border-radius: 999px;
+        padding: 12px 18px;
+        font-weight: 600;
+        transition:
+          transform 0.28s cubic-bezier(0.16, 1, 0.3, 1),
+          background 0.28s cubic-bezier(0.16, 1, 0.3, 1),
+          border-color 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+      }
+      .agents-primary-btn:active,
+      .agents-create-submit:active,
+      .agents-secondary-btn:active,
+      .agents-link-card:active,
+      .agents-template-card:active,
+      .agents-library-card:active,
+      .agents-showcase-side-card:active,
+      .agents-preset-chip:active {
+        transform: translateY(1px) scale(0.985);
+      }
+      .agents-primary-btn {
+        background: #111827;
+        color: white;
+        box-shadow: 0 12px 24px -18px rgba(17, 24, 39, 0.45);
+      }
+      .agents-create-submit {
+        width: 52px;
+        height: 52px;
+        justify-content: center;
+        padding: 0;
+        background: #111827;
+        color: #ffffff;
+        box-shadow: 0 12px 24px -18px rgba(17, 24, 39, 0.42);
+      }
+      .agents-secondary-btn,
+      .agents-link-card {
+        background: rgba(255, 255, 255, 0.84);
+        color: var(--agents-text);
+        border: 1px solid var(--agents-border);
+      }
+      .agents-link-btn {
+        background: transparent;
+        color: var(--agents-muted);
+        padding: 0;
+      }
+      .agents-link-btn:disabled,
+      .agents-primary-btn:disabled,
+      .agents-secondary-btn:disabled,
+      .agents-create-submit:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        transform: none;
+      }
+      .agents-link-card:hover,
+      .agents-secondary-btn:hover,
+      .agents-primary-btn:hover,
+      .agents-create-submit:hover {
+        transform: translateY(-1px);
+      }
+      .agents-routine-card {
+        display: grid;
+        gap: 12px;
+        padding: 14px;
+        border-radius: 18px;
+        border: 1px solid var(--agents-border);
+        background: rgba(255, 255, 255, 0.4);
+      }
+      .agents-error-banner {
+        margin: 0 0 16px;
+        padding: 14px 16px;
+        border-radius: 18px;
+        border: 1px solid rgba(239, 68, 68, 0.16);
+        background: rgba(254, 242, 242, 0.86);
+        color: #b42318;
+      }
+      .agents-summary-card,
+      .agents-library-surface,
+      .agents-templates,
+      .agents-summary-card,
+      .agents-section-card,
+      .agents-detail-card,
+      .agents-detail-surface {
+        background: var(--agents-surface);
+        border: 1px solid var(--agents-border);
+        border-radius: 30px;
+        padding: 24px;
+        box-shadow: 0 18px 42px -32px rgba(15, 23, 42, 0.18);
+      }
+      .agents-metrics-strip,
+      .agents-summary-grid,
+      .agents-detail-grid,
+      .agents-studio-grid {
+        display: grid;
+        gap: 18px;
+      }
+      .agents-studio-test-surface {
+        grid-column: 1 / -1;
+      }
+      .agents-studio-test-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
+        gap: 18px;
+        margin-top: 18px;
+      }
+      .agents-studio-test-chat,
+      .agents-studio-test-summary {
+        min-width: 0;
+        display: grid;
+        gap: 14px;
+      }
+      .agents-studio-test-suggestions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        color: var(--agents-muted);
+      }
+      .agents-studio-test-transcript {
+        min-height: 360px;
+        max-height: 640px;
+        overflow: auto;
+        display: grid;
+        align-content: start;
+        gap: 12px;
+        padding: 16px;
+        border-radius: 24px;
+        border: 1px solid var(--agents-border);
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(248, 250, 252, 0.78)),
+          rgba(255, 255, 255, 0.82);
+      }
+      .agents-studio-test-empty {
+        display: grid;
+        place-items: center;
+        min-height: 280px;
+        text-align: center;
+        color: var(--agents-muted);
+      }
+      .agents-studio-test-empty strong {
+        color: var(--agents-text);
+        font-size: 1.05rem;
+      }
+      .agents-studio-test-empty p {
+        margin: 8px 0 0;
+        max-width: 38ch;
+        line-height: 1.6;
+      }
+      .agents-studio-test-bubble {
+        max-width: min(100%, 620px);
+        display: grid;
+        gap: 6px;
+        padding: 14px 16px;
+        border-radius: 20px;
+        border: 1px solid var(--agents-border);
+        background: rgba(255, 255, 255, 0.92);
+        box-shadow: 0 14px 28px -24px rgba(15, 23, 42, 0.18);
+      }
+      .agents-studio-test-bubble.user {
+        margin-left: auto;
+        background: rgba(21, 112, 239, 0.1);
+        border-color: rgba(21, 112, 239, 0.18);
+      }
+      .agents-studio-test-bubble.assistant {
+        margin-right: auto;
+      }
+      .agents-studio-test-bubble.system {
+        max-width: 100%;
+        background: rgba(15, 23, 42, 0.04);
+      }
+      .agents-studio-test-bubble-role {
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--agents-muted);
+      }
+      .agents-studio-test-bubble p {
+        margin: 0;
+        line-height: 1.55;
+        color: var(--agents-text);
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+      }
+      .agents-studio-test-compose {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 12px;
+        align-items: end;
+      }
+      .agents-studio-test-compose textarea {
+        min-height: 84px;
+        resize: vertical;
+      }
+      .agents-studio-test-summary-card,
+      .agents-studio-test-workpaper {
+        padding: 16px 18px;
+        border-radius: 22px;
+        border: 1px solid var(--agents-border);
+        background: rgba(255, 255, 255, 0.74);
+      }
+      .agents-studio-test-summary-card span,
+      .agents-studio-test-workpaper span {
+        display: block;
+        font-size: 0.75rem;
+        color: var(--agents-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .agents-studio-test-summary-card strong,
+      .agents-studio-test-workpaper strong {
+        display: block;
+        margin-top: 6px;
+        font-size: 1.02rem;
+      }
+      .agents-studio-test-summary-card p,
+      .agents-studio-test-workpaper p {
+        margin: 8px 0 0;
+        color: var(--agents-muted);
+        line-height: 1.55;
+      }
+      .agents-metrics-strip {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        margin-bottom: 22px;
+      }
+      .agents-metric-pill {
+        padding: 18px 20px;
+        border-radius: 24px;
+        border: 1px solid var(--agents-border);
+        background: rgba(255, 255, 255, 0.72);
+        box-shadow: 0 18px 32px -28px rgba(15, 23, 42, 0.18);
+      }
+      .agents-metric-pill span,
+      .agents-kpi span {
+        display: block;
+        font-size: 0.78rem;
+        color: var(--agents-muted);
+        margin-bottom: 6px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .agents-metric-pill strong,
+      .agents-kpi strong {
+        font-size: 2rem;
+        line-height: 1;
+        font-weight: 500;
+      }
+      .agents-governance-list {
+        display: grid;
+        gap: 12px;
+      }
+      .agents-approval-preview {
+        margin-top: 14px;
+      }
+      .agents-approval-preview-card,
+      .agents-surface-preview-card {
+        padding: 14px 16px;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.56);
+        border: 1px solid var(--agents-border);
+      }
+      .agents-approval-preview-card strong,
+      .agents-surface-preview-card strong {
+        display: block;
+        margin-bottom: 6px;
+      }
+      .agents-approval-preview-card p,
+      .agents-surface-preview-card p {
+        margin: 0;
+        color: var(--agents-muted);
+      }
+      .agents-approval-columns {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 16px;
+        margin-top: 12px;
+      }
+      .agents-approval-columns span {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 12px;
+        color: var(--agents-muted);
+      }
+      .agents-approval-columns ul {
+        margin: 0;
+        padding-left: 18px;
+        color: var(--agents-text);
+      }
+      .agents-approval-columns li {
+        margin: 0 0 4px;
+      }
+      .agents-approval-matrix-card {
+        margin-top: 12px;
+      }
+      .agents-approval-matrix-card-detail {
+        margin-top: 14px;
+      }
+      .agents-approval-matrix {
+        margin-top: 10px;
+        display: grid;
+        gap: 0;
+      }
+      .agents-approval-matrix-header,
+      .agents-approval-matrix-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1.45fr) minmax(180px, 0.9fr) minmax(160px, 0.85fr);
+        gap: 18px;
+        align-items: start;
+      }
+      .agents-approval-matrix-header {
+        padding-bottom: 10px;
+        border-bottom: 1px solid var(--agents-border);
+      }
+      .agents-approval-matrix-head {
+        font-size: 12px;
+        color: var(--agents-muted);
+        font-weight: 600;
+      }
+      .agents-approval-matrix-row {
+        padding: 14px 0;
+        border-bottom: 1px solid var(--agents-border);
+      }
+      .agents-approval-matrix-row:last-child {
+        padding-bottom: 0;
+        border-bottom: none;
+      }
+      .agents-approval-matrix-cell {
+        color: var(--agents-text);
+        font-size: 13px;
+        min-width: 0;
+        display: grid;
+        gap: 6px;
+        line-height: 1.45;
+      }
+      .agents-approval-matrix-label {
+        display: none;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        color: var(--agents-muted);
+      }
+      .agents-approval-runtime-code {
+        width: fit-content;
+        max-width: 100%;
+        padding: 3px 8px;
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.06);
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        font-size: 12px;
+        line-height: 1.3;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+      .agents-approval-matrix-cell.safe {
+        color: #10b981;
+      }
+      .agents-approval-matrix-cell.danger {
+        color: #f59e0b;
+      }
+      .agents-approval-behavior-pill {
+        width: fit-content;
+        max-width: 100%;
+        padding: 4px 10px;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 700;
+        line-height: 1.3;
+        white-space: normal;
+      }
+      .agents-approval-behavior-pill.safe {
+        background: rgba(16, 185, 129, 0.12);
+        color: #059669;
+      }
+      .agents-approval-behavior-pill.danger {
+        background: rgba(245, 158, 11, 0.14);
+        color: #b45309;
+      }
+      .agents-governance-item {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        color: var(--agents-muted);
+      }
+      .agents-library-surface {
+        margin-bottom: 22px;
+      }
+      .agents-library-header {
+        display: grid;
+        gap: 10px;
+        margin-bottom: 18px;
+      }
+      .agents-tab-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+      .agents-tab {
+        border: 1px solid var(--agents-border);
+        background: rgba(255, 255, 255, 0.88);
+        color: var(--agents-muted);
+        padding: 11px 16px;
+        border-radius: 999px;
+        cursor: pointer;
+        transition:
+          transform 0.28s cubic-bezier(0.16, 1, 0.3, 1),
+          border-color 0.28s cubic-bezier(0.16, 1, 0.3, 1),
+          background 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+      }
+      .agents-tab.active {
+        color: var(--agents-text);
+        border-color: rgba(17, 24, 39, 0.14);
+        background: #ffffff;
+        box-shadow: 0 10px 22px -20px rgba(15, 23, 42, 0.22);
+      }
+      .agents-tab.subtle {
+        background: rgba(255, 255, 255, 0.64);
+      }
+      .agents-detail-grid,
+      .agents-studio-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .agents-library-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.16fr) minmax(0, 0.84fr);
+        gap: 16px;
+      }
+      .agents-library-card {
+        display: grid;
+        gap: 16px;
+        padding: 22px;
+        text-align: left;
+        border-radius: 28px;
+        border: 1px solid var(--agents-border);
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.78)),
+          rgba(255, 255, 255, 0.88);
+        box-shadow: 0 18px 42px -30px rgba(15, 23, 42, 0.16);
+        transition:
+          transform 0.32s cubic-bezier(0.16, 1, 0.3, 1),
+          box-shadow 0.32s cubic-bezier(0.16, 1, 0.3, 1);
+      }
+      .agents-library-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 28px 54px -36px rgba(15, 23, 42, 0.22);
+      }
+      .agents-library-card.feature {
+        grid-row: span 2;
+        min-height: 260px;
+        align-content: space-between;
+        background:
+          radial-gradient(circle at top right, rgba(21, 112, 239, 0.12), transparent 28%),
+          linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 255, 255, 0.86));
+      }
+      .agents-library-card-top,
+      .agents-library-card-meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .agents-library-card-status {
+        border-radius: 999px;
+        padding: 8px 12px;
+        background: rgba(17, 24, 39, 0.05);
+        color: var(--agents-muted);
+        font-size: 0.78rem;
+        text-transform: capitalize;
+      }
+      .agents-library-card-copy strong {
+        display: block;
+        font-size: 1.18rem;
+        line-height: 1.15;
+        letter-spacing: -0.02em;
+        font-weight: 500;
+      }
+      .agents-library-card-copy p {
+        margin: 10px 0 0;
+        color: var(--agents-muted);
+        line-height: 1.58;
+      }
+      .agents-library-card-meta span {
+        color: var(--agents-muted);
+        font-size: 0.82rem;
+      }
+      .agents-template-grid,
+      .agents-chip-grid {
+        display: grid;
+        gap: 12px;
+      }
+      .agents-template-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .agents-template-card {
+        display: flex;
+        align-items: flex-start;
+        gap: 14px;
+        padding: 22px;
+        border-radius: 26px;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0.84)),
+          radial-gradient(circle at top left, color-mix(in srgb, var(--template-accent), transparent 78%), transparent 42%);
+        color: inherit;
+        text-align: left;
+        border: 1px solid var(--agents-border);
+      }
+      .agents-section-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: center;
+        margin-bottom: 14px;
+      }
+      .agents-section-head h2,
+      .agents-section-head h3 {
+        margin: 0;
+        font-size: 1.32rem;
+        line-height: 1.12;
+        font-weight: 500;
+      }
+      .agents-section-head span {
+        color: var(--agents-muted);
+        font-size: 0.88rem;
+      }
+      .agents-section-head-stack {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+      }
+      .agents-list {
+        display: grid;
+        gap: 12px;
+      }
+      .agents-list-row,
+      .agents-session-row,
+      .agents-slack-target {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: center;
+        padding: 14px 0;
+        border-top: 1px solid var(--agents-border);
+      }
+      .agents-list-row:first-child,
+      .agents-session-row:first-child,
+      .agents-slack-target:first-child {
+        border-top: 0;
+        padding-top: 0;
+      }
+      .agents-list-row strong,
+      .agents-session-row strong {
+        display: block;
+      }
+      .agents-list-row span,
+      .agents-session-row span,
+      .agents-empty-note {
+        color: var(--agents-muted);
+        font-size: 13px;
+      }
+      .agents-detail-surface {
+        margin-top: 24px;
+      }
+      .agents-detail-header {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        align-items: flex-start;
+        margin-bottom: 16px;
+      }
+      .agents-detail-header h3 {
+        margin: 0 0 6px;
+        font-size: 1.6rem;
+        font-weight: 500;
+      }
+      .agents-detail-header p {
+        margin: 0;
+        color: var(--agents-muted);
+      }
+      .agents-detail-meta {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 12px;
+      }
+      .agents-detail-meta div {
+        padding: 14px;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.58);
+        border: 1px solid var(--agents-border);
+      }
+      .agents-detail-meta-secondary {
+        margin-top: 12px;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+      .agents-detail-meta span {
+        display: block;
+        color: var(--agents-muted);
+        font-size: 12px;
+        margin-bottom: 4px;
+      }
+      .agents-note-card {
+        margin-bottom: 14px;
+        padding: 14px 16px;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.6);
+        border: 1px solid var(--agents-border);
+      }
+      .agents-note-card strong {
+        display: block;
+        margin-bottom: 6px;
+      }
+      .agents-note-card p {
+        margin: 0;
+        color: var(--agents-muted);
+      }
+      .agents-surface-preview-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 14px;
+      }
+      .agents-surface-preview-grid-detail {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+      .agents-surface-preview-foot {
+        margin-top: 10px !important;
+        font-size: 12px;
+      }
+      .agents-audio-player {
+        width: 100%;
+        margin-top: 10px;
+      }
+      .agents-field-grid,
+      .agents-checkbox-row {
+        display: grid;
+        gap: 12px;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .agents-field-grid + label,
+      .agents-field-grid + .agents-chip-grid {
+        margin-top: 12px;
+      }
+      .agents-section-card label {
+        display: grid;
+        gap: 8px;
+        margin-top: 12px;
+      }
+      .agents-section-card label span {
+        font-size: 13px;
+        color: var(--agents-muted);
+      }
+      .agents-section-card input,
+      .agents-section-card textarea,
+      .agents-section-card select {
+        width: 100%;
+        border-radius: 16px;
+        border: 1px solid var(--agents-border);
+        background: rgba(255, 255, 255, 0.88);
+        color: var(--agents-text);
+        padding: 11px 12px;
+        font: inherit;
+      }
+      .agents-section-card input::placeholder,
+      .agents-section-card textarea::placeholder {
+        color: var(--agents-subtle);
+      }
+      .agents-chip-grid {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        margin-top: 10px;
+      }
+      .agents-chip {
+        padding: 10px 12px;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.7);
+        border: 1px solid var(--agents-border);
+        color: var(--agents-muted);
+        text-align: left;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .agents-chip.active {
+        background: var(--agents-accent-soft);
+        color: var(--agents-text);
+        border-color: rgba(21, 112, 239, 0.24);
+      }
+      .agents-checkbox {
+        display: inline-flex !important;
+        align-items: center;
+        gap: 10px;
+        margin-top: 0 !important;
+      }
+      .agents-checkbox input {
+        width: auto;
+      }
+      .agents-inline-create {
+        margin-top: 14px;
+      }
+      .agents-runtime-catalog-card {
+        margin-top: 14px;
+      }
+      .agents-runtime-catalog-copy {
+        margin-top: 8px !important;
+      }
+      .agents-runtime-surface-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 14px;
+      }
+      .agents-runtime-surface-card {
+        min-width: 0;
+        padding: 14px;
+        border-radius: 20px;
+        background: rgba(255, 255, 255, 0.6);
+        border: 1px solid var(--agents-border);
+      }
+      .agents-runtime-surface-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: flex-start;
+        margin-bottom: 12px;
+      }
+      .agents-runtime-surface-head strong {
+        min-width: 0;
+        margin-bottom: 0;
+        overflow-wrap: anywhere;
+      }
+      .agents-runtime-surface-head span {
+        flex: 0 0 auto;
+        color: var(--agents-muted);
+        font-size: 12px;
+        line-height: 1.35;
+        text-align: right;
+        white-space: nowrap;
+      }
+      .agents-runtime-tool-list {
+        display: grid;
+        gap: 10px;
+      }
+      .agents-runtime-tool-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 8px;
+        padding-top: 10px;
+        border-top: 1px solid var(--agents-border);
+        min-width: 0;
+      }
+      .agents-runtime-tool-row:first-child {
+        padding-top: 0;
+        border-top: 0;
+      }
+      .agents-runtime-tool-row > div {
+        min-width: 0;
+      }
+      .agents-runtime-tool-title {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        align-items: flex-start;
+        margin-bottom: 6px;
+        min-width: 0;
+      }
+      .agents-runtime-tool-title code {
+        display: inline-block;
+        max-width: 100%;
+        line-height: 1.3;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+      .agents-runtime-tool-title span,
+      .agents-runtime-meta-line {
+        display: inline-block;
+        max-width: 100%;
+        min-width: 0;
+        color: var(--agents-muted);
+        font-size: 12px;
+        line-height: 1.35;
+        overflow-wrap: anywhere;
+      }
+      .agents-runtime-tool-row p {
+        margin: 0;
+        color: var(--agents-muted);
+        font-size: 13px;
+        line-height: 1.45;
+        overflow-wrap: break-word;
+      }
+      .agents-runtime-tool-meta {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px 10px;
+        min-width: 0;
+      }
+      .agents-runtime-pill {
+        display: inline-flex;
+        align-items: center;
+        flex: 0 0 auto;
+        max-width: 100%;
+        padding: 5px 9px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.82);
+        border: 1px solid var(--agents-border);
+        font-size: 12px;
+        line-height: 1.2;
+        color: var(--agents-text);
+        white-space: nowrap;
+      }
+      .agents-runtime-pill.safe {
+        background: rgba(16, 185, 129, 0.08);
+        color: #10b981;
+      }
+      .agents-runtime-pill.danger {
+        background: rgba(245, 158, 11, 0.12);
+        color: #f59e0b;
+      }
+      .agents-governance-strip {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 12px;
+        margin-bottom: 24px;
+      }
+      .agents-governance-strip .agents-governance-item {
+        padding: 16px 18px;
+        border-radius: 22px;
+        border: 1px solid var(--agents-border);
+        background: rgba(255, 255, 255, 0.72);
+        box-shadow: 0 16px 28px -26px rgba(15, 23, 42, 0.14);
+      }
+      .agents-conversion-card {
+        margin-bottom: 20px;
+      }
+      .agents-section-card,
+      .agents-hero-card {
+        background: rgba(255, 255, 255, 0.86);
+      }
+      .agents-hero-card {
+        border-radius: 28px;
+        padding: 24px;
+      }
+      .agents-hero-card p {
+        color: var(--agents-muted);
+      }
+      .agents-section-card select,
+      .agents-approval-preview-card select {
+        border-radius: 14px;
+        border: 1px solid var(--agents-border);
+        background: #ffffff;
+        color: var(--agents-text);
+        padding: 10px 12px;
+        font: inherit;
+      }
+      .agents-showcase,
+      .agents-library-card,
+      .agents-template-card,
+      .agents-metric-pill,
+      .agents-governance-strip .agents-governance-item,
+      .agents-primary-btn,
+      .agents-secondary-btn,
+      .agents-link-card,
+      .agents-tab,
+      .agents-preset-chip {
+        will-change: transform;
+      }
+      @keyframes agentsShowcaseGlow {
+        0% {
+          transform: translate3d(0, 0, 0) scale(1);
+        }
+        100% {
+          transform: translate3d(-1.5%, 1.5%, 0) scale(1.04);
+        }
+      }
+      @keyframes agentsFloatCard {
+        0%,
+        100% {
+          transform: translate3d(0, 0, 0);
+        }
+        50% {
+          transform: translate3d(0, -6px, 0);
+        }
+      }
+      @media (max-width: 1100px) {
+        .agents-shell-header,
+        .agents-showcase,
+        .agents-metrics-strip,
+        .agents-governance-strip,
+        .agents-library-grid,
+        .agents-detail-grid,
+        .agents-studio-grid,
+        .agents-detail-meta,
+        .agents-field-grid,
+        .agents-checkbox-row,
+        .agents-kpi-grid,
+        .agents-surface-preview-grid,
+        .agents-surface-preview-grid-detail,
+        .agents-runtime-surface-grid,
+        .agents-approval-columns,
+        .agents-approval-matrix-row,
+        .agents-approval-matrix-header,
+        .agents-runtime-tool-row,
+        .agents-studio-test-grid,
+        .agents-studio-test-compose {
+          grid-template-columns: 1fr;
+        }
+        .agents-approval-matrix-header {
+          display: none;
+        }
+        .agents-approval-matrix-label {
+          display: block;
+        }
+        .agents-showcase-visual {
+          padding-left: 0;
+        }
+        .agents-showcase-message,
+        .agents-showcase-side-card,
+        .agents-showcase-core-card {
+          justify-self: stretch;
+          width: auto;
+          margin-right: 0;
+        }
+        .agents-showcase {
+          height: auto;
+          min-height: 0;
+          padding: 32px;
+        }
+        .agents-showcase-core-card,
+        .agents-showcase-side-card,
+        .agents-showcase-message {
+          align-self: stretch;
+          max-width: none;
+          margin-right: 0;
+        }
+      }
+      @media (max-width: 768px) {
+        .agents-panel,
+        .agents-studio {
+          padding: 18px;
+        }
+        .agents-create-screen-bar {
+          align-items: flex-start;
+        }
+        .agents-create-screen-hero {
+          min-height: calc(100dvh - 110px);
+          padding-top: 48px;
+        }
+        .agents-create-screen-input {
+          grid-template-columns: auto minmax(0, 1fr);
+          border-radius: 28px;
+        }
+        .agents-create-screen-submit {
+          grid-column: 1 / -1;
+          width: 100%;
+          height: 48px;
+        }
+        .agents-create-screen-row {
+          grid-template-columns: auto 1fr;
+          align-items: start;
+        }
+        .agents-create-screen-row strong {
+          grid-column: 2;
+        }
+        .agents-create-screen-row span:last-child {
+          grid-column: 2;
+          margin-top: -8px;
+        }
+        .agents-shell-copy h1 {
+          font-size: 2.5rem;
+        }
+        .agents-create-surface,
+        .agents-showcase,
+        .agents-library-surface,
+        .agents-detail-surface,
+        .agents-summary-card,
+        .agents-section-card,
+        .agents-detail-card {
+          padding: 20px;
+          border-radius: 28px;
+        }
+        .agents-showcase {
+          height: auto;
+          min-height: 0;
+        }
+        .agents-create-bar {
+          min-height: 72px;
+          border-radius: 28px;
+          grid-template-columns: auto minmax(0, 1fr);
+        }
+        .agents-create-submit {
+          grid-column: 1 / -1;
+          width: 100%;
+          height: 48px;
+        }
+        .agents-tab-row-primary,
+        .agents-tab-row-secondary,
+        .agents-shell-actions {
+          justify-content: flex-start;
+        }
+      }
+    `}</style>
+  );
+}

--- a/src/renderer/components/DigitalTwinsPanel.tsx
+++ b/src/renderer/components/DigitalTwinsPanel.tsx
@@ -17,9 +17,13 @@ const COMPANY_OPERATOR_TEMPLATE_NAMES = [
 
 interface DigitalTwinsPanelProps {
   initialCompanyId?: string | null;
+  onOpenAgents?: () => void;
 }
 
-export function DigitalTwinsPanel({ initialCompanyId = null }: DigitalTwinsPanelProps) {
+export function DigitalTwinsPanel({
+  initialCompanyId = null,
+  onOpenAgents,
+}: DigitalTwinsPanelProps) {
   const [roles, setRoles] = useState<AgentRole[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -334,6 +338,10 @@ export function DigitalTwinsPanel({ initialCompanyId = null }: DigitalTwinsPanel
           </span>
           </div>
           <div className="dt-header-actions">
+            <button className="dt-btn dt-btn-secondary" onClick={onOpenAgents}>
+              <User size={14} strokeWidth={1.5} />
+              Open Agents Hub
+            </button>
             <button className="dt-btn dt-btn-secondary" onClick={handleCreateBlank}>
               <Plus size={14} strokeWidth={2} />
               New Agent
@@ -346,7 +354,8 @@ export function DigitalTwinsPanel({ initialCompanyId = null }: DigitalTwinsPanel
         </div>
         <p className="dt-subtitle">
           Create digital twins as optional persona presets or build custom agents. Core automation
-          lives in Mission Control and is intentionally separated from Twins.
+          lives in Mission Control and is intentionally separated from Twins. New managed agents
+          now live in the Agents hub.
         </p>
         {selectedCompany ? (
           <div className="dt-company-context">

--- a/src/renderer/components/RoutineSettingsPanel.tsx
+++ b/src/renderer/components/RoutineSettingsPanel.tsx
@@ -1,0 +1,1507 @@
+import { useEffect, useMemo, useState } from "react";
+import { Cable, Clock3, Link2, Pencil, Play, Plus, Save, Trash2, Workflow } from "lucide-react";
+
+type CronSchedule =
+  | { kind: "cron"; expr: string; tz?: string }
+  | { kind: "every"; everyMs: number; anchorMs?: number }
+  | { kind: "at"; atMs: number };
+
+type RoutineTrigger =
+  | {
+      id: string;
+      type: "schedule";
+      enabled: boolean;
+      schedule: CronSchedule;
+      managedCronJobId?: string;
+    }
+  | {
+      id: string;
+      type: "api";
+      enabled: boolean;
+      path?: string;
+      token?: string;
+      managedHookMappingId?: string;
+    }
+  | {
+      id: string;
+      type: "connector_event";
+      enabled: boolean;
+      connectorId: string;
+      changeType?: string;
+      resourceUriContains?: string;
+      cooldownMs?: number;
+      managedEventTriggerId?: string;
+    }
+  | {
+      id: string;
+      type: "channel_event";
+      enabled: boolean;
+      channelType?: string;
+      chatId?: string;
+      textContains?: string;
+      senderContains?: string;
+      cooldownMs?: number;
+      managedEventTriggerId?: string;
+    }
+  | {
+      id: string;
+      type: "mailbox_event";
+      enabled: boolean;
+      eventType?: string;
+      subjectContains?: string;
+      provider?: string;
+      labelContains?: string;
+      cooldownMs?: number;
+      managedEventTriggerId?: string;
+    }
+  | {
+      id: string;
+      type: "github_event";
+      enabled: boolean;
+      eventName?: string;
+      repository?: string;
+      action?: string;
+      ref?: string;
+      cooldownMs?: number;
+      managedEventTriggerId?: string;
+    }
+  | {
+      id: string;
+      type: "manual";
+      enabled: boolean;
+    };
+
+type RoutineOutput =
+  | { kind: "task_only" }
+  | {
+      kind: "channel_message";
+      channelType?: string;
+      channelDbId?: string;
+      channelId?: string;
+      summaryOnly?: boolean;
+      deliverOnSuccess?: boolean;
+      deliverOnError?: boolean;
+    }
+  | {
+      kind: "webhook_response";
+      statusCode?: number;
+      message?: string;
+      includeTaskId?: boolean;
+    };
+
+type RoutineRun = {
+  id: string;
+  routineId: string;
+  triggerType: RoutineTrigger["type"];
+  status: string;
+  outputStatus: string;
+  startedAt: number;
+  finishedAt?: number;
+  sourceEventSummary?: string;
+  backingTaskId?: string;
+  backingManagedSessionId?: string;
+  errorSummary?: string;
+  artifactsSummary?: string;
+};
+
+type Routine = {
+  id: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  workspaceId: string;
+  instructions: string;
+  prompt: string;
+  executionTarget: {
+    kind: "workspace" | "worktree" | "device" | "managed_environment";
+    deviceId?: string;
+    managedEnvironmentId?: string;
+  };
+  connectorPolicy: {
+    mode: "prefer" | "allowlist";
+    connectorIds: string[];
+  };
+  approvalPolicy: {
+    mode: "inherit" | "auto_safe" | "confirm_external" | "strict_confirm";
+  };
+  outputs: RoutineOutput[];
+  triggers: RoutineTrigger[];
+  createdAt: number;
+  updatedAt: number;
+};
+
+type Workspace = {
+  id: string;
+  name: string;
+  path: string;
+};
+
+type HookStatus = {
+  enabled: boolean;
+  serverRunning: boolean;
+  serverAddress?: { host: string; port: number };
+};
+
+type HookSettings = {
+  path: string;
+  host?: string;
+  port?: number;
+};
+
+type MCPServerStatus = {
+  id: string;
+  name: string;
+  status: string;
+};
+
+type RoutineFormState = {
+  enabled: boolean;
+  name: string;
+  description: string;
+  workspaceId: string;
+  instructions: string;
+  executionTargetKind: Routine["executionTarget"]["kind"];
+  deviceId: string;
+  managedEnvironmentId: string;
+  connectorPolicyMode: Routine["connectorPolicy"]["mode"];
+  connectorIds: string[];
+  approvalMode: Routine["approvalPolicy"]["mode"];
+  outputTaskOnly: boolean;
+  outputChannelMessage: boolean;
+  outputChannelType: string;
+  outputChannelId: string;
+  outputSummaryOnly: boolean;
+  outputDeliverOnSuccess: boolean;
+  outputDeliverOnError: boolean;
+  outputWebhookResponse: boolean;
+  outputWebhookStatusCode: number;
+  outputWebhookMessage: string;
+  outputWebhookIncludeTaskId: boolean;
+  scheduleEnabled: boolean;
+  scheduleKind: CronSchedule["kind"];
+  scheduleExpr: string;
+  scheduleTz: string;
+  scheduleEveryMinutes: number;
+  scheduleAt: string;
+  apiEnabled: boolean;
+  apiPath: string;
+  connectorEventEnabled: boolean;
+  connectorEventConnectorId: string;
+  connectorEventChangeType: string;
+  connectorEventResourceUriContains: string;
+  channelEventEnabled: boolean;
+  channelEventChannelType: string;
+  channelEventChatId: string;
+  channelEventTextContains: string;
+  channelEventSenderContains: string;
+  mailboxEventEnabled: boolean;
+  mailboxEventType: string;
+  mailboxEventProvider: string;
+  mailboxEventSubjectContains: string;
+  mailboxEventLabelContains: string;
+  githubEventEnabled: boolean;
+  githubEventName: string;
+  githubEventRepository: string;
+  githubEventAction: string;
+  githubEventRef: string;
+  manualEnabled: boolean;
+};
+
+const DEFAULT_CRON = "0 9 * * 1-5";
+const DEFAULT_SCHEDULE_TZ =
+  Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+
+const chipStyle = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
+  padding: "6px 10px",
+  borderRadius: 999,
+  border: "1px solid var(--color-border, rgba(127, 127, 127, 0.2))",
+  background: "var(--color-surface-secondary, rgba(127, 127, 127, 0.08))",
+  color: "var(--color-text-primary)",
+  fontSize: 12,
+} as const;
+
+function createDefaultFormState(workspaceId = ""): RoutineFormState {
+  return {
+    enabled: true,
+    name: "",
+    description: "",
+    workspaceId,
+    instructions: "",
+    executionTargetKind: "workspace",
+    deviceId: "",
+    managedEnvironmentId: "",
+    connectorPolicyMode: "prefer",
+    connectorIds: [],
+    approvalMode: "inherit",
+    outputTaskOnly: true,
+    outputChannelMessage: false,
+    outputChannelType: "",
+    outputChannelId: "",
+    outputSummaryOnly: true,
+    outputDeliverOnSuccess: true,
+    outputDeliverOnError: true,
+    outputWebhookResponse: false,
+    outputWebhookStatusCode: 202,
+    outputWebhookMessage: "Routine accepted",
+    outputWebhookIncludeTaskId: true,
+    scheduleEnabled: false,
+    scheduleKind: "cron",
+    scheduleExpr: DEFAULT_CRON,
+    scheduleTz: DEFAULT_SCHEDULE_TZ,
+    scheduleEveryMinutes: 60,
+    scheduleAt: "",
+    apiEnabled: false,
+    apiPath: "",
+    connectorEventEnabled: false,
+    connectorEventConnectorId: "",
+    connectorEventChangeType: "",
+    connectorEventResourceUriContains: "",
+    channelEventEnabled: false,
+    channelEventChannelType: "",
+    channelEventChatId: "",
+    channelEventTextContains: "",
+    channelEventSenderContains: "",
+    mailboxEventEnabled: false,
+    mailboxEventType: "",
+    mailboxEventProvider: "",
+    mailboxEventSubjectContains: "",
+    mailboxEventLabelContains: "",
+    githubEventEnabled: false,
+    githubEventName: "",
+    githubEventRepository: "",
+    githubEventAction: "",
+    githubEventRef: "",
+    manualEnabled: true,
+  };
+}
+
+export function RoutineSettingsPanel() {
+  const [routines, setRoutines] = useState<Routine[]>([]);
+  const [runs, setRuns] = useState<RoutineRun[]>([]);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [mcpServers, setMcpServers] = useState<MCPServerStatus[]>([]);
+  const [hooksStatus, setHooksStatus] = useState<HookStatus | null>(null);
+  const [hooksSettings, setHooksSettings] = useState<HookSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [editingRoutineId, setEditingRoutineId] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<RoutineFormState>(() => createDefaultFormState());
+
+  useEffect(() => {
+    void loadAll();
+  }, []);
+
+  const runsByRoutine = useMemo(() => {
+    const grouped = new Map<string, RoutineRun[]>();
+    for (const run of runs) {
+      const entries = grouped.get(run.routineId) || [];
+      entries.push(run);
+      grouped.set(run.routineId, entries);
+    }
+    return grouped;
+  }, [runs]);
+
+  const workspaceMap = useMemo(
+    () => new Map(workspaces.map((workspace) => [workspace.id, workspace])),
+    [workspaces],
+  );
+
+  const apiBaseUrl = useMemo(() => {
+    const host = hooksStatus?.serverAddress?.host || hooksSettings?.host || "127.0.0.1";
+    const port = hooksStatus?.serverAddress?.port || hooksSettings?.port || 9877;
+    const path = hooksSettings?.path || "/hooks";
+    return `http://${host}:${port}${path}`;
+  }, [hooksSettings, hooksStatus]);
+
+  async function loadAll() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [routineList, routineRuns, workspaceList, status, settings, servers] = await Promise.all([
+        window.electronAPI.listRoutines(),
+        window.electronAPI.listRoutineRuns?.(undefined, 200) || Promise.resolve([]),
+        window.electronAPI.listWorkspaces(),
+        window.electronAPI.getHooksStatus(),
+        window.electronAPI.getHooksSettings(),
+        window.electronAPI.getMCPStatus?.() || Promise.resolve([]),
+      ]);
+
+      setRoutines((routineList || []) as Routine[]);
+      setRuns((routineRuns || []) as RoutineRun[]);
+      setWorkspaces(workspaceList || []);
+      setHooksStatus(status);
+      setHooksSettings(settings);
+      setMcpServers(Array.isArray(servers) ? servers : []);
+
+      if (!form.workspaceId && workspaceList?.length) {
+        setForm((current) => ({ ...current, workspaceId: workspaceList[0].id }));
+      }
+    } catch (err: Any) {
+      setError(err.message || "Failed to load routines");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function resetForm() {
+    setEditingRoutineId(null);
+    setShowForm(false);
+    setForm(createDefaultFormState(workspaces[0]?.id || ""));
+  }
+
+  function startCreate() {
+    setEditingRoutineId(null);
+    setShowForm(true);
+    setForm(createDefaultFormState(workspaces[0]?.id || ""));
+  }
+
+  function startEdit(routine: Routine) {
+    const scheduleTrigger = routine.triggers.find((trigger) => trigger.type === "schedule");
+    const apiTrigger = routine.triggers.find((trigger) => trigger.type === "api");
+    const connectorTrigger = routine.triggers.find((trigger) => trigger.type === "connector_event");
+    const channelTrigger = routine.triggers.find((trigger) => trigger.type === "channel_event");
+    const mailboxTrigger = routine.triggers.find((trigger) => trigger.type === "mailbox_event");
+    const githubTrigger = routine.triggers.find((trigger) => trigger.type === "github_event");
+    const manualTrigger = routine.triggers.find((trigger) => trigger.type === "manual");
+    const channelOutput = routine.outputs.find((output) => output.kind === "channel_message");
+    const webhookOutput = routine.outputs.find((output) => output.kind === "webhook_response");
+    const hasTaskOnly = routine.outputs.some((output) => output.kind === "task_only") || routine.outputs.length === 0;
+
+    setEditingRoutineId(routine.id);
+    setShowForm(true);
+    setForm({
+      enabled: routine.enabled,
+      name: routine.name,
+      description: routine.description || "",
+      workspaceId: routine.workspaceId,
+      instructions: routine.instructions || routine.prompt,
+      executionTargetKind: routine.executionTarget?.kind || "workspace",
+      deviceId: routine.executionTarget?.deviceId || "",
+      managedEnvironmentId: routine.executionTarget?.managedEnvironmentId || "",
+      connectorPolicyMode: routine.connectorPolicy?.mode || "prefer",
+      connectorIds: routine.connectorPolicy?.connectorIds || [],
+      approvalMode: routine.approvalPolicy?.mode || "inherit",
+      outputTaskOnly: hasTaskOnly,
+      outputChannelMessage: Boolean(channelOutput),
+      outputChannelType: channelOutput?.kind === "channel_message" ? channelOutput.channelType || "" : "",
+      outputChannelId: channelOutput?.kind === "channel_message" ? channelOutput.channelId || "" : "",
+      outputSummaryOnly: channelOutput?.kind === "channel_message" ? channelOutput.summaryOnly ?? true : true,
+      outputDeliverOnSuccess:
+        channelOutput?.kind === "channel_message" ? channelOutput.deliverOnSuccess ?? true : true,
+      outputDeliverOnError:
+        channelOutput?.kind === "channel_message" ? channelOutput.deliverOnError ?? true : true,
+      outputWebhookResponse: Boolean(webhookOutput),
+      outputWebhookStatusCode:
+        webhookOutput?.kind === "webhook_response" ? webhookOutput.statusCode ?? 202 : 202,
+      outputWebhookMessage:
+        webhookOutput?.kind === "webhook_response" ? webhookOutput.message || "" : "Routine accepted",
+      outputWebhookIncludeTaskId:
+        webhookOutput?.kind === "webhook_response" ? webhookOutput.includeTaskId ?? true : true,
+      scheduleEnabled: Boolean(scheduleTrigger),
+      scheduleKind:
+        scheduleTrigger?.type === "schedule" ? scheduleTrigger.schedule.kind : "cron",
+      scheduleExpr:
+        scheduleTrigger?.type === "schedule" && scheduleTrigger.schedule.kind === "cron"
+          ? scheduleTrigger.schedule.expr
+          : DEFAULT_CRON,
+      scheduleTz:
+        scheduleTrigger?.type === "schedule" && scheduleTrigger.schedule.kind === "cron"
+          ? scheduleTrigger.schedule.tz || DEFAULT_SCHEDULE_TZ
+          : DEFAULT_SCHEDULE_TZ,
+      scheduleEveryMinutes:
+        scheduleTrigger?.type === "schedule" && scheduleTrigger.schedule.kind === "every"
+          ? Math.max(1, Math.floor(scheduleTrigger.schedule.everyMs / 60000))
+          : 60,
+      scheduleAt:
+        scheduleTrigger?.type === "schedule" && scheduleTrigger.schedule.kind === "at"
+          ? toDateTimeLocal(scheduleTrigger.schedule.atMs)
+          : "",
+      apiEnabled: Boolean(apiTrigger),
+      apiPath: apiTrigger?.type === "api" ? apiTrigger.path || "" : "",
+      connectorEventEnabled: Boolean(connectorTrigger),
+      connectorEventConnectorId:
+        connectorTrigger?.type === "connector_event" ? connectorTrigger.connectorId : "",
+      connectorEventChangeType:
+        connectorTrigger?.type === "connector_event" ? connectorTrigger.changeType || "" : "",
+      connectorEventResourceUriContains:
+        connectorTrigger?.type === "connector_event" ? connectorTrigger.resourceUriContains || "" : "",
+      channelEventEnabled: Boolean(channelTrigger),
+      channelEventChannelType:
+        channelTrigger?.type === "channel_event" ? channelTrigger.channelType || "" : "",
+      channelEventChatId:
+        channelTrigger?.type === "channel_event" ? channelTrigger.chatId || "" : "",
+      channelEventTextContains:
+        channelTrigger?.type === "channel_event" ? channelTrigger.textContains || "" : "",
+      channelEventSenderContains:
+        channelTrigger?.type === "channel_event" ? channelTrigger.senderContains || "" : "",
+      mailboxEventEnabled: Boolean(mailboxTrigger),
+      mailboxEventType:
+        mailboxTrigger?.type === "mailbox_event" ? mailboxTrigger.eventType || "" : "",
+      mailboxEventProvider:
+        mailboxTrigger?.type === "mailbox_event" ? mailboxTrigger.provider || "" : "",
+      mailboxEventSubjectContains:
+        mailboxTrigger?.type === "mailbox_event" ? mailboxTrigger.subjectContains || "" : "",
+      mailboxEventLabelContains:
+        mailboxTrigger?.type === "mailbox_event" ? mailboxTrigger.labelContains || "" : "",
+      githubEventEnabled: Boolean(githubTrigger),
+      githubEventName:
+        githubTrigger?.type === "github_event" ? githubTrigger.eventName || "" : "",
+      githubEventRepository:
+        githubTrigger?.type === "github_event" ? githubTrigger.repository || "" : "",
+      githubEventAction:
+        githubTrigger?.type === "github_event" ? githubTrigger.action || "" : "",
+      githubEventRef:
+        githubTrigger?.type === "github_event" ? githubTrigger.ref || "" : "",
+      manualEnabled: manualTrigger?.type === "manual" ? manualTrigger.enabled : true,
+    });
+  }
+
+  function toggleConnector(connectorId: string) {
+    setForm((current) => ({
+      ...current,
+      connectorIds: current.connectorIds.includes(connectorId)
+        ? current.connectorIds.filter((item) => item !== connectorId)
+        : [...current.connectorIds, connectorId],
+    }));
+  }
+
+  async function saveRoutine() {
+    if (!form.name.trim()) {
+      setError("Routine name is required");
+      return;
+    }
+    if (!form.workspaceId) {
+      setError("Workspace is required");
+      return;
+    }
+    if (!form.instructions.trim()) {
+      setError("Routine instructions are required");
+      return;
+    }
+    if (form.executionTargetKind === "device" && !form.deviceId.trim()) {
+      setError("Device ID is required for device-targeted routines");
+      return;
+    }
+    if (form.executionTargetKind === "managed_environment" && !form.managedEnvironmentId.trim()) {
+      setError("Managed environment ID is required for managed-environment routines");
+      return;
+    }
+    if (form.scheduleEnabled && form.scheduleKind === "cron" && !form.scheduleExpr.trim()) {
+      setError("Cron expression is required when the schedule trigger is enabled");
+      return;
+    }
+    if (form.scheduleEnabled && form.scheduleKind === "at" && !form.scheduleAt) {
+      setError("Choose a run time for one-shot schedules");
+      return;
+    }
+    if (form.connectorEventEnabled && !form.connectorEventConnectorId.trim()) {
+      setError("Choose a connector for the connector event trigger");
+      return;
+    }
+    if (form.outputChannelMessage && (!form.outputChannelType.trim() || !form.outputChannelId.trim())) {
+      setError("Channel outputs need both a channel type and channel ID");
+      return;
+    }
+
+    const existing =
+      editingRoutineId ? routines.find((routine) => routine.id === editingRoutineId) || null : null;
+    const triggers = buildTriggers(form, existing);
+    const outputs = buildOutputs(form);
+
+    const payload = {
+      enabled: form.enabled,
+      name: form.name.trim(),
+      description: form.description.trim() || undefined,
+      workspaceId: form.workspaceId,
+      instructions: form.instructions.trim(),
+      executionTarget: {
+        kind: form.executionTargetKind,
+        deviceId: form.deviceId.trim() || undefined,
+        managedEnvironmentId: form.managedEnvironmentId.trim() || undefined,
+      },
+      connectorPolicy: {
+        mode: form.connectorPolicyMode,
+        connectorIds: form.connectorIds,
+      },
+      connectors: form.connectorIds,
+      approvalPolicy: { mode: form.approvalMode },
+      outputs,
+      triggers,
+    };
+
+    setSaving(true);
+    setError(null);
+    try {
+      if (existing) {
+        await window.electronAPI.updateRoutine(existing.id, payload);
+      } else {
+        await window.electronAPI.createRoutine(payload);
+      }
+      await loadAll();
+      resetForm();
+    } catch (err: Any) {
+      setError(err.message || "Failed to save routine");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function deleteRoutine(routineId: string) {
+    if (!confirm("Delete this routine and all of its generated triggers, hooks, and schedule jobs?")) {
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await window.electronAPI.removeRoutine(routineId);
+      await loadAll();
+      if (editingRoutineId === routineId) {
+        resetForm();
+      }
+    } catch (err: Any) {
+      setError(err.message || "Failed to delete routine");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function runRoutineNow(routineId: string) {
+    setSaving(true);
+    setError(null);
+    try {
+      await window.electronAPI.runRoutineNow?.(routineId);
+      await loadAll();
+    } catch (err: Any) {
+      setError(err.message || "Failed to run routine");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function regenerateApiToken(routine: Routine, triggerId: string) {
+    setSaving(true);
+    setError(null);
+    try {
+      await window.electronAPI.regenerateRoutineApiToken(routine.id, triggerId);
+      await loadAll();
+    } catch (err: Any) {
+      setError(err.message || "Failed to regenerate API token");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function copyText(text: string) {
+    await navigator.clipboard.writeText(text);
+  }
+
+  if (loading) {
+    return <div className="settings-loading">Loading routines...</div>;
+  }
+
+  return (
+    <div className="settings-subsection">
+      <div className="settings-section">
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start" }}>
+          <div>
+            <h3>Routines</h3>
+            <p className="settings-description">
+              Routines are CoWork&apos;s saved automations: one set of instructions, one execution
+              target, and one or more triggers. Comparable to Claude Routines, but designed for
+              CoWork&apos;s local-first runtime.
+            </p>
+          </div>
+          <button className="settings-button primary" onClick={startCreate}>
+            <Plus size={16} />
+            New Routine
+          </button>
+        </div>
+
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 12 }}>
+          <span style={chipStyle}>
+            <Workflow size={14} />
+            Routines first
+          </span>
+          <span style={chipStyle}>
+            <Clock3 size={14} />
+            Scheduled Tasks, Webhooks, and Event Triggers remain as generated infrastructure
+          </span>
+          <span style={chipStyle}>
+            <Cable size={14} />
+            Connector allowlists can now be enforced, not just hinted
+          </span>
+        </div>
+
+        {error && (
+          <div className="settings-error" style={{ marginTop: 12 }}>
+            {error}
+          </div>
+        )}
+      </div>
+
+      {showForm && (
+        <div className="settings-section" style={{ display: "grid", gap: 16 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <h4 style={{ margin: 0 }}>{editingRoutineId ? "Edit Routine" : "Create Routine"}</h4>
+            <button className="settings-button secondary" onClick={resetForm}>
+              Cancel
+            </button>
+          </div>
+
+          <label className="settings-field">
+            <span>Name</span>
+            <input
+              className="settings-input"
+              value={form.name}
+              onChange={(event) => setForm({ ...form, name: event.target.value })}
+              placeholder="PR triage"
+            />
+          </label>
+
+          <label className="settings-field">
+            <span>Description</span>
+            <input
+              className="settings-input"
+              value={form.description}
+              onChange={(event) => setForm({ ...form, description: event.target.value })}
+              placeholder="Review repo events and draft next actions."
+            />
+          </label>
+
+          <label className="settings-field">
+            <span>Workspace</span>
+            <select
+              className="settings-select"
+              value={form.workspaceId}
+              onChange={(event) => setForm({ ...form, workspaceId: event.target.value })}
+            >
+              {workspaces.map((workspace) => (
+                <option key={workspace.id} value={workspace.id}>
+                  {workspace.name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="settings-field">
+            <span>Instructions</span>
+            <textarea
+              className="settings-textarea"
+              rows={7}
+              value={form.instructions}
+              onChange={(event) => setForm({ ...form, instructions: event.target.value })}
+              placeholder="Review PRs targeting main. Check missing tests, risky migrations, and auth changes. Leave a pass/flag/fail summary. Do not merge or push."
+            />
+          </label>
+
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 16 }}>
+            <label className="settings-field">
+              <span>Execution Target</span>
+              <select
+                className="settings-select"
+                value={form.executionTargetKind}
+                onChange={(event) =>
+                  setForm({
+                    ...form,
+                    executionTargetKind: event.target.value as RoutineFormState["executionTargetKind"],
+                  })
+                }
+              >
+                <option value="workspace">Workspace</option>
+                <option value="worktree">Git Worktree</option>
+                <option value="device">Remote Device</option>
+                <option value="managed_environment">Managed Environment</option>
+              </select>
+            </label>
+
+            {form.executionTargetKind === "device" && (
+              <label className="settings-field">
+                <span>Device ID</span>
+                <input
+                  className="settings-input"
+                  value={form.deviceId}
+                  onChange={(event) => setForm({ ...form, deviceId: event.target.value })}
+                  placeholder="remote-node-id"
+                />
+              </label>
+            )}
+
+            {form.executionTargetKind === "managed_environment" && (
+              <label className="settings-field">
+                <span>Managed Environment ID</span>
+                <input
+                  className="settings-input"
+                  value={form.managedEnvironmentId}
+                  onChange={(event) =>
+                    setForm({ ...form, managedEnvironmentId: event.target.value })
+                  }
+                  placeholder="env_..."
+                />
+              </label>
+            )}
+
+            <label className="settings-field">
+              <span>Approval Policy</span>
+              <select
+                className="settings-select"
+                value={form.approvalMode}
+                onChange={(event) =>
+                  setForm({
+                    ...form,
+                    approvalMode: event.target.value as RoutineFormState["approvalMode"],
+                  })
+                }
+              >
+                <option value="inherit">Inherit workspace defaults</option>
+                <option value="auto_safe">Auto-safe</option>
+                <option value="confirm_external">Confirm external actions</option>
+                <option value="strict_confirm">Strict confirm</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="settings-field">
+            <span>Connector Policy</span>
+            <div style={{ display: "grid", gap: 12 }}>
+              <select
+                className="settings-select"
+                value={form.connectorPolicyMode}
+                onChange={(event) =>
+                  setForm({
+                    ...form,
+                    connectorPolicyMode: event.target.value as RoutineFormState["connectorPolicyMode"],
+                  })
+                }
+              >
+                <option value="prefer">Prefer connectors in prompt context</option>
+                <option value="allowlist">Enforce connector allowlist at runtime</option>
+              </select>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                {mcpServers.map((server) => {
+                  const active = form.connectorIds.includes(server.id);
+                  return (
+                    <button
+                      key={server.id}
+                      type="button"
+                      className={`settings-chip ${active ? "active" : ""}`}
+                      onClick={() => toggleConnector(server.id)}
+                    >
+                      {server.name}
+                    </button>
+                  );
+                })}
+                {mcpServers.length === 0 && (
+                  <div className="settings-help">No MCP connectors found.</div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="settings-field">
+            <span>Outputs</span>
+            <div style={{ display: "grid", gap: 12 }}>
+              <label className="settings-checkbox">
+                <input
+                  type="checkbox"
+                  checked={form.outputTaskOnly}
+                  onChange={(event) => setForm({ ...form, outputTaskOnly: event.target.checked })}
+                />
+                <span>Create a task and keep results in CoWork</span>
+              </label>
+              <label className="settings-checkbox">
+                <input
+                  type="checkbox"
+                  checked={form.outputChannelMessage}
+                  onChange={(event) =>
+                    setForm({ ...form, outputChannelMessage: event.target.checked })
+                  }
+                />
+                <span>Deliver a channel summary</span>
+              </label>
+              {form.outputChannelMessage && (
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+                  <input
+                    className="settings-input"
+                    value={form.outputChannelType}
+                    onChange={(event) => setForm({ ...form, outputChannelType: event.target.value })}
+                    placeholder="slack"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.outputChannelId}
+                    onChange={(event) => setForm({ ...form, outputChannelId: event.target.value })}
+                    placeholder="C123456"
+                  />
+                  <label className="settings-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={form.outputSummaryOnly}
+                      onChange={(event) =>
+                        setForm({ ...form, outputSummaryOnly: event.target.checked })
+                      }
+                    />
+                    <span>Summary only</span>
+                  </label>
+                  <label className="settings-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={form.outputDeliverOnSuccess}
+                      onChange={(event) =>
+                        setForm({ ...form, outputDeliverOnSuccess: event.target.checked })
+                      }
+                    />
+                    <span>Send on success</span>
+                  </label>
+                  <label className="settings-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={form.outputDeliverOnError}
+                      onChange={(event) =>
+                        setForm({ ...form, outputDeliverOnError: event.target.checked })
+                      }
+                    />
+                    <span>Send on error</span>
+                  </label>
+                </div>
+              )}
+
+              <label className="settings-checkbox">
+                <input
+                  type="checkbox"
+                  checked={form.outputWebhookResponse}
+                  onChange={(event) =>
+                    setForm({ ...form, outputWebhookResponse: event.target.checked })
+                  }
+                />
+                <span>Return a webhook response body for API-triggered runs</span>
+              </label>
+              {form.outputWebhookResponse && (
+                <div style={{ display: "grid", gridTemplateColumns: "140px 1fr auto", gap: 12 }}>
+                  <input
+                    className="settings-input"
+                    type="number"
+                    min={100}
+                    max={599}
+                    value={form.outputWebhookStatusCode}
+                    onChange={(event) =>
+                      setForm({
+                        ...form,
+                        outputWebhookStatusCode: Number(event.target.value || 202),
+                      })
+                    }
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.outputWebhookMessage}
+                    onChange={(event) =>
+                      setForm({ ...form, outputWebhookMessage: event.target.value })
+                    }
+                    placeholder="Routine accepted"
+                  />
+                  <label className="settings-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={form.outputWebhookIncludeTaskId}
+                      onChange={(event) =>
+                        setForm({
+                          ...form,
+                          outputWebhookIncludeTaskId: event.target.checked,
+                        })
+                      }
+                    />
+                    <span>Include task ID</span>
+                  </label>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="settings-field">
+            <span>Triggers</span>
+            <div style={{ display: "grid", gap: 14 }}>
+              <TriggerToggle
+                checked={form.scheduleEnabled}
+                label="Schedule"
+                description="Compile this routine into a managed cron job."
+                onChange={(checked) => setForm({ ...form, scheduleEnabled: checked })}
+              />
+              {form.scheduleEnabled && (
+                <div style={{ display: "grid", gap: 12 }}>
+                  <select
+                    className="settings-select"
+                    value={form.scheduleKind}
+                    onChange={(event) =>
+                      setForm({
+                        ...form,
+                        scheduleKind: event.target.value as RoutineFormState["scheduleKind"],
+                      })
+                    }
+                  >
+                    <option value="cron">Cron</option>
+                    <option value="every">Every N minutes</option>
+                    <option value="at">Run once</option>
+                  </select>
+                  {form.scheduleKind === "cron" && (
+                    <div style={{ display: "grid", gridTemplateColumns: "1fr 220px", gap: 12 }}>
+                      <input
+                        className="settings-input"
+                        value={form.scheduleExpr}
+                        onChange={(event) =>
+                          setForm({ ...form, scheduleExpr: event.target.value })
+                        }
+                        placeholder="0 9 * * 1-5"
+                      />
+                      <input
+                        className="settings-input"
+                        value={form.scheduleTz}
+                        onChange={(event) => setForm({ ...form, scheduleTz: event.target.value })}
+                        placeholder="Europe/Lisbon"
+                      />
+                    </div>
+                  )}
+                  {form.scheduleKind === "every" && (
+                    <input
+                      className="settings-input"
+                      type="number"
+                      min={1}
+                      value={form.scheduleEveryMinutes}
+                      onChange={(event) =>
+                        setForm({
+                          ...form,
+                          scheduleEveryMinutes: Math.max(1, Number(event.target.value || 1)),
+                        })
+                      }
+                    />
+                  )}
+                  {form.scheduleKind === "at" && (
+                    <input
+                      className="settings-input"
+                      type="datetime-local"
+                      value={form.scheduleAt}
+                      onChange={(event) => setForm({ ...form, scheduleAt: event.target.value })}
+                    />
+                  )}
+                </div>
+              )}
+
+              <TriggerToggle
+                checked={form.apiEnabled}
+                label="API"
+                description="Generate a webhook path and token for external callers."
+                onChange={(checked) => setForm({ ...form, apiEnabled: checked })}
+              />
+              {form.apiEnabled && (
+                <input
+                  className="settings-input"
+                  value={form.apiPath}
+                  onChange={(event) => setForm({ ...form, apiPath: event.target.value })}
+                  placeholder="routines/pr-triage"
+                />
+              )}
+
+              <TriggerToggle
+                checked={form.connectorEventEnabled}
+                label="Connector Event"
+                description="Watch MCP connector notifications."
+                onChange={(checked) => setForm({ ...form, connectorEventEnabled: checked })}
+              />
+              {form.connectorEventEnabled && (
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+                  <input
+                    className="settings-input"
+                    value={form.connectorEventConnectorId}
+                    onChange={(event) =>
+                      setForm({ ...form, connectorEventConnectorId: event.target.value })
+                    }
+                    placeholder="github"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.connectorEventChangeType}
+                    onChange={(event) =>
+                      setForm({ ...form, connectorEventChangeType: event.target.value })
+                    }
+                    placeholder="resource_updated"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.connectorEventResourceUriContains}
+                    onChange={(event) =>
+                      setForm({
+                        ...form,
+                        connectorEventResourceUriContains: event.target.value,
+                      })
+                    }
+                    placeholder="repo://..."
+                  />
+                </div>
+              )}
+
+              <TriggerToggle
+                checked={form.channelEventEnabled}
+                label="Channel Event"
+                description="Listen for incoming channel messages."
+                onChange={(checked) => setForm({ ...form, channelEventEnabled: checked })}
+              />
+              {form.channelEventEnabled && (
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+                  <input
+                    className="settings-input"
+                    value={form.channelEventChannelType}
+                    onChange={(event) =>
+                      setForm({ ...form, channelEventChannelType: event.target.value })
+                    }
+                    placeholder="slack"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.channelEventChatId}
+                    onChange={(event) =>
+                      setForm({ ...form, channelEventChatId: event.target.value })
+                    }
+                    placeholder="C123456"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.channelEventTextContains}
+                    onChange={(event) =>
+                      setForm({ ...form, channelEventTextContains: event.target.value })
+                    }
+                    placeholder="contains text"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.channelEventSenderContains}
+                    onChange={(event) =>
+                      setForm({ ...form, channelEventSenderContains: event.target.value })
+                    }
+                    placeholder="sender contains"
+                  />
+                </div>
+              )}
+
+              <TriggerToggle
+                checked={form.mailboxEventEnabled}
+                label="Mailbox Event"
+                description="Use normalized inbox events as a trigger source."
+                onChange={(checked) => setForm({ ...form, mailboxEventEnabled: checked })}
+              />
+              {form.mailboxEventEnabled && (
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+                  <input
+                    className="settings-input"
+                    value={form.mailboxEventType}
+                    onChange={(event) =>
+                      setForm({ ...form, mailboxEventType: event.target.value })
+                    }
+                    placeholder="message_received"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.mailboxEventProvider}
+                    onChange={(event) =>
+                      setForm({ ...form, mailboxEventProvider: event.target.value })
+                    }
+                    placeholder="gmail"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.mailboxEventSubjectContains}
+                    onChange={(event) =>
+                      setForm({ ...form, mailboxEventSubjectContains: event.target.value })
+                    }
+                    placeholder="subject contains"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.mailboxEventLabelContains}
+                    onChange={(event) =>
+                      setForm({ ...form, mailboxEventLabelContains: event.target.value })
+                    }
+                    placeholder="label contains"
+                  />
+                </div>
+              )}
+
+              <TriggerToggle
+                checked={form.githubEventEnabled}
+                label="GitHub Event"
+                description="First-class GitHub trigger surface over connector events."
+                onChange={(checked) => setForm({ ...form, githubEventEnabled: checked })}
+              />
+              {form.githubEventEnabled && (
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+                  <input
+                    className="settings-input"
+                    value={form.githubEventName}
+                    onChange={(event) =>
+                      setForm({ ...form, githubEventName: event.target.value })
+                    }
+                    placeholder="pull_request.opened"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.githubEventRepository}
+                    onChange={(event) =>
+                      setForm({ ...form, githubEventRepository: event.target.value })
+                    }
+                    placeholder="owner/repo"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.githubEventAction}
+                    onChange={(event) =>
+                      setForm({ ...form, githubEventAction: event.target.value })
+                    }
+                    placeholder="opened"
+                  />
+                  <input
+                    className="settings-input"
+                    value={form.githubEventRef}
+                    onChange={(event) =>
+                      setForm({ ...form, githubEventRef: event.target.value })
+                    }
+                    placeholder="refs/heads/main"
+                  />
+                </div>
+              )}
+
+              <TriggerToggle
+                checked={form.manualEnabled}
+                label="Manual"
+                description="Allow manual runs from the routines panel."
+                onChange={(checked) => setForm({ ...form, manualEnabled: checked })}
+              />
+            </div>
+          </div>
+
+          <div style={{ display: "flex", gap: 12, justifyContent: "flex-end" }}>
+            <button className="settings-button primary" onClick={saveRoutine} disabled={saving}>
+              <Save size={16} />
+              {saving ? "Saving..." : "Save Routine"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="settings-section" style={{ display: "grid", gap: 16 }}>
+        {routines.length === 0 ? (
+          <div className="settings-empty-state">
+            No routines yet. Create one to compile schedules, webhooks, and event triggers from a
+            single top-level automation definition.
+          </div>
+        ) : (
+          routines.map((routine) => {
+            const routineRuns = (runsByRoutine.get(routine.id) || []).slice(0, 5);
+            const apiTrigger = routine.triggers.find((trigger) => trigger.type === "api");
+            const workspace = workspaceMap.get(routine.workspaceId);
+            return (
+              <div
+                key={routine.id}
+                style={{
+                  border: "1px solid var(--color-border, rgba(127, 127, 127, 0.2))",
+                  borderRadius: 16,
+                  padding: 16,
+                  display: "grid",
+                  gap: 14,
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start" }}>
+                  <div>
+                    <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                      <strong>{routine.name}</strong>
+                      <span style={chipStyle}>{routine.enabled ? "Enabled" : "Disabled"}</span>
+                      <span style={chipStyle}>{routine.executionTarget.kind.replace(/_/g, " ")}</span>
+                      <span style={chipStyle}>{workspace?.name || routine.workspaceId}</span>
+                    </div>
+                    {routine.description && (
+                      <div className="settings-description" style={{ marginTop: 8 }}>
+                        {routine.description}
+                      </div>
+                    )}
+                  </div>
+
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                    <button className="settings-button secondary" onClick={() => runRoutineNow(routine.id)} disabled={saving}>
+                      <Play size={16} />
+                      Run Now
+                    </button>
+                    <button className="settings-button secondary" onClick={() => startEdit(routine)}>
+                      <Pencil size={16} />
+                      Edit
+                    </button>
+                    <button className="settings-button danger" onClick={() => deleteRoutine(routine.id)} disabled={saving}>
+                      <Trash2 size={16} />
+                      Delete
+                    </button>
+                  </div>
+                </div>
+
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  {routine.triggers.map((trigger) => (
+                    <span key={trigger.id} style={chipStyle}>
+                      {trigger.type.replace(/_/g, " ")}
+                    </span>
+                  ))}
+                  {routine.outputs.map((output, index) => (
+                    <span key={`${routine.id}-output-${index}`} style={chipStyle}>
+                      output: {output.kind.replace(/_/g, " ")}
+                    </span>
+                  ))}
+                  {routine.connectorPolicy.connectorIds.map((connectorId) => (
+                    <span key={`${routine.id}-${connectorId}`} style={chipStyle}>
+                      connector: {connectorId}
+                    </span>
+                  ))}
+                </div>
+
+                {apiTrigger?.type === "api" && (
+                  <div
+                    style={{
+                      border: "1px solid var(--color-border, rgba(127, 127, 127, 0.2))",
+                      borderRadius: 12,
+                      padding: 12,
+                      display: "grid",
+                      gap: 8,
+                    }}
+                  >
+                    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                      <Link2 size={16} />
+                      <strong>API Trigger</strong>
+                    </div>
+                    <code style={{ wordBreak: "break-all" }}>
+                      {apiBaseUrl}/{apiTrigger.path || `routines/${routine.id}/${apiTrigger.id}`}
+                    </code>
+                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                      <button
+                        className="settings-button secondary"
+                        onClick={() =>
+                          copyText(`${apiBaseUrl}/${apiTrigger.path || `routines/${routine.id}/${apiTrigger.id}`}`)
+                        }
+                      >
+                        Copy URL
+                      </button>
+                      {apiTrigger.token && (
+                        <>
+                          <button
+                            className="settings-button secondary"
+                            onClick={() => copyText(apiTrigger.token || "")}
+                          >
+                            Copy Token
+                          </button>
+                          <button
+                            className="settings-button secondary"
+                            onClick={() => regenerateApiToken(routine, apiTrigger.id)}
+                            disabled={saving}
+                          >
+                            Rotate Token
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                <div style={{ display: "grid", gap: 8 }}>
+                  <strong>Recent Runs</strong>
+                  {routineRuns.length === 0 ? (
+                    <div className="settings-help">No runs recorded yet.</div>
+                  ) : (
+                    routineRuns.map((run) => (
+                      <div
+                        key={run.id}
+                        style={{
+                          border: "1px solid var(--color-border, rgba(127, 127, 127, 0.16))",
+                          borderRadius: 10,
+                          padding: 10,
+                          display: "grid",
+                          gap: 6,
+                        }}
+                      >
+                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+                          <span style={chipStyle}>{run.triggerType.replace(/_/g, " ")}</span>
+                          <span style={chipStyle}>{run.status}</span>
+                          <span style={chipStyle}>output: {run.outputStatus}</span>
+                          <span style={chipStyle}>{formatTime(run.startedAt)}</span>
+                        </div>
+                        {run.sourceEventSummary && <div>{run.sourceEventSummary}</div>}
+                        {run.errorSummary && (
+                          <div className="settings-error" style={{ margin: 0 }}>
+                            {run.errorSummary}
+                          </div>
+                        )}
+                        {run.artifactsSummary && (
+                          <div className="settings-help">{run.artifactsSummary}</div>
+                        )}
+                        {(run.backingTaskId || run.backingManagedSessionId) && (
+                          <div className="settings-help">
+                            {run.backingTaskId ? `Task: ${run.backingTaskId}` : ""}
+                            {run.backingTaskId && run.backingManagedSessionId ? " · " : ""}
+                            {run.backingManagedSessionId ? `Session: ${run.backingManagedSessionId}` : ""}
+                          </div>
+                        )}
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TriggerToggle(props: {
+  checked: boolean;
+  label: string;
+  description: string;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="settings-checkbox" style={{ display: "grid", gap: 4 }}>
+      <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+        <input type="checkbox" checked={props.checked} onChange={(event) => props.onChange(event.target.checked)} />
+        <span>{props.label}</span>
+      </div>
+      <span className="settings-help">{props.description}</span>
+    </label>
+  );
+}
+
+function buildTriggers(form: RoutineFormState, existing: Routine | null): RoutineTrigger[] {
+  const findExisting = <T extends RoutineTrigger["type"]>(type: T) =>
+    existing?.triggers.find((trigger): trigger is Extract<RoutineTrigger, { type: T }> => trigger.type === type);
+
+  const triggers: RoutineTrigger[] = [];
+  const scheduleExisting = findExisting("schedule");
+  const apiExisting = findExisting("api");
+  const connectorExisting = findExisting("connector_event");
+  const channelExisting = findExisting("channel_event");
+  const mailboxExisting = findExisting("mailbox_event");
+  const githubExisting = findExisting("github_event");
+  const manualExisting = findExisting("manual");
+
+  if (form.scheduleEnabled) {
+    const schedule: CronSchedule =
+      form.scheduleKind === "every"
+        ? { kind: "every", everyMs: form.scheduleEveryMinutes * 60_000 }
+        : form.scheduleKind === "at"
+          ? { kind: "at", atMs: new Date(form.scheduleAt).getTime() }
+          : { kind: "cron", expr: form.scheduleExpr.trim(), tz: form.scheduleTz.trim() || undefined };
+    triggers.push({
+      ...(scheduleExisting || { id: window.crypto.randomUUID() }),
+      type: "schedule",
+      enabled: true,
+      schedule,
+    });
+  }
+
+  if (form.apiEnabled) {
+    triggers.push({
+      ...(apiExisting || { id: window.crypto.randomUUID() }),
+      type: "api",
+      enabled: true,
+      path: form.apiPath.trim() || undefined,
+    });
+  }
+
+  if (form.connectorEventEnabled) {
+    triggers.push({
+      ...(connectorExisting || { id: window.crypto.randomUUID() }),
+      type: "connector_event",
+      enabled: true,
+      connectorId: form.connectorEventConnectorId.trim(),
+      changeType: form.connectorEventChangeType.trim() || undefined,
+      resourceUriContains: form.connectorEventResourceUriContains.trim() || undefined,
+    });
+  }
+
+  if (form.channelEventEnabled) {
+    triggers.push({
+      ...(channelExisting || { id: window.crypto.randomUUID() }),
+      type: "channel_event",
+      enabled: true,
+      channelType: form.channelEventChannelType.trim() || undefined,
+      chatId: form.channelEventChatId.trim() || undefined,
+      textContains: form.channelEventTextContains.trim() || undefined,
+      senderContains: form.channelEventSenderContains.trim() || undefined,
+    });
+  }
+
+  if (form.mailboxEventEnabled) {
+    triggers.push({
+      ...(mailboxExisting || { id: window.crypto.randomUUID() }),
+      type: "mailbox_event",
+      enabled: true,
+      eventType: form.mailboxEventType.trim() || undefined,
+      provider: form.mailboxEventProvider.trim() || undefined,
+      subjectContains: form.mailboxEventSubjectContains.trim() || undefined,
+      labelContains: form.mailboxEventLabelContains.trim() || undefined,
+    });
+  }
+
+  if (form.githubEventEnabled) {
+    triggers.push({
+      ...(githubExisting || { id: window.crypto.randomUUID() }),
+      type: "github_event",
+      enabled: true,
+      eventName: form.githubEventName.trim() || undefined,
+      repository: form.githubEventRepository.trim() || undefined,
+      action: form.githubEventAction.trim() || undefined,
+      ref: form.githubEventRef.trim() || undefined,
+    });
+  }
+
+  if (form.manualEnabled) {
+    triggers.push({
+      ...(manualExisting || { id: window.crypto.randomUUID() }),
+      type: "manual",
+      enabled: true,
+    });
+  }
+
+  return triggers;
+}
+
+function buildOutputs(form: RoutineFormState): RoutineOutput[] {
+  const outputs: RoutineOutput[] = [];
+  if (form.outputTaskOnly || (!form.outputChannelMessage && !form.outputWebhookResponse)) {
+    outputs.push({ kind: "task_only" });
+  }
+  if (form.outputChannelMessage) {
+    outputs.push({
+      kind: "channel_message",
+      channelType: form.outputChannelType.trim() || undefined,
+      channelId: form.outputChannelId.trim() || undefined,
+      summaryOnly: form.outputSummaryOnly,
+      deliverOnSuccess: form.outputDeliverOnSuccess,
+      deliverOnError: form.outputDeliverOnError,
+    });
+  }
+  if (form.outputWebhookResponse) {
+    outputs.push({
+      kind: "webhook_response",
+      statusCode: form.outputWebhookStatusCode,
+      message: form.outputWebhookMessage.trim() || undefined,
+      includeTaskId: form.outputWebhookIncludeTaskId,
+    });
+  }
+  return outputs;
+}
+
+function toDateTimeLocal(timestampMs: number): string {
+  const date = new Date(timestampMs);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function formatTime(timestampMs: number): string {
+  return new Date(timestampMs).toLocaleString();
+}

--- a/src/renderer/components/TaskPauseBanner.tsx
+++ b/src/renderer/components/TaskPauseBanner.tsx
@@ -1,23 +1,60 @@
 import { useEffect, useId, useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import { buildPauseBannerPreview } from "../utils/pause-banner-summary";
 
 type TaskPauseBannerProps = {
   message?: string | null;
   reasonCode?: string | null;
+  markdownComponents?: Any;
   onStopTask?: (() => void) | undefined;
+  onEnableShell?: (() => void | Promise<void>) | undefined;
+  onContinueWithoutShell?: (() => void | Promise<void>) | undefined;
 };
 
-export function TaskPauseBanner({ message, reasonCode, onStopTask }: TaskPauseBannerProps) {
+export function TaskPauseBannerDetailsContent({
+  message,
+  markdownComponents,
+}: {
+  message: string;
+  markdownComponents?: Any;
+}) {
+  return (
+    <div className="task-pause-details-text markdown-content">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        {message}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+export function TaskPauseBanner({
+  message,
+  reasonCode,
+  markdownComponents,
+  onStopTask,
+  onEnableShell,
+  onContinueWithoutShell,
+}: TaskPauseBannerProps) {
   const [showDetails, setShowDetails] = useState(false);
+  const [pendingAction, setPendingAction] = useState<"enable_shell" | "continue_without_shell" | null>(
+    null,
+  );
   const detailsTitleId = useId();
   const normalizedMessage = typeof message === "string" ? message.trim() : "";
   const preview = useMemo(() => buildPauseBannerPreview(normalizedMessage), [normalizedMessage]);
   const waitingForSkillParameter = reasonCode === "skill_parameters";
+  const waitingForShellPermission =
+    reasonCode === "shell_permission_required" || reasonCode === "shell_permission_still_disabled";
 
   useEffect(() => {
     setShowDetails(false);
   }, [normalizedMessage]);
+
+  useEffect(() => {
+    setPendingAction(null);
+  }, [reasonCode, normalizedMessage]);
 
   useEffect(() => {
     if (!showDetails) return undefined;
@@ -32,12 +69,27 @@ export function TaskPauseBanner({ message, reasonCode, onStopTask }: TaskPauseBa
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [showDetails]);
 
+  const runBannerAction = async (
+    action: "enable_shell" | "continue_without_shell",
+    handler?: (() => void | Promise<void>) | undefined,
+  ) => {
+    if (!handler || pendingAction) return;
+    setPendingAction(action);
+    try {
+      await handler();
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
   return (
     <>
       <div className="task-status-banner task-status-banner-paused">
         <div className="task-status-banner-content">
           <strong>
-            {waitingForSkillParameter
+            {waitingForShellPermission
+              ? "Shell access is needed to continue."
+              : waitingForSkillParameter
               ? "Skill needs one more detail."
               : "Quick check-in - I'm at a decision point."}
           </strong>
@@ -47,18 +99,45 @@ export function TaskPauseBanner({ message, reasonCode, onStopTask }: TaskPauseBa
             </span>
           )}
           <span className="task-status-banner-detail">
-            {waitingForSkillParameter
+            {waitingForShellPermission
+              ? "Enable shell to let me run commands, or continue without it and I’ll use a limited path."
+              : waitingForSkillParameter
               ? "Reply below with the requested value, or stop this task here."
               : "Type anything below to continue, or stop this task here."}
           </span>
         </div>
-        {(preview.showDetails || onStopTask) && (
+        {(waitingForShellPermission || preview.showDetails || onStopTask) && (
           <div className="task-status-banner-actions">
+            {waitingForShellPermission && onEnableShell && (
+              <button
+                type="button"
+                className="task-status-banner-primary-btn"
+                onClick={() => void runBannerAction("enable_shell", onEnableShell)}
+                disabled={pendingAction !== null}
+              >
+                {pendingAction === "enable_shell" ? "Enabling shell..." : "Enable shell"}
+              </button>
+            )}
+            {waitingForShellPermission && onContinueWithoutShell && (
+              <button
+                type="button"
+                className="task-status-banner-secondary-btn"
+                onClick={() =>
+                  void runBannerAction("continue_without_shell", onContinueWithoutShell)
+                }
+                disabled={pendingAction !== null}
+              >
+                {pendingAction === "continue_without_shell"
+                  ? "Continuing..."
+                  : "Continue without shell"}
+              </button>
+            )}
             {preview.showDetails && (
               <button
                 type="button"
                 className="task-status-banner-secondary-btn"
                 onClick={() => setShowDetails(true)}
+                disabled={pendingAction !== null}
               >
                 View details
               </button>
@@ -69,6 +148,7 @@ export function TaskPauseBanner({ message, reasonCode, onStopTask }: TaskPauseBa
                 className="task-status-banner-stop-btn"
                 onClick={onStopTask}
                 title="Stop task"
+                disabled={pendingAction !== null}
               >
                 Stop task
               </button>
@@ -98,7 +178,10 @@ export function TaskPauseBanner({ message, reasonCode, onStopTask }: TaskPauseBa
               </button>
             </div>
             <div className="modal-body">
-              <div className="task-pause-details-text">{preview.fullText}</div>
+              <TaskPauseBannerDetailsContent
+                message={preview.fullText}
+                markdownComponents={markdownComponents}
+              />
             </div>
           </div>
         </div>

--- a/src/renderer/components/UsageInsightsOverview.tsx
+++ b/src/renderer/components/UsageInsightsOverview.tsx
@@ -1,0 +1,256 @@
+import { useMemo } from "react";
+
+interface RequestDayRow {
+  dateKey: string;
+  llmCalls: number;
+  cost: number;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+}
+
+interface OverviewProps {
+  sessions: number;
+  messages: number;
+  totalTokens: number;
+  mostActiveHour: number | null;
+  favoriteModel: string | null;
+  requestsByDay: RequestDayRow[];
+}
+
+const DAY_LABELS = ["Mon", "Wed", "Fri"];
+
+// Roughly the word count of Moby-Dick (~210k words ≈ ~270k tokens).
+const MOBY_DICK_TOKENS = 270_000;
+
+// A few well-known works to cycle through for a fun comparison.
+const BOOK_COMPARISONS: Array<{ name: string; tokens: number }> = [
+  { name: "Moby-Dick", tokens: 270_000 },
+  { name: "the Harry Potter series", tokens: 1_400_000 },
+  { name: "the Lord of the Rings trilogy", tokens: 620_000 },
+  { name: "War and Peace", tokens: 780_000 },
+  { name: "the complete works of Shakespeare", tokens: 1_100_000 },
+];
+
+function formatBigNumber(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function formatHourRange(hour: number): string {
+  const wrap = (h: number) => {
+    const suffix = h < 12 ? "AM" : "PM";
+    const hh = h % 12 === 0 ? 12 : h % 12;
+    return `${hh} ${suffix}`;
+  };
+  return wrap(hour);
+}
+
+function parseDateKey(dateKey: string): Date | null {
+  const parts = dateKey.split("-").map(Number);
+  if (parts.length !== 3 || parts.some((n) => !Number.isFinite(n))) return null;
+  const [y, m, d] = parts;
+  return new Date(y, m - 1, d);
+}
+
+function toKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
+    d.getDate(),
+  ).padStart(2, "0")}`;
+}
+
+interface HeatmapCell {
+  dateKey: string;
+  count: number;
+  intensity: number; // 0..4
+  inRange: boolean;
+}
+
+function buildHeatmap(
+  requestsByDay: RequestDayRow[],
+): { weeks: HeatmapCell[][]; max: number } {
+  if (requestsByDay.length === 0) return { weeks: [], max: 0 };
+  const byDate = new Map<string, number>();
+  for (const row of requestsByDay) {
+    byDate.set(row.dateKey, row.llmCalls);
+  }
+
+  const sorted = [...requestsByDay].sort((a, b) => a.dateKey.localeCompare(b.dateKey));
+  const firstDate = parseDateKey(sorted[0].dateKey);
+  const lastDate = parseDateKey(sorted[sorted.length - 1].dateKey);
+  if (!firstDate || !lastDate) return { weeks: [], max: 0 };
+
+  // Back up to the preceding Sunday so the first column is a full week.
+  const start = new Date(firstDate);
+  start.setDate(start.getDate() - start.getDay());
+  const end = new Date(lastDate);
+  end.setDate(end.getDate() + (6 - end.getDay()));
+
+  const values = Array.from(byDate.values()).filter((v) => v > 0);
+  const max = values.length > 0 ? Math.max(...values) : 0;
+
+  const weeks: HeatmapCell[][] = [];
+  let cursor = new Date(start);
+  while (cursor <= end) {
+    const week: HeatmapCell[] = [];
+    for (let i = 0; i < 7; i++) {
+      const key = toKey(cursor);
+      const count = byDate.get(key) ?? 0;
+      const inRange = cursor >= firstDate && cursor <= lastDate;
+      let intensity = 0;
+      if (count > 0 && max > 0) {
+        const ratio = count / max;
+        intensity = ratio > 0.75 ? 4 : ratio > 0.5 ? 3 : ratio > 0.25 ? 2 : 1;
+      }
+      week.push({ dateKey: key, count, intensity, inRange });
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    weeks.push(week);
+  }
+  return { weeks, max };
+}
+
+function computeStreaks(requestsByDay: RequestDayRow[]): {
+  activeDays: number;
+  currentStreak: number;
+  longestStreak: number;
+} {
+  const activeSet = new Set(
+    requestsByDay.filter((r) => r.llmCalls > 0).map((r) => r.dateKey),
+  );
+  const activeDays = activeSet.size;
+
+  if (activeSet.size === 0) {
+    return { activeDays: 0, currentStreak: 0, longestStreak: 0 };
+  }
+
+  const sortedKeys = [...activeSet].sort();
+  let longestStreak = 1;
+  let run = 1;
+  for (let i = 1; i < sortedKeys.length; i++) {
+    const prev = parseDateKey(sortedKeys[i - 1]);
+    const curr = parseDateKey(sortedKeys[i]);
+    if (!prev || !curr) {
+      run = 1;
+      continue;
+    }
+    const diff = Math.round((curr.getTime() - prev.getTime()) / 86_400_000);
+    if (diff === 1) {
+      run += 1;
+      longestStreak = Math.max(longestStreak, run);
+    } else {
+      run = 1;
+    }
+  }
+
+  // Current streak: consecutive days up to the most recent activity day.
+  let currentStreak = 0;
+  let cursor = parseDateKey(sortedKeys[sortedKeys.length - 1]);
+  while (cursor && activeSet.has(toKey(cursor))) {
+    currentStreak += 1;
+    cursor.setDate(cursor.getDate() - 1);
+  }
+
+  return { activeDays, currentStreak, longestStreak };
+}
+
+function pickBookComparison(totalTokens: number): string | null {
+  if (totalTokens <= 0) return null;
+  // Pick the book whose multiple lands closest to an impressive-but-readable number.
+  let best: { name: string; multiple: number } | null = null;
+  for (const book of BOOK_COMPARISONS) {
+    const multiple = totalTokens / book.tokens;
+    if (multiple < 0.1) continue;
+    if (!best || Math.abs(Math.log10(multiple) - 0.7) < Math.abs(Math.log10(best.multiple) - 0.7)) {
+      best = { name: book.name, multiple };
+    }
+  }
+  if (!best) {
+    const multiple = totalTokens / MOBY_DICK_TOKENS;
+    best = { name: "Moby-Dick", multiple };
+  }
+  const mult = best.multiple;
+  const rendered =
+    mult >= 10 ? `~${Math.round(mult)}\u00D7` : `~${mult.toFixed(1)}\u00D7`;
+  return `You've used ${rendered} more tokens than ${best.name}.`;
+}
+
+export function UsageInsightsOverview(props: OverviewProps) {
+  const { sessions, messages, totalTokens, mostActiveHour, favoriteModel, requestsByDay } = props;
+
+  const { activeDays, currentStreak, longestStreak } = useMemo(
+    () => computeStreaks(requestsByDay),
+    [requestsByDay],
+  );
+
+  const { weeks } = useMemo(() => buildHeatmap(requestsByDay), [requestsByDay]);
+  const comparison = useMemo(() => pickBookComparison(totalTokens), [totalTokens]);
+
+  const peakLabel =
+    mostActiveHour !== null && mostActiveHour >= 0 ? formatHourRange(mostActiveHour) : "\u2014";
+
+  return (
+    <div className="insights-overview">
+      <div className="insights-overview-stats">
+        <StatCard label="Sessions" value={formatBigNumber(sessions)} />
+        <StatCard label="Messages" value={formatBigNumber(messages)} />
+        <StatCard label="Total tokens" value={formatBigNumber(totalTokens)} />
+        <StatCard label="Active days" value={formatBigNumber(activeDays)} />
+        <StatCard label="Current streak" value={`${currentStreak}d`} />
+        <StatCard label="Longest streak" value={`${longestStreak}d`} />
+        <StatCard label="Peak hour" value={peakLabel} />
+        <StatCard
+          label="Favorite model"
+          value={favoriteModel ?? "\u2014"}
+          valueClass="insights-overview-stat-value--small"
+        />
+      </div>
+
+      {weeks.length > 0 && (
+        <div className="insights-overview-heatmap" aria-label="Daily activity heatmap">
+          <div className="insights-overview-heatmap-labels">
+            {DAY_LABELS.map((d) => (
+              <span key={d}>{d}</span>
+            ))}
+          </div>
+          <div className="insights-overview-heatmap-grid">
+            {weeks.map((week, wi) => (
+              <div key={wi} className="insights-overview-heatmap-col">
+                {week.map((cell) => (
+                  <div
+                    key={cell.dateKey}
+                    className={`insights-overview-heatmap-cell insights-overview-heatmap-cell-l${cell.intensity}${cell.inRange ? "" : " out-of-range"}`}
+                    title={`${cell.dateKey}: ${cell.count} call${cell.count === 1 ? "" : "s"}`}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {comparison && <div className="insights-overview-caption">{comparison}</div>}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  valueClass,
+}: {
+  label: string;
+  value: string;
+  valueClass?: string;
+}) {
+  return (
+    <div className="insights-overview-stat">
+      <div className="insights-overview-stat-label">{label}</div>
+      <div className={`insights-overview-stat-value${valueClass ? ` ${valueClass}` : ""}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/UsageInsightsPanel.tsx
+++ b/src/renderer/components/UsageInsightsPanel.tsx
@@ -13,6 +13,7 @@ import {
 import type { Workspace } from "../../shared/types";
 import { formatUsageCount } from "./usageInsightsFormatting";
 import { UsageInsightsLlmSection } from "./UsageInsightsLlmSection";
+import { UsageInsightsOverview } from "./UsageInsightsOverview";
 import {
   DEFAULT_USAGE_INSIGHTS_PERIOD_PRESET,
   getVisibleUsageInsightsPeriodPresets,
@@ -635,6 +636,21 @@ export function UsageInsightsPanel({ workspaceId: initialWorkspaceId }: UsageIns
           </div>
         </div>
       </div>
+
+      {data && (
+        <UsageInsightsOverview
+          sessions={tm?.totalCreated ?? 0}
+          messages={em?.totalLlmCalls ?? 0}
+          totalTokens={em?.totalTokens ?? 0}
+          mostActiveHour={ap ? ap.mostActiveHour : null}
+          favoriteModel={
+            modelRows.length > 0
+              ? [...modelRows].sort((a, b) => b.calls - a.calls)[0]?.model ?? null
+              : null
+          }
+          requestsByDay={data.requestsByDay ?? []}
+        />
+      )}
 
       {/* Hero stats row */}
       {tm && (

--- a/src/renderer/components/__tests__/AgentsHubPanel.test.ts
+++ b/src/renderer/components/__tests__/AgentsHubPanel.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDraftFromAgent,
+  buildDraftFromWorkflowBrief,
+  buildDraftFromTemplate,
+  getEffectiveApprovalPreview,
+  getApprovalRuntimeMatrix,
+  getSlackDeploymentHealth,
+  makeBlankDraft,
+  normalizeSlackDeploymentHealth,
+  sortRuntimeToolCatalogEntries,
+  suggestTemplateFromWorkflowBrief,
+} from "../AgentsHubPanel";
+
+describe("AgentsHubPanel draft helpers", () => {
+  it("builds a template-backed studio draft with seeded schedule, tools, and memory", () => {
+    const draft = buildDraftFromTemplate(
+      {
+        id: "team-chat-qna",
+        name: "Team Chat Q&A",
+        description: "Answer questions from team chat.",
+        icon: "💬",
+        color: "#0ea5e9",
+        category: "communication",
+        systemPrompt: "Answer grounded questions.",
+        executionMode: "solo",
+        skills: ["slack-faq"],
+        mcpServers: ["slack", "drive"],
+        studio: {
+          apps: {
+            allowedToolFamilies: ["communication", "search"],
+            mcpServers: ["slack", "drive"],
+          },
+          memoryConfig: {
+            mode: "focused",
+            sources: ["workspace", "docs"],
+          },
+          scheduleConfig: {
+            enabled: true,
+            mode: "routine",
+            cadenceMinutes: 60,
+            label: "Hourly",
+          },
+          audioSummaryConfig: {
+            enabled: true,
+            style: "executive-briefing",
+          },
+        },
+        environmentConfig: {
+          enableShell: false,
+          enableBrowser: true,
+          enableComputerUse: false,
+        },
+      } as Any,
+      [{ id: "ws-1", name: "Workspace", path: "/workspace" }] as Any,
+    );
+
+    expect(draft.templateId).toBe("team-chat-qna");
+    expect(draft.workspaceId).toBe("ws-1");
+    expect(draft.selectedSkills).toEqual(["slack-faq"]);
+    expect(draft.selectedMcpServers).toEqual(["slack", "drive"]);
+    expect(draft.selectedToolFamilies).toEqual(["communication", "search"]);
+    expect(draft.memoryConfig).toEqual({ mode: "focused", sources: ["workspace", "docs"] });
+    expect(draft.scheduleConfig.enabled).toBe(true);
+    expect(draft.audioSummaryEnabled).toBe(true);
+    expect(draft.enableBrowser).toBe(true);
+    expect(draft.workflowBrief).toBe("Answer questions from team chat.");
+    expect(draft.sharing.visibility).toBe("team");
+    expect(draft.deployment.surfaces).toEqual(["chatgpt"]);
+  });
+
+  it("rehydrates an existing managed agent draft from studio metadata and environment settings", () => {
+    const draft = buildDraftFromAgent(
+      {
+        id: "agent-1",
+        name: "Chief of Staff",
+        description: "Executive briefings and follow-through.",
+        status: "active",
+      } as Any,
+      {
+        systemPrompt: "Prepare a weekly executive brief.",
+        executionMode: "solo",
+        skills: ["calendar", "email"],
+        mcpServers: ["slack"],
+        metadata: {
+          studio: {
+            templateId: "chief-of-staff",
+            instructions: {
+              operatingNotes: "Escalate blockers quickly.",
+            },
+            skills: ["calendar", "email"],
+            apps: {
+              mcpServers: ["slack"],
+              allowedToolFamilies: ["communication", "documents"],
+            },
+            fileRefs: [{ id: "file-1", path: "/docs/brief.md", name: "brief.md" }],
+            memoryConfig: { mode: "default", sources: ["workspace"] },
+            channelTargets: [
+              {
+                id: "channel-1",
+                channelType: "slack",
+                channelId: "slack-channel",
+                channelName: "#ops",
+                enabled: true,
+              },
+            ],
+            scheduleConfig: {
+              enabled: true,
+              mode: "recurring",
+              cadenceMinutes: 120,
+            },
+            audioSummaryConfig: {
+              enabled: true,
+              style: "public-radio",
+            },
+            imageGenProfileId: "profile-1",
+            workflowBrief: "Prepare weekly executive briefs, escalate blockers, and share decisions.",
+            approvalPolicy: {
+              autoApproveReadOnly: true,
+              requireApprovalFor: ["send email"],
+            },
+            sharing: {
+              visibility: "workspace",
+              ownerLabel: "Founder Office",
+            },
+            deployment: {
+              surfaces: ["chatgpt", "slack"],
+            },
+            defaultEnvironmentId: "env-1",
+          },
+        },
+      } as Any,
+      [
+        {
+          id: "env-1",
+          config: {
+            workspaceId: "ws-1",
+            enableShell: true,
+            enableBrowser: false,
+            enableComputerUse: true,
+          },
+        },
+      ] as Any,
+      [{ id: "ws-1", name: "Workspace", path: "/workspace" }] as Any,
+      [
+        {
+          id: "routine-1",
+          name: "Morning brief",
+          enabled: true,
+          trigger: { type: "schedule", cadenceMinutes: 120 },
+        },
+      ] as Any,
+    );
+
+    expect(draft.agentId).toBe("agent-1");
+    expect(draft.status).toBe("active");
+    expect(draft.templateId).toBe("chief-of-staff");
+    expect(draft.operatingNotes).toBe("Escalate blockers quickly.");
+    expect(draft.selectedToolFamilies).toEqual(["communication", "documents"]);
+    expect(draft.fileRefs).toHaveLength(1);
+    expect(draft.channelTargets).toHaveLength(1);
+    expect(draft.audioSummaryStyle).toBe("public-radio");
+    expect(draft.imageGenProfileId).toBe("profile-1");
+    expect(draft.workflowBrief).toContain("Prepare weekly executive briefs");
+    expect(draft.approvalPolicy.requireApprovalFor).toEqual(["send email"]);
+    expect(draft.sharing.ownerLabel).toBe("Founder Office");
+    expect(draft.deployment.surfaces).toEqual(["chatgpt", "slack"]);
+    expect(draft.workspaceId).toBe("ws-1");
+    expect(draft.enableShell).toBe(true);
+    expect(draft.enableBrowser).toBe(false);
+    expect(draft.enableComputerUse).toBe(true);
+    expect(draft.routines).toHaveLength(1);
+    expect(draft.routines[0]?.trigger.type).toBe("schedule");
+  });
+
+  it("creates a sane blank draft baseline", () => {
+    const draft = makeBlankDraft([{ id: "ws-1", name: "Workspace", path: "/workspace" }] as Any);
+
+    expect(draft.name).toBe("New Agent");
+    expect(draft.workspaceId).toBe("ws-1");
+    expect(draft.selectedToolFamilies).toEqual(["communication", "search", "files"]);
+    expect(draft.scheduleConfig).toEqual({ enabled: false, mode: "manual" });
+    expect(draft.sharing.visibility).toBe("team");
+    expect(draft.approvalPolicy.autoApproveReadOnly).toBe(true);
+    expect(draft.enableBrowser).toBe(true);
+    expect(draft.enableShell).toBe(false);
+    expect(draft.routines[0]?.trigger.type).toBe("manual");
+  });
+
+  it("suggests a template and seeds a workflow-first draft from the brief", () => {
+    const templates = [
+      {
+        id: "weekly-metrics",
+        name: "Weekly Metrics Reporter",
+        description: "Pulls weekly data, generates charts, and writes a report.",
+        icon: "📈",
+        color: "#2563eb",
+        category: "operations",
+        systemPrompt: "Produce a metrics report.",
+        executionMode: "solo",
+      },
+      {
+        id: "lead-outreach",
+        name: "Lead Outreach Agent",
+        description: "Qualifies leads and drafts follow-up emails.",
+        icon: "✉️",
+        color: "#10b981",
+        category: "support",
+        systemPrompt: "Work inbound leads.",
+        executionMode: "solo",
+      },
+    ] as Any;
+
+    expect(
+      suggestTemplateFromWorkflowBrief(
+        "Pull Friday metrics, generate charts, and write the weekly narrative.",
+        templates,
+      )?.id,
+    ).toBe("weekly-metrics");
+
+    const draft = buildDraftFromWorkflowBrief(
+      "Pull Friday metrics, generate charts, and write the weekly narrative.",
+      templates,
+      [{ id: "ws-1", name: "Workspace", path: "/workspace" }] as Any,
+    );
+
+    expect(draft.templateId).toBe("weekly-metrics");
+    expect(draft.workflowBrief).toContain("Pull Friday metrics");
+    expect(draft.name).toBe("Pull Friday Metrics Generate Charts");
+    expect(draft.systemPrompt).toContain("Primary workflow");
+  });
+
+  it("describes the effective approval posture for CoWork OS and Slack", () => {
+    const preview = getEffectiveApprovalPreview(
+      {
+        autoApproveReadOnly: true,
+        requireApprovalFor: ["send email", "edit spreadsheet"],
+        escalationChannel: "#ops-approvals",
+      },
+      { surfaces: ["chatgpt", "slack"] },
+    );
+
+    expect(preview.autoApproved).toEqual(["read-only web and knowledge lookups"]);
+    expect(preview.gatedActions).toEqual(["send email", "edit spreadsheet"]);
+    expect(preview.chatgptSummary).toContain("can research and gather context");
+    expect(preview.slackSummary).toContain("sensitive follow-through still pauses for approval");
+  });
+
+  it("maps semantic approval actions to exact runtime approval classes", () => {
+    const matrix = getApprovalRuntimeMatrix({
+      autoApproveReadOnly: true,
+      requireApprovalFor: ["send email", "edit spreadsheet"],
+    });
+
+    expect(matrix).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          semanticAction: "Read-only research and documentation lookup",
+          runtimeType: "network_access",
+          behavior: "auto_approve",
+        }),
+        expect.objectContaining({
+          semanticAction: "send email",
+          runtimeType: "external_service",
+          behavior: "require_approval",
+        }),
+        expect.objectContaining({
+          semanticAction: "edit spreadsheet",
+          runtimeType: "data_export",
+          behavior: "require_approval",
+        }),
+        expect.objectContaining({
+          semanticAction: "file external ticket",
+          runtimeType: "external_service",
+          behavior: "auto_approve",
+        }),
+      ]),
+    );
+  });
+
+  it("sorts live runtime tool entries by approval severity before name", () => {
+    const sorted = sortRuntimeToolCatalogEntries([
+      {
+        name: "web_fetch",
+        description: "Fetches a URL",
+        approvalBehavior: "auto_approve",
+        approvalKind: "none",
+        sideEffectLevel: "none",
+        resultKind: "read",
+        capabilityTags: ["research"],
+        exposure: "always",
+        readOnly: true,
+      },
+      {
+        name: "send_email_action",
+        description: "Sends an email",
+        approvalBehavior: "require_approval",
+        approvalKind: "external_service",
+        approvalType: "external_service",
+        sideEffectLevel: "high",
+        resultKind: "integration",
+        capabilityTags: ["integration"],
+        exposure: "conditional",
+        readOnly: false,
+      },
+      {
+        name: "write_file",
+        description: "Writes a file",
+        approvalBehavior: "workspace_policy",
+        approvalKind: "workspace_policy",
+        sideEffectLevel: "low",
+        resultKind: "mutation",
+        capabilityTags: ["code"],
+        exposure: "always",
+        readOnly: false,
+      },
+    ] as Any);
+
+    expect(sorted.map((entry) => entry.name)).toEqual([
+      "send_email_action",
+      "write_file",
+      "web_fetch",
+    ]);
+  });
+
+  it("normalizes Slack deployment health without targets", () => {
+    const fallback = getSlackDeploymentHealth(
+      {
+        channelTargets: [
+          {
+            id: "target-1",
+            channelType: "slack",
+            channelId: "channel-1",
+            channelName: "#ops",
+            enabled: true,
+          },
+        ],
+      } as Any,
+      [{ id: "channel-1", name: "#ops", type: "slack", status: "connected" }] as Any,
+      "agent-1",
+    );
+
+    const normalized = normalizeSlackDeploymentHealth(
+      {
+        agentId: "agent-1",
+        connectedCount: 0,
+        misconfiguredCount: 0,
+        updatedAt: 123,
+      } as Any,
+      fallback,
+    );
+
+    expect(normalized.targets).toHaveLength(1);
+    expect(normalized.targets[0]?.channelName).toBe("#ops");
+  });
+});

--- a/src/renderer/components/__tests__/task-pause-banner.test.ts
+++ b/src/renderer/components/__tests__/task-pause-banner.test.ts
@@ -1,0 +1,48 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { TaskPauseBanner, TaskPauseBannerDetailsContent } from "../TaskPauseBanner";
+
+describe("TaskPauseBanner", () => {
+  it("renders explicit shell action buttons for shell permission pauses", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(TaskPauseBanner, {
+        message: "Shell access is currently disabled for this workspace.",
+        reasonCode: "shell_permission_required",
+        onEnableShell: vi.fn(),
+        onContinueWithoutShell: vi.fn(),
+      }),
+    );
+
+    expect(markup).toContain("Enable shell");
+    expect(markup).toContain("Continue without shell");
+    expect(markup).toContain("Shell access is needed to continue.");
+  });
+
+  it("keeps generic paused tasks on the normal free-text path", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(TaskPauseBanner, {
+        message: "Need your confirmation before changing the rollout scope.",
+        reasonCode: "required_decision",
+      }),
+    );
+
+    expect(markup).not.toContain("Enable shell");
+    expect(markup).not.toContain("Continue without shell");
+    expect(markup).toContain("Type anything below to continue");
+  });
+
+  it("renders markdown formatting in the details content", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(TaskPauseBannerDetailsContent, {
+        message: "Need your confirmation.\n\n## Recommended next step\n\n- Ship the fix\n- Re-test the modal",
+        markdownComponents: {},
+      }),
+    );
+
+    expect(markup).toContain("<h2>Recommended next step</h2>");
+    expect(markup).toContain("<li>Ship the fix</li>");
+    expect(markup).not.toContain("## Recommended next step");
+  });
+});

--- a/src/shared/__tests__/timeline-v2.test.ts
+++ b/src/shared/__tests__/timeline-v2.test.ts
@@ -51,6 +51,25 @@ describe("timeline v2 helpers", () => {
     expect(projected.payload.message).toBe("Task completed successfully");
   });
 
+  it("promotes legacy tool_error payload.error into timeline_error payload.message", () => {
+    const normalized = normalizeTaskEventToTimelineV2({
+      taskId: "task-tool-error",
+      type: "tool_error",
+      payload: {
+        tool: "click",
+        error: "ModuleNotFoundError: No module named 'Quartz'",
+      },
+      timestamp: 1_700_000_000_150,
+      eventId: "event-tool-error",
+      seq: 23,
+    });
+
+    expect(normalized.type).toBe("timeline_error");
+    expect(normalized.status).toBe("failed");
+    expect(normalized.legacyType).toBe("tool_error");
+    expect(normalized.payload.message).toBe("ModuleNotFoundError: No module named 'Quartz'");
+  });
+
   it("maps key legacy lifecycle events to timeline stages", () => {
     expect(inferTimelineStageForLegacyType("task_created")).toBe("DISCOVER");
     expect(inferTimelineStageForLegacyType("tool_call")).toBe("BUILD");

--- a/src/shared/timeline-v2.ts
+++ b/src/shared/timeline-v2.ts
@@ -64,6 +64,30 @@ function asObject(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+function coerceNonEmptyText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const nested = value as Record<string, unknown>;
+    if (typeof nested.message === "string" && nested.message.trim().length > 0) {
+      return nested.message.trim();
+    }
+  }
+  return undefined;
+}
+
+function resolveTimelineErrorMessage(payload: Record<string, unknown>): string | undefined {
+  return (
+    coerceNonEmptyText(payload.message) ||
+    coerceNonEmptyText(payload.error) ||
+    coerceNonEmptyText(payload.reason) ||
+    coerceNonEmptyText(payload.display) ||
+    coerceNonEmptyText(payload.failureReason)
+  );
+}
+
 function deriveStepId(
   taskId: string,
   payload: Record<string, unknown>,
@@ -512,8 +536,17 @@ export function normalizeTaskEventToTimelineV2(params: {
 
     const maybeEvidenceRefs =
       rawType === "timeline_evidence_attached" ? toEvidenceRefs(payload, params.timestamp) : [];
-    const nextPayload =
+    const nextPayloadBase =
       maybeEvidenceRefs.length > 0 ? { ...payload, evidenceRefs: maybeEvidenceRefs } : payload;
+    const nextPayload =
+      rawType === "timeline_error"
+        ? {
+            ...nextPayloadBase,
+            ...(resolveTimelineErrorMessage(nextPayloadBase)
+              ? { message: resolveTimelineErrorMessage(nextPayloadBase) }
+              : {}),
+          }
+        : nextPayloadBase;
 
     return {
       id: eventId,
@@ -552,6 +585,12 @@ export function normalizeTaskEventToTimelineV2(params: {
   };
   if (timelineType === "timeline_evidence_attached") {
     nextPayload.evidenceRefs = toEvidenceRefs(payload, params.timestamp);
+  }
+  if (timelineType === "timeline_error") {
+    const resolvedMessage = resolveTimelineErrorMessage(nextPayload);
+    if (resolvedMessage) {
+      nextPayload.message = resolvedMessage;
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- Adds managed agents, managed session routines, runtime tool catalog, audit/insights/workpaper support, and conversion paths.
- Adds the routines service and IPC route helpers.
- Adds Agents Hub, Routine Settings, usage overview UI, and related tests.

## Validation
- npm run type-check
- npx vitest run src/electron/routines/__tests__/service.test.ts src/electron/managed/__tests__/ManagedSessionService.test.ts src/renderer/components/__tests__/AgentsHubPanel.test.ts src/renderer/components/__tests__/task-pause-banner.test.ts src/electron/database/__tests__/TaskRepository.findAll.test.ts src/shared/__tests__/timeline-v2.test.ts

## Test note
The targeted Vitest command completed with 21 passed tests and 17 skipped tests. The skipped suites are currently skipped by their definitions: routines service and managed session service.

## Notes
This is the next stack layer after merged PR #79.