### PR TITLE
[codex] Fix custom provider model lists

### DIFF
--- a/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
+++ b/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
@@ -111,7 +111,7 @@ describe("LLMProviderFactory custom provider config resolution", () => {
     expect(modelId).toBe("us.anthropic.claude-opus-4-6-20260115-v1:0");
   });
 
-  it("uses cached custom-provider models when available", () => {
+  it("keeps cached custom-provider models and adds documented models", () => {
     const modelStatus = LLMProviderFactory.getProviderModelStatus({
       providerType: "minimax-portal",
       modelKey: "sonnet-3-5",
@@ -136,17 +136,14 @@ describe("LLMProviderFactory custom provider config resolution", () => {
     } as Any);
 
     expect(modelStatus.currentModel).toBe("MiniMax-M2.5");
-    expect(modelStatus.models).toEqual([
-      {
-        key: "MiniMax-M2.5",
-        displayName: "MiniMax M2.5",
-        description: "MiniMax Portal model",
-      },
-      {
-        key: "MiniMax-M2.1",
-        displayName: "MiniMax M2.1",
-        description: "MiniMax Portal model",
-      },
+    expect(modelStatus.models.map((model) => model.key)).toEqual([
+      "MiniMax-M2.5",
+      "MiniMax-M2.1",
+      "MiniMax-M2.7",
+      "MiniMax-M2.7-highspeed",
+      "MiniMax-M2.5-highspeed",
+      "MiniMax-M2.1-highspeed",
+      "MiniMax-M2",
     ]);
   });
 
@@ -170,13 +167,23 @@ describe("LLMProviderFactory custom provider config resolution", () => {
         description: "MiniMax Portal model",
       },
       {
-        key: "MiniMax-M2.1",
-        displayName: "MiniMax-M2.1",
+        key: "MiniMax-M2.7",
+        displayName: "MiniMax-M2.7",
+        description: "MiniMax Portal model",
+      },
+      {
+        key: "MiniMax-M2.7-highspeed",
+        displayName: "MiniMax-M2.7-highspeed",
         description: "MiniMax Portal model",
       },
       {
         key: "MiniMax-M2.5-highspeed",
         displayName: "MiniMax-M2.5-highspeed",
+        description: "MiniMax Portal model",
+      },
+      {
+        key: "MiniMax-M2.1",
+        displayName: "MiniMax-M2.1",
         description: "MiniMax Portal model",
       },
       {
@@ -192,5 +199,34 @@ describe("LLMProviderFactory custom provider config resolution", () => {
     ]);
 
     expect(saveSpy).toHaveBeenCalled();
+  });
+
+  it("adds documented Z.AI coding-plan models to partial refresh results", async () => {
+    vi.spyOn(LLMProviderFactory, "loadSettings").mockReturnValue({
+      providerType: "zai",
+      modelKey: "sonnet-3-5",
+      customProviders: {
+        zai: {
+          apiKey: "zai-test",
+          baseUrl: "https://api.z.ai/api/paas/v4",
+          model: "glm-4.7",
+        },
+      },
+    } as Any);
+    vi.spyOn(LLMProviderFactory, "saveSettings").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "glm-4.7" }] }),
+    } as Response);
+
+    const models = await LLMProviderFactory.getCustomProviderModels("zai");
+
+    expect(models.map((model) => model.key)).toEqual([
+      "glm-4.7",
+      "GLM-5.1",
+      "GLM-5-Turbo",
+      "GLM-5V-Turbo",
+      "glm-4.5-air",
+    ]);
   });
 });

--- a/src/electron/agent/llm/provider-factory.ts
+++ b/src/electron/agent/llm/provider-factory.ts
@@ -381,6 +381,30 @@ function getKnownCustomProviderModels(
   }));
 }
 
+function mergeCustomProviderModels(
+  entry: ProviderCatalogEntry,
+  ...modelGroups: Array<CachedModelInfo[] | undefined>
+): CachedModelInfo[] {
+  const merged: CachedModelInfo[] = [];
+  const seen = new Set<string>();
+
+  for (const group of modelGroups) {
+    for (const model of group || []) {
+      const key = model.key?.trim();
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      merged.push({
+        ...model,
+        displayName: model.displayName || key,
+        description:
+          model.description || entry.description || `${entry.name} model`,
+      });
+    }
+  }
+
+  return merged;
+}
+
 function getCustomProviderConfig(
   customProviders: Record<string, CustomProviderConfig> | undefined,
   providerType: LLMProviderType,
@@ -2431,13 +2455,20 @@ export class LLMProviderFactory {
                 },
               ]
             : [];
+      const modelList = mergeCustomProviderModels(
+        customEntry,
+        cachedModels,
+        getKnownCustomProviderModels(customEntry),
+      );
       return {
         currentModel,
-        models: attachMetadata(ensureCurrentModel(
-          cachedModels,
-          currentModel,
-          customEntry.description || `${customEntry.name} model`,
-        )),
+        models: attachMetadata(
+          ensureCurrentModel(
+            modelList,
+            currentModel,
+            customEntry.description || `${customEntry.name} model`,
+          ),
+        ),
       };
     }
 
