### PR TITLE
feat(images): add OpenAI OAuth image provider path

### DIFF
--- a/src/electron/agent/llm/__tests__/azure-openai-provider.test.ts
+++ b/src/electron/agent/llm/__tests__/azure-openai-provider.test.ts
@@ -300,6 +300,36 @@ describe("AzureOpenAIProvider", () => {
     expect(body.stream).toBe(true);
   });
 
+  it("parses streamed chat-completions tool calls into tool_use blocks", async () => {
+    mockFetch.mockResolvedValue(
+      createStreamingResponse([
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"screenshot","arguments":"{\\"app\\":\\"Cal"}}]}}]}\n\n',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"type":"function","function":{"arguments":"culator\\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+        "data: [DONE]\n\n",
+      ]),
+    );
+
+    const provider = new AzureOpenAIProvider(baseConfig);
+    const response = await provider.createMessage({
+      model: "gpt-4o",
+      maxTokens: 20,
+      system: "system prompt",
+      messages: [{ role: "user", content: "hi" }],
+      onStreamProgress: vi.fn(),
+    });
+
+    expect(response.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call_1",
+        name: "screenshot",
+        input: { app: "Calculator" },
+      },
+    ]);
+    expect(response.stopReason).toBe("tool_use");
+    expect(response.usage).toEqual({ inputTokens: 4, outputTokens: 2 });
+  });
+
   it("falls back to Responses API when chat completions are unsupported", async () => {
     mockFetch
       .mockResolvedValueOnce(
@@ -545,6 +575,53 @@ describe("AzureOpenAIProvider", () => {
     expect(JSON.parse(secondOptions.body).stream).toBe(true);
     const [, thirdOptions] = mockFetch.mock.calls[2];
     expect(JSON.parse(thirdOptions.body).stream).toBe(true);
+  });
+
+  it("parses streamed Responses API tool calls into tool_use blocks", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        createErrorResponse(400, "Bad Request", {
+          error: {
+            message: "The chatCompletion operation does not work with the specified model.",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        createErrorResponse(400, "Bad Request", {
+          error: {
+            message: "The chatCompletion operation does not work with the specified model.",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        createStreamingResponse([
+          'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_1","name":"screenshot","arguments":""}}\n\n',
+          'data: {"type":"response.function_call_arguments.delta","item_id":"call_1","delta":"{\\"app\\":\\"Cal"}\n\n',
+          'data: {"type":"response.function_call_arguments.done","item_id":"call_1","arguments":"{\\"app\\":\\"Calculator\\"}"}\n\n',
+          'data: {"type":"response.completed","response":{"output":[{"type":"function_call","call_id":"call_1","name":"screenshot","arguments":"{\\"app\\":\\"Calculator\\"}"}],"usage":{"input_tokens":6,"output_tokens":2}}}\n\n',
+          "data: [DONE]\n\n",
+        ]),
+      );
+
+    const provider = new AzureOpenAIProvider(baseConfig);
+    const response = await provider.createMessage({
+      model: "gpt-5.2-codex",
+      maxTokens: 20,
+      system: "system prompt",
+      messages: [{ role: "user", content: "hi" }],
+      onStreamProgress: vi.fn(),
+    });
+
+    expect(response.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call_1",
+        name: "screenshot",
+        input: { app: "Calculator" },
+      },
+    ]);
+    expect(response.stopReason).toBe("tool_use");
+    expect(response.usage).toEqual({ inputTokens: 6, outputTokens: 2 });
   });
 
   it("throws a descriptive error on API failures", async () => {

--- a/src/electron/agent/llm/azure-openai-provider.ts
+++ b/src/electron/agent/llm/azure-openai-provider.ts
@@ -447,6 +447,10 @@ export class AzureOpenAIProvider implements LLMProvider {
     request: LLMRequest,
     startedAt: number,
   ): Promise<LLMResponse> {
+    const streamedToolCalls = new Map<
+      number,
+      { id?: string; name?: string; argumentsText: string }
+    >();
     let contentText = "";
     let inputTokens = 0;
     let outputTokens = 0;
@@ -476,15 +480,50 @@ export class AzureOpenAIProvider implements LLMProvider {
       const deltaText = choice?.delta?.content;
       if (typeof deltaText === "string" && deltaText.length > 0) {
         contentText += deltaText;
-          this.emitStreamProgress(
-            request.onStreamProgress,
-            startedAt,
-            inputTokens,
-            outputTokens,
-            contentText.length,
-            true,
-            contentText,
-          );
+        this.emitStreamProgress(
+          request.onStreamProgress,
+          startedAt,
+          inputTokens,
+          outputTokens,
+          contentText.length,
+          true,
+          contentText,
+        );
+      }
+
+      const deltaToolCalls = Array.isArray(choice?.delta?.tool_calls) ? choice.delta.tool_calls : [];
+      for (const toolCall of deltaToolCalls) {
+        const index =
+          typeof toolCall?.index === "number" && Number.isFinite(toolCall.index)
+            ? toolCall.index
+            : streamedToolCalls.size;
+        const existing = streamedToolCalls.get(index) ?? { argumentsText: "" };
+        if (typeof toolCall?.id === "string" && toolCall.id.trim()) {
+          existing.id = toolCall.id;
+        }
+        if (typeof toolCall?.function?.name === "string" && toolCall.function.name.trim()) {
+          existing.name = toolCall.function.name;
+        }
+        if (typeof toolCall?.function?.arguments === "string" && toolCall.function.arguments) {
+          existing.argumentsText += toolCall.function.arguments;
+        }
+        streamedToolCalls.set(index, existing);
+      }
+
+      const messageToolCalls = Array.isArray(choice?.message?.tool_calls) ? choice.message.tool_calls : [];
+      for (const toolCall of messageToolCalls) {
+        const index = streamedToolCalls.size;
+        const existing = streamedToolCalls.get(index) ?? { argumentsText: "" };
+        if (typeof toolCall?.id === "string" && toolCall.id.trim()) {
+          existing.id = toolCall.id;
+        }
+        if (typeof toolCall?.function?.name === "string" && toolCall.function.name.trim()) {
+          existing.name = toolCall.function.name;
+        }
+        if (typeof toolCall?.function?.arguments === "string") {
+          existing.argumentsText = toolCall.function.arguments;
+        }
+        streamedToolCalls.set(index, existing);
       }
 
       switch (choice?.finish_reason) {
@@ -515,8 +554,27 @@ export class AzureOpenAIProvider implements LLMProvider {
       contentText,
     );
 
+    const content: LLMContent[] = [];
+    if (contentText.length > 0) {
+      content.push({ type: "text", text: contentText });
+    }
+    for (const [index, toolCall] of [...streamedToolCalls.entries()].sort((a, b) => a[0] - b[0])) {
+      if (!toolCall.name) {
+        continue;
+      }
+      content.push({
+        type: "tool_use",
+        id: toolCall.id || `call_${index}`,
+        name: toolCall.name,
+        input: this.parseFunctionCallArguments(toolCall.argumentsText),
+      });
+    }
+    if (content.length === 0) {
+      content.push({ type: "text", text: "" });
+    }
+
     return {
-      content: [{ type: "text", text: contentText }],
+      content,
       stopReason: finishReason,
       usage: inputTokens || outputTokens || cachedTokens || cacheWriteTokens
         ? {
@@ -534,6 +592,12 @@ export class AzureOpenAIProvider implements LLMProvider {
     request: LLMRequest,
     startedAt: number,
   ): Promise<LLMResponse> {
+    const streamedToolCalls = new Map<
+      string,
+      { order: number; id: string; name?: string; argumentsText: string }
+    >();
+    let nextToolOrder = 0;
+    let completedResponse: Any | undefined;
     let contentText = "";
     let inputTokens = 0;
     let outputTokens = 0;
@@ -579,7 +643,62 @@ export class AzureOpenAIProvider implements LLMProvider {
             contentText = payload.text;
           }
           break;
+        case "response.output_item.added":
+        case "response.output_item.done": {
+          const item = payload.item;
+          if (item?.type === "function_call") {
+            const key =
+              String(item.call_id || item.id || payload.output_index || payload.item_index || "")
+                .trim() || `call_${nextToolOrder}`;
+            const existing = streamedToolCalls.get(key) ?? {
+              order: nextToolOrder++,
+              id: String(item.call_id || item.id || key),
+              argumentsText: "",
+            };
+            if (typeof item.name === "string" && item.name.trim()) {
+              existing.name = item.name;
+            }
+            if (typeof item.arguments === "string") {
+              existing.argumentsText = item.arguments;
+            }
+            streamedToolCalls.set(key, existing);
+          }
+          break;
+        }
+        case "response.function_call_arguments.delta": {
+          const key =
+            String(
+              payload.call_id || payload.item_id || payload.output_index || payload.item_index || "",
+            ).trim() || `call_${nextToolOrder}`;
+          const existing = streamedToolCalls.get(key) ?? {
+            order: nextToolOrder++,
+            id: String(payload.call_id || payload.item_id || key),
+            argumentsText: "",
+          };
+          if (typeof payload.delta === "string" && payload.delta) {
+            existing.argumentsText += payload.delta;
+          }
+          streamedToolCalls.set(key, existing);
+          break;
+        }
+        case "response.function_call_arguments.done": {
+          const key =
+            String(
+              payload.call_id || payload.item_id || payload.output_index || payload.item_index || "",
+            ).trim() || `call_${nextToolOrder}`;
+          const existing = streamedToolCalls.get(key) ?? {
+            order: nextToolOrder++,
+            id: String(payload.call_id || payload.item_id || key),
+            argumentsText: "",
+          };
+          if (typeof payload.arguments === "string") {
+            existing.argumentsText = payload.arguments;
+          }
+          streamedToolCalls.set(key, existing);
+          break;
+        }
         case "response.completed":
+          completedResponse = payload.response;
           if (payload.response?.usage) {
             inputTokens = payload.response.usage.input_tokens ?? inputTokens;
             outputTokens = payload.response.usage.output_tokens ?? outputTokens;
@@ -591,9 +710,23 @@ export class AzureOpenAIProvider implements LLMProvider {
             contentText = payload.response.output_text;
           }
           if (Array.isArray(payload.response?.output)) {
-            for (const item of payload.response.output) {
+            for (const [index, item] of payload.response.output.entries()) {
               if (item?.type === "function_call") {
                 finishReason = "tool_use";
+                const key =
+                  String(item.call_id || item.id || index).trim() || `call_${nextToolOrder}`;
+                const existing = streamedToolCalls.get(key) ?? {
+                  order: nextToolOrder++,
+                  id: String(item.call_id || item.id || key),
+                  argumentsText: "",
+                };
+                if (typeof item.name === "string" && item.name.trim()) {
+                  existing.name = item.name;
+                }
+                if (typeof item.arguments === "string") {
+                  existing.argumentsText = item.arguments;
+                }
+                streamedToolCalls.set(key, existing);
               }
             }
           }
@@ -613,8 +746,50 @@ export class AzureOpenAIProvider implements LLMProvider {
       contentText,
     );
 
+    if (completedResponse) {
+      const parsed = this.fromResponsesApiResponse(completedResponse);
+      const shouldFallbackToStreamedText =
+        contentText.length > 0 &&
+        parsed.content.length === 1 &&
+        parsed.content[0]?.type === "text" &&
+        parsed.content[0].text === "";
+      return {
+        ...parsed,
+        content: shouldFallbackToStreamedText ? [{ type: "text", text: contentText }] : parsed.content,
+        usage:
+          parsed.usage ||
+          (inputTokens || outputTokens || cachedTokens || cacheWriteTokens
+            ? {
+                inputTokens,
+                outputTokens,
+                ...(cachedTokens ? { cachedTokens } : {}),
+                ...(cacheWriteTokens ? { cacheWriteTokens } : {}),
+              }
+            : undefined),
+      };
+    }
+
+    const content: LLMContent[] = [];
+    if (contentText.length > 0) {
+      content.push({ type: "text", text: contentText });
+    }
+    for (const toolCall of [...streamedToolCalls.values()].sort((a, b) => a.order - b.order)) {
+      if (!toolCall.name) {
+        continue;
+      }
+      content.push({
+        type: "tool_use",
+        id: toolCall.id,
+        name: toolCall.name,
+        input: this.parseFunctionCallArguments(toolCall.argumentsText),
+      });
+    }
+    if (content.length === 0) {
+      content.push({ type: "text", text: "" });
+    }
+
     return {
-      content: [{ type: "text", text: contentText }],
+      content,
       stopReason: finishReason,
       usage: inputTokens || outputTokens || cachedTokens || cacheWriteTokens
         ? {

--- a/src/electron/agent/llm/provider-factory.ts
+++ b/src/electron/agent/llm/provider-factory.ts
@@ -831,7 +831,9 @@ export interface LLMSettings {
   customProviders?: Record<string, CustomProviderConfig>;
   /** Text-to-image model selection. Default tried first; backup used on failure. */
   imageGeneration?: {
+    defaultProvider?: "openai" | "openai-codex" | "azure" | "openrouter" | "gemini";
     defaultModel?: "gpt-image-1.5" | "nano-banana-2";
+    backupProvider?: "openai" | "openai-codex" | "azure" | "openrouter" | "gemini";
     backupModel?: "gpt-image-1.5" | "nano-banana-2";
   };
   /** Text-to-video generation settings. Provider-specific config + routing. */

--- a/src/electron/agent/llm/types.ts
+++ b/src/electron/agent/llm/types.ts
@@ -135,6 +135,7 @@ export interface LLMImageContent {
 }
 
 export type LLMContent = LLMToolUse | LLMTextContent | LLMImageContent;
+export type LLMToolResultCompanionContent = LLMTextContent | LLMImageContent;
 
 /** Per-provider image capability limits */
 export interface LLMProviderImageCaps {
@@ -204,6 +205,7 @@ export interface LLMToolResult {
   tool_use_id: string;
   content: string;
   is_error?: boolean;
+  companion_user_content?: LLMToolResultCompanionContent[];
 }
 
 export interface LLMMessage {
@@ -255,6 +257,7 @@ export interface StreamProgress {
   elapsedMs: number;
   /** `true` while still streaming; `false` on the final event. */
   streaming: boolean;
+  text?: string;
 }
 
 export type StreamProgressCallback = (progress: StreamProgress) => void;

--- a/src/electron/agent/skills/__tests__/image-generator-oauth.test.ts
+++ b/src/electron/agent/skills/__tests__/image-generator-oauth.test.ts
@@ -1,0 +1,222 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadSettingsMock = vi.fn();
+const saveSettingsMock = vi.fn();
+const clearCacheMock = vi.fn();
+const getApiKeyFromTokensMock = vi.fn();
+const loadPiAiModuleMock = vi.fn();
+
+let openAIConfigs: Any[] = [];
+let responseStreamParams: Any[] = [];
+let streamFactory: () => Any;
+
+vi.mock("../../llm/provider-factory", () => ({
+  LLMProviderFactory: {
+    loadSettings: (...args: Any[]) => loadSettingsMock(...args),
+    saveSettings: (...args: Any[]) => saveSettingsMock(...args),
+    clearCache: (...args: Any[]) => clearCacheMock(...args),
+  },
+}));
+
+vi.mock("../../llm/openai-oauth", () => ({
+  OpenAIOAuth: {
+    getApiKeyFromTokens: (...args: Any[]) => getApiKeyFromTokensMock(...args),
+  },
+}));
+
+vi.mock("../../llm/pi-ai-loader", () => ({
+  loadPiAiModule: (...args: Any[]) => loadPiAiModuleMock(...args),
+}));
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    responses = {
+      stream: (params: Any) => {
+        responseStreamParams.push(params);
+        return streamFactory();
+      },
+    };
+
+    constructor(config: Any) {
+      openAIConfigs.push(config);
+    }
+  },
+}));
+
+import { ImageGenerator } from "../image-generator";
+
+function createAccessToken(accountId: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+    }),
+  ).toString("base64url");
+  return `${header}.${payload}.signature`;
+}
+
+describe("ImageGenerator OpenAI OAuth", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openAIConfigs = [];
+    responseStreamParams = [];
+    streamFactory = () => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "response.output_item.done",
+          item: {
+            type: "image_generation_call",
+            result: Buffer.from("oauth-image").toString("base64"),
+          },
+        };
+      },
+      finalResponse: vi.fn().mockResolvedValue({ output: [] }),
+    });
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "cowork-image-oauth-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("treats OpenAI OAuth as an available image provider", () => {
+    loadSettingsMock.mockReturnValue({
+      openai: {
+        accessToken: "oauth-access-token",
+        refreshToken: "oauth-refresh-token",
+        authMethod: "oauth",
+      },
+    } as Any);
+
+    expect(ImageGenerator.isAvailable()).toBe(true);
+  });
+
+  it("generates images through the Codex/ChatGPT Responses backend", async () => {
+    const refreshedAccessToken = createAccessToken("acct_test_oauth");
+    loadSettingsMock.mockReturnValue({
+      providerType: "openai",
+      openai: {
+        accessToken: "stale-access-token",
+        refreshToken: "oauth-refresh-token",
+        tokenExpiresAt: 0,
+        authMethod: "oauth",
+      },
+    } as Any);
+    getApiKeyFromTokensMock.mockResolvedValue({
+      apiKey: refreshedAccessToken,
+      newTokens: {
+        access_token: refreshedAccessToken,
+        refresh_token: "oauth-refresh-token-2",
+        expires_at: 123456789,
+      },
+    });
+    loadPiAiModuleMock.mockResolvedValue({
+      getModels: () => [{ id: "gpt-5.2" }],
+    });
+
+    const generator = new ImageGenerator({ path: tempDir } as Any);
+    const result = await generator.generate({
+      prompt: "draw a poster of a lighthouse in fog",
+      provider: "openai-codex",
+      model: "gpt-image-1.5",
+      filename: "poster",
+      imageSize: "1K",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.provider).toBe("openai-codex");
+    expect(result.model).toBe("gpt-image-1.5");
+    expect(result.images).toHaveLength(1);
+    expect(fs.readFileSync(path.join(tempDir, "poster.png")).toString()).toBe("oauth-image");
+
+    expect(openAIConfigs[0]).toMatchObject({
+      apiKey: refreshedAccessToken,
+      baseURL: "https://chatgpt.com/backend-api/codex",
+      defaultHeaders: expect.objectContaining({
+        "chatgpt-account-id": "acct_test_oauth",
+        "OpenAI-Beta": "responses=experimental",
+        originator: "cowork-os",
+      }),
+    });
+
+    expect(responseStreamParams[0]).toMatchObject({
+      model: "gpt-5.2",
+      instructions:
+        "You are an assistant that must fulfill image generation requests by using the image_generation tool when provided.",
+      tools: [
+        expect.objectContaining({
+          type: "image_generation",
+          model: "gpt-image-1.5",
+          action: "generate",
+          output_format: "png",
+        }),
+      ],
+    });
+    expect(responseStreamParams[0].tools[0]).not.toHaveProperty("quality");
+
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        openai: expect.objectContaining({
+          accessToken: refreshedAccessToken,
+          refreshToken: "oauth-refresh-token-2",
+          tokenExpiresAt: 123456789,
+          authMethod: "oauth",
+        }),
+      }),
+    );
+    expect(clearCacheMock).toHaveBeenCalled();
+  });
+
+  it("removes already-written OAuth images when a later image fails", async () => {
+    const accessToken = createAccessToken("acct_test_oauth");
+    let calls = 0;
+    streamFactory = () => {
+      calls += 1;
+      const call = calls;
+      return {
+        async *[Symbol.asyncIterator]() {
+          if (call === 1) {
+            yield {
+              type: "response.output_item.done",
+              item: {
+                type: "image_generation_call",
+                result: Buffer.from("first-image").toString("base64"),
+              },
+            };
+          }
+        },
+        finalResponse: vi.fn().mockResolvedValue({ output: [] }),
+      };
+    };
+    loadSettingsMock.mockReturnValue({
+      providerType: "openai",
+      openai: {
+        accessToken,
+        tokenExpiresAt: Date.now() + 60_000,
+        authMethod: "oauth",
+      },
+    } as Any);
+    loadPiAiModuleMock.mockResolvedValue({
+      getModels: () => [{ id: "gpt-5.2" }],
+    });
+
+    const generator = new ImageGenerator({ path: tempDir } as Any);
+    const result = await generator.generate({
+      prompt: "draw two posters",
+      provider: "openai-codex",
+      model: "gpt-image-1.5",
+      filename: "poster",
+      imageSize: "1K",
+      numberOfImages: 2,
+    });
+
+    expect(result.success).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, "poster_1.png"))).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, "poster_2.png"))).toBe(false);
+  });
+});

