### PR TITLE
fix(hooks): scope same-path mapping tokens to matched source

### DIFF
--- a/src/electron/hooks/__tests__/server.test.ts
+++ b/src/electron/hooks/__tests__/server.test.ts
@@ -392,6 +392,57 @@ describe("HooksServer", () => {
       );
     });
 
+    it("accepts the token for the selected same-path mapping only", async () => {
+      server.setHooksConfig({
+        enabled: true,
+        token: "test-secret-token",
+        path: "/hooks",
+        maxBodyBytes: 256 * 1024,
+        presets: [],
+        mappings: [
+          {
+            id: "gmail-alert",
+            token: "gmail-token",
+            match: { path: "shared", source: "gmail" },
+            action: "agent",
+            messageTemplate: "Gmail: {{payload.text}}",
+          },
+          {
+            id: "slack-alert",
+            token: "slack-token",
+            match: { path: "shared", source: "slack" },
+            action: "agent",
+            messageTemplate: "Slack: {{payload.text}}",
+          },
+        ],
+      });
+
+      const onAgent = vi.fn().mockResolvedValue({ taskId: "task-slack" });
+      server.setHandlers({ onAgent });
+
+      const slackResponse = await makeRequest(
+        "POST",
+        "/hooks/shared",
+        { source: "slack", text: "deploy alert" },
+        { Authorization: "Bearer slack-token" },
+      );
+      const wrongTokenResponse = await makeRequest(
+        "POST",
+        "/hooks/shared",
+        { source: "gmail", text: "mail alert" },
+        { Authorization: "Bearer slack-token" },
+      );
+
+      expect(slackResponse.statusCode).toBe(202);
+      expect(wrongTokenResponse.statusCode).toBe(401);
+      expect(onAgent).toHaveBeenCalledTimes(1);
+      expect(onAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Slack: deploy alert",
+        }),
+      );
+    });
+
     it("should call onTaskMessage handler", async () => {
       const onTaskMessage = vi.fn().mockResolvedValue(undefined);
       server.setHandlers({ onTaskMessage });

--- a/src/electron/hooks/mappings.ts
+++ b/src/electron/hooks/mappings.ts
@@ -123,25 +123,34 @@ export async function applyHookMappings(
 ): Promise<HookMappingResult | null> {
   if (mappings.length === 0) return null;
 
+  const mapping = findHookMapping(mappings, ctx);
+  if (!mapping) return null;
+
+  const base = buildActionFromMapping(mapping, ctx);
+  if (!base.ok) return base;
+
+  let override: HookTransformResult = null;
+  if (mapping.transform) {
+    const transform = await loadTransform(mapping.transform);
+    override = await transform(ctx);
+    if (override === null) {
+      return { ok: true, action: null, skipped: true };
+    }
+  }
+
+  if (!base.action) return { ok: true, action: null, skipped: true };
+  const merged = mergeAction(base.action, override, mapping.action);
+  if (!merged.ok) return merged;
+  return merged;
+}
+
+export function findHookMapping(
+  mappings: HookMappingResolved[],
+  ctx: HookMappingContext,
+): HookMappingResolved | null {
   for (const mapping of mappings) {
     if (!mappingMatches(mapping, ctx)) continue;
-
-    const base = buildActionFromMapping(mapping, ctx);
-    if (!base.ok) return base;
-
-    let override: HookTransformResult = null;
-    if (mapping.transform) {
-      const transform = await loadTransform(mapping.transform);
-      override = await transform(ctx);
-      if (override === null) {
-        return { ok: true, action: null, skipped: true };
-      }
-    }
-
-    if (!base.action) return { ok: true, action: null, skipped: true };
-    const merged = mergeAction(base.action, override, mapping.action);
-    if (!merged.ok) return merged;
-    return merged;
+    return mapping;
   }
 
   return null;

--- a/src/electron/hooks/server.ts
+++ b/src/electron/hooks/server.ts
@@ -22,7 +22,12 @@ import {
   DEFAULT_HOOKS_MAX_BODY_BYTES,
   DEFAULT_HOOKS_PORT as _DEFAULT_HOOKS_PORT,
 } from "./types";
-import { resolveHookMappings, applyHookMappings, normalizeHooksPath as _normalizeHooksPath } from "./mappings";
+import {
+  resolveHookMappings,
+  applyHookMappings,
+  findHookMapping,
+  normalizeHooksPath as _normalizeHooksPath,
+} from "./mappings";
 
 const RESEND_SIGNATURE_ALLOWED_DRIFT_SECONDS = 300;
 const RESEND_REPLAY_CACHE_MAX_ENTRIES = 10_000;
@@ -259,7 +264,7 @@ export class HooksServer {
     // Extract the hook path after base
     const hookPath = url.pathname.slice(basePath.length).replace(/^\/+/, "").replace(/\/+$/, "");
 
-    const mappedToken = this.findMappedToken(hookPath, req.method || "GET");
+    const mappedTokens = this.findMappedTokenCandidates(hookPath, req.method || "GET");
 
     // Emit request event
     this.emitEvent({
@@ -271,7 +276,7 @@ export class HooksServer {
 
     // Verify authentication
     const tokenResult = this.extractHookToken(req, url);
-    if (!this.verifyToken(tokenResult.token, mappedToken)) {
+    if (!this.verifyAnyToken(tokenResult.token, mappedTokens)) {
       this.sendJsonResponse(res, 401, { success: false, error: "Invalid or missing token" });
       return;
     }
@@ -521,9 +526,8 @@ export class HooksServer {
       path: hookPath,
     };
 
-    const result = await applyHookMappings(this.hooksConfig.mappings, ctx);
-
-    if (!result) {
+    const selectedMapping = findHookMapping(this.hooksConfig.mappings, ctx);
+    if (!selectedMapping) {
       if (hookPath === "resend") {
         const eventType = typeof body.type === "string" ? body.type : undefined;
         if (eventType && eventType !== "email.received") {
@@ -535,6 +539,19 @@ export class HooksServer {
           return;
         }
       }
+      this.sendJsonResponse(res, 404, { success: false, error: "No matching hook mapping" });
+      return;
+    }
+
+    const tokenResult = this.extractHookToken(req, url);
+    if (!this.verifyToken(tokenResult.token, selectedMapping.token)) {
+      this.sendJsonResponse(res, 401, { success: false, error: "Invalid or missing token" });
+      return;
+    }
+
+    const result = await applyHookMappings(this.hooksConfig.mappings, ctx);
+
+    if (!result) {
       this.sendJsonResponse(res, 404, { success: false, error: "No matching hook mapping" });
       return;
     }
@@ -649,16 +666,37 @@ export class HooksServer {
     return crypto.timingSafeEqual(expected, actual);
   }
 
-  private findMappedToken(hookPath: string, method: string): string | undefined {
-    if (method.toUpperCase() !== "POST") return undefined;
-    const mapping = this.findMappingByPath(hookPath);
-    return mapping?.token;
+  private verifyAnyToken(
+    provided: string | undefined,
+    overrides?: Array<string | undefined>,
+  ): boolean {
+    if (!overrides) return this.verifyToken(provided);
+    return overrides.some((override) => this.verifyToken(provided, override));
   }
 
-  private findMappingByPath(hookPath: string): HookMappingResolved | undefined {
-    if (!this.hooksConfig?.mappings?.length) return undefined;
+  private findMappedTokenCandidates(
+    hookPath: string,
+    method: string,
+  ): Array<string | undefined> | undefined {
+    if (method.toUpperCase() !== "POST") return undefined;
+    const mappings = this.findMappingsByPath(hookPath);
+    if (mappings.length === 0) return undefined;
+    const tokens = new Set<string>();
+    let includeGlobalToken = false;
+    for (const mapping of mappings) {
+      if (mapping.token) {
+        tokens.add(mapping.token);
+      } else {
+        includeGlobalToken = true;
+      }
+    }
+    return [...tokens, ...(includeGlobalToken ? [undefined] : [])];
+  }
+
+  private findMappingsByPath(hookPath: string): HookMappingResolved[] {
+    if (!this.hooksConfig?.mappings?.length) return [];
     const normalizedPath = hookPath.replace(/^\/+/, "").replace(/\/+$/, "");
-    return this.hooksConfig.mappings.find((mapping) => mapping.matchPath === normalizedPath);
+    return this.hooksConfig.mappings.filter((mapping) => mapping.matchPath === normalizedPath);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Selects the hook mapping after body/source matching before enforcing mapping-specific token checks.
- Allows same-path mappings to use distinct route tokens without accepting a token from a different source mapping.
- Adds regression coverage for same-path Gmail/Slack mappings with different tokens.

## Validation
- npm run type-check
- npx vitest run src/electron/hooks/__tests__/server.test.ts

## Notes
This is the second-to-last fix-only PR from the original recovered stack.