### PR TITLE
fix(agents): sync managed routine lifecycle through service

### DIFF
--- a/src/electron/control-plane/handlers.ts
+++ b/src/electron/control-plane/handlers.ts
@@ -41,6 +41,7 @@ import type { AgentConfig } from "../../shared/types";
 import type { AgentDaemon } from "../agent/daemon";
 import type { DatabaseManager } from "../database/schema";
 import type { ChannelGateway } from "../gateway";
+import type { RoutineService } from "../routines/service";
 import {
   ApprovalRepository,
   ArtifactRepository,
@@ -103,6 +104,7 @@ export interface ControlPlaneMethodDeps {
   agentDaemon: AgentDaemon;
   dbManager: DatabaseManager;
   channelGateway?: ChannelGateway;
+  getRoutineService?: () => RoutineService | null;
 }
 
 let controlPlaneDeps: ControlPlaneMethodDeps | null = null;
@@ -111,7 +113,9 @@ let managedSessionService: ManagedSessionService | null = null;
 
 function getManagedSessionService(deps: ControlPlaneMethodDeps): ManagedSessionService {
   if (!managedSessionService) {
-    managedSessionService = new ManagedSessionService(deps.dbManager.getDatabase(), deps.agentDaemon);
+    managedSessionService = new ManagedSessionService(deps.dbManager.getDatabase(), deps.agentDaemon, {
+      getRoutineService: deps.getRoutineService,
+    });
   }
   return managedSessionService;
 }
@@ -2806,7 +2810,7 @@ function registerTaskAndWorkspaceMethods(
   server.registerMethod(Methods.MANAGED_AGENT_ARCHIVE, async (client, params) => {
     requireScope(client, "admin");
     const { agentId } = sanitizeManagedAgentIdParams(params);
-    return { agent: managedSessions.archiveAgent(agentId) || null };
+    return { agent: (await managedSessions.archiveAgent(agentId)) || null };
   });
 
   server.registerMethod(Methods.MANAGED_AGENT_VERSION_LIST, async (client, params) => {

--- a/src/electron/ipc/handlers.ts
+++ b/src/electron/ipc/handlers.ts
@@ -1046,7 +1046,10 @@ export async function setupIpcHandlers(
   );
   agentMailRealtimeService.start();
   const contextPolicyManager = new ContextPolicyManager(db);
-  const managedSessionService = new ManagedSessionService(db, agentDaemon);
+  const getRoutineService = () => options?.getRoutineService?.() || null;
+  const managedSessionService = new ManagedSessionService(db, agentDaemon, {
+    getRoutineService,
+  });
   const agentTemplateService = new AgentTemplateService();
   const imageGenProfileService = new ImageGenProfileService();
   const emitTaskStatusEvent = (
@@ -4045,7 +4048,6 @@ export async function setupIpcHandlers(
   });
 
   // Agents Hub handlers
-  const getRoutineService = () => options?.getRoutineService?.() || null;
   const toManagedRoutinePayload = (
     input: ReturnType<ManagedSessionService["buildManagedAgentRoutineDefinition"]>,
     agentId: string,
@@ -4162,13 +4164,13 @@ export async function setupIpcHandlers(
     return managedSessionService.updateAgent(request.agentId, request);
   });
   ipcMain.handle(IPC_CHANNELS.MANAGED_AGENT_ARCHIVE_IPC, async (_, agentId: string) => {
-    return managedSessionService.archiveAgent(agentId) || null;
+    return (await managedSessionService.archiveAgent(agentId)) || null;
   });
   ipcMain.handle(IPC_CHANNELS.MANAGED_AGENT_PUBLISH_IPC, async (_, agentId: string) => {
-    return managedSessionService.publishAgent(agentId) || null;
+    return (await managedSessionService.publishAgent(agentId)) || null;
   });
   ipcMain.handle(IPC_CHANNELS.MANAGED_AGENT_SUSPEND_IPC, async (_, agentId: string) => {
-    return managedSessionService.suspendAgent(agentId) || null;
+    return (await managedSessionService.suspendAgent(agentId)) || null;
   });
   ipcMain.handle(IPC_CHANNELS.MANAGED_AGENT_ROUTINE_LIST_IPC, async (_, agentId: string) => {
     return managedSessionService.listManagedAgentRoutines(agentId);

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -2254,7 +2254,7 @@ if (!gotTheLock) {
 
       // Start Control Plane if enabled (or force-enabled via flag/env)
       const cp = await startControlPlaneFromSettings({
-        deps: { agentDaemon, dbManager, channelGateway },
+        deps: { agentDaemon, dbManager, channelGateway, getRoutineService: () => routineService },
         forceEnable: FORCE_ENABLE_CONTROL_PLANE,
         onEvent: (event) => {
           try {
@@ -2334,10 +2334,11 @@ if (!gotTheLock) {
         agentDaemon,
         dbManager,
         channelGateway,
+        getRoutineService: () => routineService,
       });
       // Auto-start control plane if enabled (and register methods/bridge)
       await startControlPlaneFromSettings({
-        deps: { agentDaemon, dbManager, channelGateway },
+        deps: { agentDaemon, dbManager, channelGateway, getRoutineService: () => routineService },
       });
 
       // ── Gap features: triggers, briefing, file hub, web access ───────

--- a/src/electron/managed/ManagedSessionService.ts
+++ b/src/electron/managed/ManagedSessionService.ts
@@ -72,6 +72,7 @@ import { MCPSettingsManager } from "../mcp/settings";
 import { ManagedAccountManager } from "../accounts/managed-account-manager";
 import { getVoiceService } from "../voice/VoiceService";
 import { ImageGenProfileService } from "./ImageGenProfileService";
+import type { RoutineService } from "../routines/service";
 import type { Routine, RoutineTrigger } from "../routines/types";
 import {
   ManagedAgentRepository,
@@ -586,6 +587,9 @@ export class ManagedSessionService {
   constructor(
     private readonly db: import("better-sqlite3").Database,
     private readonly agentDaemon: AgentDaemon,
+    private readonly options: {
+      getRoutineService?: () => RoutineService | null;
+    } = {},
   ) {
     this.ensureGovernanceSchema();
     this.taskRepo = new TaskRepository(db);
@@ -1041,7 +1045,7 @@ export class ManagedSessionService {
     return linkedRoutines;
   }
 
-  private setRoutineEnabled(routineId: string, enabled: boolean): void {
+  private setRoutineEnabledInDb(routineId: string, enabled: boolean): void {
     const row = this.db
       .prepare("SELECT * FROM automation_routines WHERE id = ?")
       .get(routineId) as Any | undefined;
@@ -1061,6 +1065,15 @@ export class ManagedSessionService {
          WHERE id = ?`,
       )
       .run(enabled ? 1 : 0, JSON.stringify(nextDefinition), nextDefinition.updatedAt, routineId);
+  }
+
+  private async setRoutineEnabled(routineId: string, enabled: boolean): Promise<void> {
+    const routineService = this.options.getRoutineService?.() || null;
+    if (routineService) {
+      const updated = await routineService.update(routineId, { enabled });
+      if (updated) return;
+    }
+    this.setRoutineEnabledInDb(routineId, enabled);
   }
 
   getRuntimeToolCatalog(agentId: string): ManagedAgentRuntimeToolCatalog {
@@ -1232,14 +1245,14 @@ export class ManagedSessionService {
     return { agent, version: syncedVersion };
   }
 
-  archiveAgent(agentId: string): ManagedAgent | undefined {
+  async archiveAgent(agentId: string): Promise<ManagedAgent | undefined> {
     const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
     if (workspaceId) this.assertWorkspacePermission(workspaceId, "canPublishAgents");
     const agent = this.managedAgentRepo.update(agentId, { status: "archived" });
     if (!agent) return undefined;
     const routines = this.listManagedAgentRoutines(agentId);
     for (const routine of routines) {
-      this.setRoutineEnabled(routine.id, false);
+      await this.setRoutineEnabled(routine.id, false);
     }
     const detail = this.getAgent(agentId);
     if (detail?.currentVersion) {
@@ -1257,7 +1270,7 @@ export class ManagedSessionService {
     return agent;
   }
 
-  publishAgent(agentId: string): ManagedAgent | undefined {
+  async publishAgent(agentId: string): Promise<ManagedAgent | undefined> {
     const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
     if (workspaceId) this.assertWorkspacePermission(workspaceId, "canPublishAgents");
     const agent = this.managedAgentRepo.update(agentId, { status: "active" });
@@ -1265,7 +1278,7 @@ export class ManagedSessionService {
     const detail = this.getAgent(agentId);
     const studio = detail?.currentVersion ? getStudioConfig(detail.currentVersion) : undefined;
     for (const routine of this.listManagedAgentRoutines(agentId)) {
-      this.setRoutineEnabled(routine.id, routine.trigger.enabled !== false);
+      await this.setRoutineEnabled(routine.id, routine.trigger.enabled !== false);
     }
     if (detail?.currentVersion) {
       this.syncLegacyMirror(agent, detail.currentVersion, studio);
@@ -1282,7 +1295,7 @@ export class ManagedSessionService {
     return agent;
   }
 
-  suspendAgent(agentId: string): ManagedAgent | undefined {
+  async suspendAgent(agentId: string): Promise<ManagedAgent | undefined> {
     const workspaceId = this.resolveWorkspaceIdForAgent(agentId);
     if (workspaceId) this.assertWorkspacePermission(workspaceId, "canPublishAgents");
     const agent = this.managedAgentRepo.update(agentId, { status: "suspended" });
@@ -1291,7 +1304,7 @@ export class ManagedSessionService {
     const currentVersion = detail?.currentVersion;
     const studio = currentVersion ? getStudioConfig(currentVersion) : undefined;
     for (const routine of this.listManagedAgentRoutines(agentId)) {
-      this.setRoutineEnabled(routine.id, false);
+      await this.setRoutineEnabled(routine.id, false);
     }
     if (currentVersion) {
       this.syncLegacyMirror(agent, currentVersion, studio);

--- a/src/electron/managed/__tests__/ManagedSessionService.test.ts
+++ b/src/electron/managed/__tests__/ManagedSessionService.test.ts
@@ -459,7 +459,7 @@ describeWithSqlite("ManagedSessionService", () => {
     expect(attackerMembership).toBeUndefined();
   });
 
-  it("preserves authored Slack targets when suspending an agent while removing live routing", () => {
+  it("preserves authored Slack targets when suspending an agent while removing live routing", async () => {
     const workspace = insertWorkspace("suspend-slack");
     const environment = service.createEnvironment({
       name: "Slack env",
@@ -495,8 +495,8 @@ describeWithSqlite("ManagedSessionService", () => {
       },
     });
 
-    service.publishAgent(created.agent.id);
-    service.suspendAgent(created.agent.id);
+    await service.publishAgent(created.agent.id);
+    await service.suspendAgent(created.agent.id);
 
     const suspended = service.getAgent(created.agent.id);
     const studio = suspended?.currentVersion?.metadata?.studio as Any;
@@ -508,6 +508,94 @@ describeWithSqlite("ManagedSessionService", () => {
     expect(updatedChannel?.config?.allowedAgentRoleIds || []).not.toContain(
       studio?.legacyMirror?.agentRoleId,
     );
+  });
+
+  it("uses the routine service when suspending managed agent routines", async () => {
+    const workspace = insertWorkspace("suspend-routine-sync");
+    const environment = service.createEnvironment({
+      name: "Routine env",
+      config: { workspaceId: workspace.id },
+    });
+    const created = service.createAgent({
+      name: "Routine agent",
+      systemPrompt: "Run scheduled work.",
+      executionMode: "solo",
+      metadata: {
+        studio: {
+          defaultEnvironmentId: environment.id,
+        },
+      },
+    });
+    const routineId = "routine-sync-test";
+    const now = Date.now();
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS automation_routines (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        workspace_id TEXT NOT NULL,
+        prompt TEXT NOT NULL,
+        connectors_json TEXT NOT NULL,
+        triggers_json TEXT NOT NULL,
+        definition_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+    const definition = {
+      id: routineId,
+      name: "Daily routine",
+      enabled: true,
+      workspaceId: workspace.id,
+      instructions: "Run scheduled work.",
+      prompt: "Run scheduled work.",
+      executionTarget: {
+        kind: "managed_environment",
+        managedEnvironmentId: environment.id,
+      },
+      contextBindings: {
+        metadata: { managedAgentId: created.agent.id },
+      },
+      triggers: [{ id: "manual-trigger", type: "manual", enabled: true }],
+      outputs: [{ kind: "task_only" }],
+      approvalPolicy: { mode: "inherit" },
+      connectorPolicy: { mode: "prefer", connectorIds: [] },
+      connectors: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    db.prepare(
+      `INSERT INTO automation_routines
+       (id, name, enabled, workspace_id, prompt, connectors_json, triggers_json, definition_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      routineId,
+      definition.name,
+      1,
+      workspace.id,
+      definition.prompt,
+      "[]",
+      JSON.stringify(definition.triggers),
+      JSON.stringify(definition),
+      now,
+      now,
+    );
+    const updateRoutine = vi.fn(async (_routineId: string, patch: { enabled?: boolean }) => {
+      db.prepare("UPDATE automation_routines SET enabled = ?, updated_at = ? WHERE id = ?").run(
+        patch.enabled ? 1 : 0,
+        Date.now(),
+        _routineId,
+      );
+      return { ...definition, enabled: patch.enabled ?? definition.enabled };
+    });
+    const serviceWithRoutineSync = new ManagedSessionService(db, daemon, {
+      getRoutineService: () => ({ update: updateRoutine }) as Any,
+    });
+
+    await serviceWithRoutineSync.suspendAgent(created.agent.id);
+
+    expect(updateRoutine).toHaveBeenCalledWith(routineId, { enabled: false });
   });
 
   it("returns workpapers to viewers without requiring audit permission", async () => {
@@ -604,7 +692,7 @@ describeWithSqlite("ManagedSessionService", () => {
         },
       },
     });
-    service.publishAgent(created.agent.id);
+    await service.publishAgent(created.agent.id);
 
     const manualSession = await service.createSession({
       agentId: created.agent.id,


### PR DESCRIPTION
## Summary
- Passes the routine service into managed-session/control-plane wiring.
- Makes managed agent publish/suspend/archive update routine enabled state through RoutineService when available, falling back to direct DB updates otherwise.
- Updates IPC/control-plane handlers for the async lifecycle methods and adds regression coverage.

## Validation
- npm run type-check
- npx vitest run src/electron/managed/__tests__/ManagedSessionService.test.ts

## Test note
The managed-session Vitest command completed successfully, but the suite is currently skipped by definition: 15 skipped tests.

## Notes
This is the final fix-only PR from the original recovered stack.