@@ -3992,19 +4023,30 @@ export class LLMProviderFactory {
       entry.baseUrl ||
       "";
     const documentedModels = getKnownCustomProviderModels(entry);
-    const fallbackCachedModels = Array.from(
-      new Set(
-        [
-          existingConfig.model?.trim(),
-          entry.defaultModel?.trim(),
-          ...documentedModels.map((model) => model.key),
-        ].filter(Boolean),
-      ),
-    ).map((modelId) => ({
-      key: modelId!,
-      displayName: modelId!,
-      description: entry.description || `${entry.name} model`,
-    }));
+    const selectedModel = existingConfig.model?.trim();
+    const defaultModel = entry.defaultModel?.trim();
+    const fallbackCachedModels = mergeCustomProviderModels(
+      entry,
+      selectedModel
+        ? [
+            {
+              key: selectedModel,
+              displayName: selectedModel,
+              description: entry.description || `${entry.name} model`,
+            },
+          ]
+        : undefined,
+      documentedModels,
+      defaultModel
+        ? [
+            {
+              key: defaultModel,
+              displayName: defaultModel,
+              description: entry.description || `${entry.name} model`,
+            },
+          ]
+        : undefined,
+    );
 
     // MiniMax documents its supported model IDs, but the Anthropic-compatible
     // endpoint does not expose a usable public /models listing endpoint.
@@ -4017,7 +4059,7 @@ export class LLMProviderFactory {
       updatedSettings.customProviders = {
         ...updatedSettings.customProviders,
         [resolvedProviderType]: {
-          ...(updatedSettings.customProviders?.[resolvedProviderType] || {}),
+          ...updatedSettings.customProviders?.[resolvedProviderType],
           cachedModels: fallbackCachedModels,
         },
       };
@@ -4026,7 +4068,11 @@ export class LLMProviderFactory {
     }
 
     if (!baseUrl) {
-      return existingConfig.cachedModels || fallbackCachedModels;
+      return mergeCustomProviderModels(
+        entry,
+        existingConfig.cachedModels,
+        fallbackCachedModels,
+      );
     }
 
     const provider =
@@ -4047,18 +4093,22 @@ export class LLMProviderFactory {
           });
 
     const models = await provider.getAvailableModels();
-    const cachedModels = models.map((model) => ({
-      key: model.id,
-      displayName: model.name || model.id,
-      description: entry.description || `${entry.name} model`,
-    }));
+    const cachedModels = mergeCustomProviderModels(
+      entry,
+      models.map((model) => ({
+        key: model.id,
+        displayName: model.name || model.id,
+        description: entry.description || `${entry.name} model`,
+      })),
+      fallbackCachedModels,
+    );
 
     if (cachedModels.length > 0) {
       const updatedSettings = this.loadSettings();
       updatedSettings.customProviders = {
         ...updatedSettings.customProviders,
         [resolvedProviderType]: {
-          ...(updatedSettings.customProviders?.[resolvedProviderType] || {}),
+          ...updatedSettings.customProviders?.[resolvedProviderType],
           cachedModels,
         },
       };
@@ -4071,7 +4121,7 @@ export class LLMProviderFactory {
       updatedSettings.customProviders = {
         ...updatedSettings.customProviders,
         [resolvedProviderType]: {
-          ...(updatedSettings.customProviders?.[resolvedProviderType] || {}),
+          ...updatedSettings.customProviders?.[resolvedProviderType],
           cachedModels: fallbackCachedModels,
         },
       };
@@ -4079,6 +4129,10 @@ export class LLMProviderFactory {
       return fallbackCachedModels;
     }
 
-    return existingConfig.cachedModels || [];
+    return mergeCustomProviderModels(
+      entry,
+      existingConfig.cachedModels,
+      fallbackCachedModels,
+    );
   }
 }

--- a/src/shared/llm-provider-catalog.ts
+++ b/src/shared/llm-provider-catalog.ts
@@ -63,6 +63,13 @@ export const CUSTOM_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     name: "Z.AI",
     compatibility: "openai",
     defaultModel: "glm-4.7",
+    knownModels: [
+      "GLM-5.1",
+      "GLM-5-Turbo",
+      "GLM-5V-Turbo",
+      "glm-4.7",
+      "glm-4.5-air",
+    ],
     apiKeyLabel: "API Key",
     apiKeyPlaceholder: "zai-...",
     requiresBaseUrl: true,
@@ -141,6 +148,8 @@ export const CUSTOM_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     baseUrl: "https://api.minimax.io/v1",
     defaultModel: "MiniMax-M2.1",
     knownModels: [
+      "MiniMax-M2.7",
+      "MiniMax-M2.7-highspeed",
       "MiniMax-M2.5",
       "MiniMax-M2.5-highspeed",
       "MiniMax-M2.1",
@@ -157,6 +166,8 @@ export const CUSTOM_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     baseUrl: "https://api.minimax.io/anthropic",
     defaultModel: "MiniMax-M2.1",
     knownModels: [
+      "MiniMax-M2.7",
+      "MiniMax-M2.7-highspeed",
       "MiniMax-M2.5",
       "MiniMax-M2.5-highspeed",
       "MiniMax-M2.1",


### PR DESCRIPTION
## Summary
- Add documented MiniMax M2.7 and M2.7-highspeed model IDs to MiniMax custom provider catalogs.
- Add documented Z.AI coding-plan model IDs, including GLM-5V-Turbo.
- Merge documented provider models with cached/fetched model lists so partial /models responses or stale caches do not hide newer documented models.

Fixes #88.

## Validation
- npx vitest run src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
- npx oxlint src/shared/llm-provider-catalog.ts src/electron/agent/llm/provider-factory.ts src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts -c .oxlintrc.json --tsconfig tsconfig.json
- npm run type-check
- git diff --check

Notes: npm run fmt:check is currently blocked by the repo's Vite config serialization issue. Full npm run lint still reports unrelated existing repo-wide lint errors.