--- a/src/electron/agent/skills/__tests__/image-generator-selection.test.ts
+++ b/src/electron/agent/skills/__tests__/image-generator-selection.test.ts
@@ -63,4 +63,47 @@ describe("selectImageProviderOrder", () => {
 
     expect(order[0]?.provider).toBe("azure");
   });
+
+  it("includes openai-codex when OpenAI OAuth is configured", () => {
+    const order = selectImageProviderOrder({
+      settings: {
+        providerType: "openai",
+        modelKey: "x",
+        openai: {
+          accessToken: "oauth-access-token",
+          refreshToken: "oauth-refresh-token",
+          authMethod: "oauth",
+        },
+        openrouter: { apiKey: "or" },
+      } as Any,
+      prompt: "make a poster",
+      providerOverride: "auto",
+    });
+
+    expect(order[0]?.provider).toBe("openai-codex");
+    expect(order.map((entry) => entry.provider)).toContain("openrouter");
+  });
+
+  it("honors an explicit OpenAI OAuth image provider when API key auth is also configured", () => {
+    const order = selectImageProviderOrder({
+      settings: {
+        providerType: "openai",
+        modelKey: "x",
+        openai: {
+          apiKey: "openai-api-key",
+          accessToken: "oauth-access-token",
+          refreshToken: "oauth-refresh-token",
+          authMethod: "oauth",
+        },
+        imageGeneration: {
+          defaultProvider: "openai-codex",
+          defaultModel: "gpt-image-1.5",
+        },
+      } as Any,
+      prompt: "make a poster",
+      providerOverride: "auto",
+    });
+
+    expect(order[0]).toEqual({ provider: "openai-codex", modelPreset: "gpt-image-1.5" });
+  });
 });

