### PR TITLE
fix(images): use derived Codex API key for OAuth images

### DIFF
--- a/src/electron/agent/skills/__tests__/image-generator-oauth.test.ts
+++ b/src/electron/agent/skills/__tests__/image-generator-oauth.test.ts
@@ -108,7 +108,7 @@ describe("ImageGenerator OpenAI OAuth", () => {
       },
     } as Any);
     getApiKeyFromTokensMock.mockResolvedValue({
-      apiKey: refreshedAccessToken,
+      apiKey: "derived-api-key",
       newTokens: {
         access_token: refreshedAccessToken,
         refresh_token: "oauth-refresh-token-2",
@@ -135,7 +135,7 @@ describe("ImageGenerator OpenAI OAuth", () => {
     expect(fs.readFileSync(path.join(tempDir, "poster.png")).toString()).toBe("oauth-image");
 
     expect(openAIConfigs[0]).toMatchObject({
-      apiKey: refreshedAccessToken,
+      apiKey: "derived-api-key",
       baseURL: "https://chatgpt.com/backend-api/codex",
       defaultHeaders: expect.objectContaining({
         "chatgpt-account-id": "acct_test_oauth",

--- a/src/electron/agent/skills/image-generator.ts
+++ b/src/electron/agent/skills/image-generator.ts
@@ -445,9 +445,14 @@ function persistUpdatedOpenAITokens(tokens: OpenAIOAuthTokens): void {
   LLMProviderFactory.clearCache();
 }
 
-async function resolveOpenAICodexAccessToken(
+interface OpenAICodexCredentials {
+  apiKey: string;
+  accessToken: string;
+}
+
+async function resolveOpenAICodexCredentials(
   settings: ReturnType<typeof LLMProviderFactory.loadSettings>,
-): Promise<string> {
+): Promise<OpenAICodexCredentials> {
   const accessToken = settings.openai?.accessToken?.trim();
   const refreshToken = settings.openai?.refreshToken?.trim();
   const tokenExpiresAt = settings.openai?.tokenExpiresAt;
@@ -471,7 +476,7 @@ async function resolveOpenAICodexAccessToken(
     ) {
       persistUpdatedOpenAITokens(newTokens);
     }
-    return apiKey;
+    return { apiKey, accessToken: newTokens?.access_token ?? accessToken };
   }
 
   if (
@@ -482,7 +487,7 @@ async function resolveOpenAICodexAccessToken(
     throw new Error("OpenAI OAuth token has expired. Sign in again in Settings.");
   }
 
-  return accessToken;
+  return { apiKey: accessToken, accessToken };
 }
 
 async function resolveOpenAICodexHostModel(): Promise<string> {
@@ -629,9 +634,10 @@ export class ImageGenerator {
             );
             continue;
           }
-          const accessToken = await resolveOpenAICodexAccessToken(settings);
+          const credentials = await resolveOpenAICodexCredentials(settings);
           return await this.generateWithOpenAICodex({
-            accessToken,
+            apiKey: credentials.apiKey,
+            accessToken: credentials.accessToken,
             model: normalizedChosenModel,
             prompt,
             filename,
@@ -1017,6 +1023,7 @@ export class ImageGenerator {
   }
 
   private async generateWithOpenAICodex(args: {
+    apiKey: string;
     accessToken: string;
     model: string;
     prompt: string;
@@ -1040,7 +1047,7 @@ export class ImageGenerator {
       const accountId = extractChatGPTAccountId(args.accessToken);
       const hostModel = await resolveOpenAICodexHostModel();
       const client = new OpenAI({
-        apiKey: args.accessToken,
+        apiKey: args.apiKey,
         baseURL: OPENAI_CODEX_BASE_URL,
         defaultHeaders: {
           "chatgpt-account-id": accountId,


### PR DESCRIPTION
## Summary
- Separates the Codex backend API key from the OAuth access token used for account metadata.
- Uses the derived API key for OpenAI client authentication while retaining the access token for ChatGPT account header extraction.
- Updates the OpenAI OAuth image-generation test expectations.

## Validation
- npm run type-check
- npx vitest run src/electron/agent/skills/__tests__/image-generator-oauth.test.ts

## Notes
This is the first of the final three fix-only PRs after the broad app integration layer.