--- a/src/electron/agent/skills/image-generator.ts
+++ b/src/electron/agent/skills/image-generator.ts
@@ -1,14 +1,17 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as mimetypes from "mime-types";
+import OpenAI from "openai";
 import { Workspace } from "../../../shared/types";
 import { getOpenRouterAttributionHeaders } from "../llm/openrouter-attribution";
+import { OpenAIOAuth, OpenAIOAuthTokens } from "../llm/openai-oauth";
+import { loadPiAiModule } from "../llm/pi-ai-loader";
 import { LLMProviderFactory } from "../llm/provider-factory";
 
 /**
  * Image generation provider types
  */
-export type ImageProvider = "gemini" | "openai" | "azure" | "openrouter";
+export type ImageProvider = "gemini" | "openai" | "openai-codex" | "azure" | "openrouter";
 
 /**
  * Image generation model types
@@ -30,6 +33,7 @@ export type ImageModel =
  * Image size options
  */
 export type ImageSize = "1K" | "2K";
+type OpenAIImageSize = "auto" | "1024x1024" | "1024x1536" | "1536x1024";
 
 /**
  * Image generation request
@@ -83,6 +87,19 @@ const GEMINI_MODEL_MAP: Record<
   "nano-banana-2": "gemini-3.1-flash-image-preview",
 };
 
+const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex";
+const OPENAI_CODEX_IMAGE_INSTRUCTIONS =
+  "You are an assistant that must fulfill image generation requests by using the image_generation tool when provided.";
+const OPENAI_CODEX_PREFERRED_HOST_MODELS = [
+  "gpt-5.4",
+  "gpt-5.3",
+  "gpt-5.2",
+  "gpt-5.1",
+  "gpt-5.1-codex-max",
+  "gpt-5.1-codex-mini",
+] as const;
+const OPENAI_CODEX_RESPONSES_IMAGE_MODELS = new Set(["gpt-image-1", "gpt-image-1.5"]);
+
 function buildSetupHint(provider: ImageProvider): { type: string; label: string; target: string } {
   if (provider === "gemini")
     return { type: "open_settings", label: "Set up Gemini API key", target: "gemini" };
@@ -90,6 +107,9 @@ function buildSetupHint(provider: ImageProvider): { type: string; label: string;
     return { type: "open_settings", label: "Set up Azure OpenAI", target: "azure" };
   if (provider === "openrouter")
     return { type: "open_settings", label: "Set up OpenRouter API key", target: "openrouter" };
+  if (provider === "openai-codex") {
+    return { type: "open_settings", label: "Sign in to OpenAI OAuth", target: "openai" };
+  }
   return { type: "open_settings", label: "Set up OpenAI API key", target: "openai" };
 }
 
@@ -221,10 +241,21 @@ export function inferImageProviderFromText(text: string): ImageProvider | null {
   const t = (text || "").toLowerCase();
   if (!t.trim()) return null;
   if (t.includes("azure openai") || /\bazure\b/.test(t)) return "azure";
+  if (t.includes("codex auth") || t.includes("openai oauth") || t.includes("chatgpt oauth"))
+    return "openai-codex";
   if (t.includes("openrouter")) return "openrouter";
   if (t.includes("gemini")) return "gemini";
   if (t.includes("openai")) return "openai";
   return null;
+}
+
+function hasOpenAIOAuthTokens(
+  settings: ReturnType<typeof LLMProviderFactory.loadSettings>,
+): boolean {
+  return Boolean(
+    settings.openai?.accessToken?.trim() &&
+      (settings.openai?.authMethod === "oauth" || settings.openai?.refreshToken?.trim()),
+  );
 }
 
 function getConfiguredImageProviders(
@@ -242,6 +273,8 @@ function getConfiguredImageProviders(
   const openaiKey = settings.openai?.apiKey?.trim();
   if (openaiKey) providers.push("openai");
 
+  if (hasOpenAIOAuthTokens(settings)) providers.push("openai-codex");
+
   const openrouterKey = settings.openrouter?.apiKey?.trim();
   if (openrouterKey) providers.push("openrouter");
 
@@ -255,37 +288,68 @@ function sortProvidersByDefaultPreference(providers: ImageProvider[]): ImageProv
   const priority: Record<ImageProvider, number> = {
     azure: 0,
     openai: 1,
-    openrouter: 2,
-    gemini: 3,
+    "openai-codex": 2,
+    openrouter: 3,
+    gemini: 4,
   };
   return [...providers].sort((a, b) => (priority[a] ?? 99) - (priority[b] ?? 99));
 }
 
 type ImageModelPreset = "gpt-image-1.5" | "nano-banana-2";
 
+function getCompatibleImageModelPreset(
+  provider: ImageProvider,
+  preset?: ImageModelPreset,
+): ImageModelPreset | undefined {
+  if (!preset) return undefined;
+  if (preset === "nano-banana-2") return provider === "gemini" ? preset : undefined;
+  if (preset === "gpt-image-1.5") return provider === "gemini" ? undefined : preset;
+  return undefined;
+}
+
+function pushConfiguredImageRoute(
+  order: Array<{ provider: ImageProvider; modelPreset?: ImageModelPreset }>,
+  configured: ImageProvider[],
+  provider: ImageProvider | undefined,
+  modelPreset?: ImageModelPreset,
+): void {
+  if (!provider || !configured.includes(provider)) return;
+  if (order.some((entry) => entry.provider === provider)) return;
+  order.push({
+    provider,
+    modelPreset: getCompatibleImageModelPreset(provider, modelPreset),
+  });
+}
+
 /** Build provider order from settings.imageGeneration (default + backup). */
 function buildProviderOrderFromImageSettings(
   settings: ReturnType<typeof LLMProviderFactory.loadSettings>,
 ): Array<{ provider: ImageProvider; modelPreset?: ImageModelPreset }> {
   const img = settings.imageGeneration;
+  const defaultProvider = img?.defaultProvider;
   const defaultPreset = img?.defaultModel;
+  const backupProvider = img?.backupProvider;
   const backupPreset = img?.backupModel;
   const configured = getConfiguredImageProviders(settings);
 
   const order: Array<{ provider: ImageProvider; modelPreset?: ImageModelPreset }> = [];
 
-  if (defaultPreset === "gpt-image-1.5") {
-    for (const p of ["azure", "openai", "openrouter"] as ImageProvider[]) {
+  pushConfiguredImageRoute(order, configured, defaultProvider, defaultPreset);
+
+  if (!defaultProvider && defaultPreset === "gpt-image-1.5") {
+    for (const p of ["azure", "openai", "openai-codex", "openrouter"] as ImageProvider[]) {
       if (configured.includes(p)) order.push({ provider: p, modelPreset: "gpt-image-1.5" });
     }
   }
-  if (defaultPreset === "nano-banana-2" && configured.includes("gemini")) {
+  if (!defaultProvider && defaultPreset === "nano-banana-2" && configured.includes("gemini")) {
     order.push({ provider: "gemini", modelPreset: "nano-banana-2" });
   }
 
-  if (backupPreset && backupPreset !== defaultPreset) {
+  pushConfiguredImageRoute(order, configured, backupProvider, backupPreset);
+
+  if (!backupProvider && backupPreset && backupPreset !== defaultPreset) {
     if (backupPreset === "gpt-image-1.5") {
-      for (const p of ["azure", "openai", "openrouter"] as ImageProvider[]) {
+      for (const p of ["azure", "openai", "openai-codex", "openrouter"] as ImageProvider[]) {
         if (configured.includes(p) && !order.some((o) => o.provider === p))
           order.push({ provider: p, modelPreset: "gpt-image-1.5" });
       }
@@ -328,6 +392,8 @@ export function selectImageProviderOrder(args: {
         ? "azure"
         : configured.includes("openai")
           ? "openai"
+          : configured.includes("openai-codex")
+            ? "openai-codex"
           : configured.includes("openrouter")
             ? "openrouter"
             : null
@@ -339,12 +405,97 @@ export function selectImageProviderOrder(args: {
     for (const p of configured) {
       if (!legacyOrder.includes(p)) legacyOrder.push(p);
     }
-    for (const p of ["gemini", "openai", "azure", "openrouter"] as ImageProvider[]) {
+    for (const p of [
+      "gemini",
+      "openai",
+      "openai-codex",
+      "azure",
+      "openrouter",
+    ] as ImageProvider[]) {
       if (!legacyOrder.includes(p)) legacyOrder.push(p);
     }
   }
   const deduped = legacyOrder.filter((p, idx) => legacyOrder.indexOf(p) === idx);
   return deduped.map((provider) => ({ provider }));
+}
+
+function extractChatGPTAccountId(token: string): string {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) throw new Error("invalid_token");
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    const accountId = payload?.["https://api.openai.com/auth"]?.chatgpt_account_id;
+    if (typeof accountId !== "string" || !accountId.trim()) throw new Error("missing_account_id");
+    return accountId.trim();
+  } catch {
+    throw new Error("Failed to extract ChatGPT account ID from OpenAI OAuth token");
+  }
+}
+
+function persistUpdatedOpenAITokens(tokens: OpenAIOAuthTokens): void {
+  const settings = LLMProviderFactory.loadSettings();
+  settings.openai = {
+    ...settings.openai,
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    tokenExpiresAt: tokens.expires_at,
+    authMethod: "oauth",
+  };
+  LLMProviderFactory.saveSettings(settings);
+  LLMProviderFactory.clearCache();
+}
+
+async function resolveOpenAICodexAccessToken(
+  settings: ReturnType<typeof LLMProviderFactory.loadSettings>,
+): Promise<string> {
+  const accessToken = settings.openai?.accessToken?.trim();
+  const refreshToken = settings.openai?.refreshToken?.trim();
+  const tokenExpiresAt = settings.openai?.tokenExpiresAt;
+
+  if (!accessToken) {
+    throw new Error("OpenAI OAuth is not configured");
+  }
+
+  if (refreshToken) {
+    const { apiKey, newTokens } = await OpenAIOAuth.getApiKeyFromTokens({
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      expires_at:
+        typeof tokenExpiresAt === "number" && Number.isFinite(tokenExpiresAt) ? tokenExpiresAt : 0,
+    });
+    if (
+      newTokens &&
+      (newTokens.access_token !== accessToken ||
+        newTokens.refresh_token !== refreshToken ||
+        newTokens.expires_at !== tokenExpiresAt)
+    ) {
+      persistUpdatedOpenAITokens(newTokens);
+    }
+    return apiKey;
+  }
+
+  if (
+    typeof tokenExpiresAt === "number" &&
+    Number.isFinite(tokenExpiresAt) &&
+    Date.now() > tokenExpiresAt - 5 * 60 * 1000
+  ) {
+    throw new Error("OpenAI OAuth token has expired. Sign in again in Settings.");
+  }
+
+  return accessToken;
+}
+
+async function resolveOpenAICodexHostModel(): Promise<string> {
+  try {
+    const { getModels } = await loadPiAiModule();
+    const availableModelIds = new Set(getModels("openai-codex").map((model) => model.id));
+    for (const candidate of OPENAI_CODEX_PREFERRED_HOST_MODELS) {
+      if (availableModelIds.has(candidate)) return candidate;
+    }
+    return [...availableModelIds][0] || "gpt-5.1";
+  } catch {
+    return "gpt-5.1";
+  }
 }
 
 /**
@@ -401,7 +552,7 @@ export class ImageGenerator {
         images: [],
         model: normalizeOpenAIImageModel(modelOverride) || "gpt-image-1.5",
         error:
-          "No image generation provider configured. Configure Gemini/OpenAI/Azure/OpenRouter in Settings.",
+          "No image generation provider configured. Configure Gemini/OpenAI/Azure/OpenRouter/OpenAI OAuth in Settings.",
         actionHint: buildSetupHint("openai"),
       };
     }
@@ -438,10 +589,7 @@ export class ImageGenerator {
           const apiKey = settings.openai?.apiKey?.trim();
           if (!apiKey) {
             if (configuredProviders.includes("openai")) {
-              considerError(
-                "openai",
-                "OpenAI API key not configured (OpenAI OAuth sign-in does not support image generation here yet).",
-              );
+              considerError("openai", "OpenAI API key not configured.");
             }
             continue;
           }
@@ -453,6 +601,38 @@ export class ImageGenerator {
           return await this.generateWithOpenAI({
             apiKey,
             model: chosenModel,
+            prompt,
+            filename,
+            imageSize,
+            numberOfImages,
+          });
+        }
+
+        if (provider === "openai-codex") {
+          if (!hasOpenAIOAuthTokens(settings)) {
+            if (configuredProviders.includes("openai-codex")) {
+              considerError("openai-codex", "OpenAI OAuth is not connected.");
+            }
+            continue;
+          }
+          const chosenModel =
+            resolveOpenAIModelOverride(modelOverride) ||
+            (modelPreset === "gpt-image-1.5" ? "gpt-image-1.5" : null) ||
+            inferOpenAIImageModelFromText(prompt) ||
+            "gpt-image-1.5";
+          const normalizedChosenModel = normalizeOpenAIImageModel(chosenModel) || chosenModel;
+          if (!OPENAI_CODEX_RESPONSES_IMAGE_MODELS.has(normalizedChosenModel.toLowerCase())) {
+            considerError(
+              "openai-codex",
+              "OpenAI OAuth image generation supports GPT Image models in the Responses tool path (for example gpt-image-1.5).",
+              normalizedChosenModel,
+            );
+            continue;
+          }
+          const accessToken = await resolveOpenAICodexAccessToken(settings);
+          return await this.generateWithOpenAICodex({
+            accessToken,
+            model: normalizedChosenModel,
             prompt,
             filename,
             imageSize,
@@ -589,13 +769,13 @@ export class ImageGenerator {
       {
         id: "gpt-image-1.5",
         name: "OpenAI GPT Image 1.5",
-        description: "OpenAI Images API model (newer)",
+        description: "OpenAI GPT Image model (API key, Azure/OpenRouter, or OpenAI OAuth)",
         modelId: "gpt-image-1.5",
       },
     ];
   }
 
-  private mapOpenAIImageSize(size: ImageSize): string {
+  private mapOpenAIImageSize(size: ImageSize): OpenAIImageSize {
     // OpenAI image models support "auto" and a fixed set of sizes depending on model.
     // Use conservative defaults; "2K" maps to auto (larger output when supported).
     if (size === "2K") return "auto";
@@ -832,6 +1012,132 @@ export class ImageGenerator {
         model: args.model,
         error: error?.message || "Failed to generate image",
         actionHint: buildSetupHint("openai"),
+      };
+    }
+  }
+
+  private async generateWithOpenAICodex(args: {
+    accessToken: string;
+    model: string;
+    prompt: string;
+    filename?: string;
+    imageSize: ImageSize;
+    numberOfImages: number;
+  }): Promise<ImageGenerationResult> {
+    const baseFilename = args.filename || `generated_${Date.now()}`;
+    const outputDir = this.workspace.path;
+    const size = this.mapOpenAIImageSize(args.imageSize);
+    const writtenPaths: string[] = [];
+    const cleanupWrittenImages = async () => {
+      await Promise.all(
+        writtenPaths.map((filePath) => fs.promises.unlink(filePath).catch(() => undefined)),
+      );
+    };
+
+    try {
+      console.log(`[ImageGenerator] Generating image with openai-codex (${args.model})`);
+
+      const accountId = extractChatGPTAccountId(args.accessToken);
+      const hostModel = await resolveOpenAICodexHostModel();
+      const client = new OpenAI({
+        apiKey: args.accessToken,
+        baseURL: OPENAI_CODEX_BASE_URL,
+        defaultHeaders: {
+          "chatgpt-account-id": accountId,
+          "OpenAI-Beta": "responses=experimental",
+          originator: "cowork-os",
+        },
+      });
+
+      const images: ImageGenerationResult["images"] = [];
+      const n = Math.min(args.numberOfImages, 4);
+
+      for (let i = 0; i < n; i++) {
+        let imageBase64: string | null = null;
+        const stream = client.responses.stream({
+          model: hostModel,
+          store: false,
+          instructions: OPENAI_CODEX_IMAGE_INSTRUCTIONS,
+          input: [
+            {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: args.prompt }],
+            },
+          ],
+          tools: [
+            {
+              type: "image_generation",
+              model: args.model,
+              size,
+              output_format: "png",
+              background: "opaque",
+              partial_images: 1,
+              ...(args.model === "gpt-image-1.5" ? { action: "generate" } : {}),
+            },
+          ],
+          tool_choice: {
+            type: "allowed_tools",
+            mode: "required",
+            tools: [{ type: "image_generation" }],
+          },
+        });
+
+        for await (const event of stream) {
+          if (event.type === "response.output_item.done" && event.item.type === "image_generation_call") {
+            if (typeof event.item.result === "string" && event.item.result) {
+              imageBase64 = event.item.result;
+            }
+          } else if (event.type === "response.image_generation_call.partial_image") {
+            if (typeof event.partial_image_b64 === "string" && event.partial_image_b64) {
+              imageBase64 = event.partial_image_b64;
+            }
+          }
+        }
+
+        const finalResponse = await stream.finalResponse();
+        for (const item of finalResponse.output || []) {
+          if (item.type === "image_generation_call" && typeof item.result === "string" && item.result) {
+            imageBase64 = item.result;
+          }
+        }
+
+        if (!imageBase64) {
+          await cleanupWrittenImages();
+          return {
+            success: false,
+            images: [],
+            provider: "openai-codex",
+            model: args.model,
+            error: "No images were returned by OpenAI OAuth image generation.",
+            actionHint: buildSetupHint("openai-codex"),
+          };
+        }
+
+        const imageBuffer = Buffer.from(imageBase64, "base64");
+        const imageName = n > 1 ? `${baseFilename}_${i + 1}.png` : `${baseFilename}.png`;
+        const outputPath = path.join(outputDir, imageName);
+        await fs.promises.writeFile(outputPath, imageBuffer);
+        writtenPaths.push(outputPath);
+        const stats = await fs.promises.stat(outputPath);
+        images.push({
+          path: outputPath,
+          filename: imageName,
+          mimeType: "image/png",
+          size: stats.size,
+        });
+      }
+
+      return { success: true, images, provider: "openai-codex", model: args.model };
+    } catch (error: Any) {
+      await cleanupWrittenImages();
+      return {
+        success: false,
+        images: [],
+        provider: "openai-codex",
+        model: args.model,
+        error: error?.message || "Failed to generate image",
+        actionHint: buildSetupHint("openai-codex"),
       };
     }
   }

--- a/src/electron/agent/tools/image-tools.ts
+++ b/src/electron/agent/tools/image-tools.ts
@@ -15,6 +15,7 @@ import { LLMTool } from "../llm/types";
  * Supports multiple backends depending on what's configured in Settings:
  * - Gemini (image generation)
  * - OpenAI (gpt-image-* / dall-e-*)
+ * - OpenAI OAuth via Codex/ChatGPT (gpt-image-* through the Responses image_generation tool)
  * - Azure OpenAI (deployment-based)
  *
  * If multiple are configured, the tool prefers the configured default provider,
@@ -106,10 +107,11 @@ export class ImageTools {
     return [
       {
         name: "generate_image",
-        description: `Generate an image from a text description using AI. CoWork OS will pick the best configured provider by default (Gemini/OpenAI/Azure/OpenRouter), unless you specify a provider/model.
+        description: `Generate an image from a text description using AI. CoWork OS will pick the best configured provider by default (Gemini/OpenAI/OpenAI OAuth/Azure/OpenRouter), unless you specify a provider/model.
 
 Providers/models:
 - OpenAI: gpt-image-1, gpt-image-1.5, dall-e-3, dall-e-2 (also accepts "gpt-1.5" alias)
+- OpenAI (Codex auth): gpt-image-1, gpt-image-1.5 via ChatGPT/Codex OAuth
 - Azure OpenAI: model maps to a deployment name (configured in Settings)
 - OpenRouter: gpt-image-1.5 via openai/gpt-image-1.5
 - Gemini: nano-banana-2 (gemini-3.1-flash-image-preview), gemini-image-pro, gemini-image-fast
@@ -125,7 +127,7 @@ The generated images are saved to the workspace folder.`,
             },
             provider: {
               type: "string",
-              enum: ["auto", "gemini", "openai", "azure", "openrouter"],
+              enum: ["auto", "gemini", "openai", "openai-codex", "azure", "openrouter"],
               description:
                 'Optional provider override. "auto" uses the configured default with fallbacks (default: auto).',
             },

--- a/src/renderer/components/BuiltinToolsSettings.tsx
+++ b/src/renderer/components/BuiltinToolsSettings.tsx
@@ -11,6 +11,7 @@ import {
   Code,
   ArrowDownToLine,
   MousePointer2,
+  History,
 } from "lucide-react";
 
 interface ToolCategoryConfig {
@@ -30,6 +31,7 @@ interface BuiltinToolsSettingsData {
     skill: ToolCategoryConfig;
     shell: ToolCategoryConfig;
     image: ToolCategoryConfig;
+    chronicle: ToolCategoryConfig;
     computer_use: ToolCategoryConfig;
   };
   toolOverrides: Record<string, { enabled: boolean; priority?: "high" | "normal" | "low" }>;
@@ -92,6 +94,11 @@ const CATEGORY_INFO: Record<
     icon: <Image {...IC} />,
     description: "Generate images using AI (requires Gemini API)",
   },
+  chronicle: {
+    name: "Chronicle",
+    icon: <History {...IC} />,
+    description: "Passive local screen-context disambiguation and recall",
+  },
   computer_use: {
     name: "Computer Use (macOS)",
     icon: <MousePointer2 {...IC} />,
@@ -110,6 +117,7 @@ const CATEGORY_ORDER: CategoryKey[] = [
   "skill",
   "shell",
   "image",
+  "chronicle",
   "computer_use",
 ];
 
@@ -407,8 +415,8 @@ export function BuiltinToolsSettings() {
                     <div className="builtin-tool-advanced-text">
                       <div className="builtin-tool-advanced-label">Approval mode</div>
                       <div className="builtin-tool-advanced-hint">
-                        Per command asks each time. Single bundle asks once and reuses approval for
-                        safe commands in this task.
+                        Single bundle is the lower-noise option. It asks once and reuses approval
+                        for safe commands in this task.
                       </div>
                     </div>
                     <select
@@ -422,7 +430,7 @@ export function BuiltinToolsSettings() {
                       disabled={!config.enabled}
                     >
                       <option value="per_command">Per command</option>
-                      <option value="single_bundle">Single approval bundle</option>
+                      <option value="single_bundle">Single approval bundle (Recommended)</option>
                     </select>
                   </div>
 


### PR DESCRIPTION
## Summary
- Adds OpenAI OAuth / Codex image generation provider support.
- Adds provider ordering/model compatibility logic for OpenAI OAuth, Azure/OpenAI/OpenRouter/Gemini paths.
- Improves Azure OpenAI retry classification and image provider settings labels.

## Validation
- npm run type-check
- npx vitest run src/electron/agent/skills/__tests__/image-generator-oauth.test.ts src/electron/agent/skills/__tests__/image-generator-selection.test.ts src/electron/agent/llm/__tests__/azure-openai-provider.test.ts

## Notes
This is the next stack layer after merged PR #80. A follow-up fix for derived Codex API keys remains as a later stack layer.