### PR TITLE
Fix Windows skill git import cleanup

### DIFF
--- a/src/electron/agent/__tests__/skill-registry.test.ts
+++ b/src/electron/agent/__tests__/skill-registry.test.ts
@@ -10,6 +10,7 @@ import type { CustomSkill, SkillRegistryEntry, SkillSearchResult } from "../../.
 // Track file system operations
 let mockFiles: Map<string, string> = new Map();
 let mockDirs: Set<string> = new Set();
+let mockRmSyncThrowOnceFor: string | null = null;
 
 function normalizePath(value: string): string {
   const normalized = value.replace(/\\/g, "/").replace(/\/+/g, "/");
@@ -78,6 +79,28 @@ function movePath(source: string, destination: string): void {
 function pathExists(value: string): boolean {
   const normalized = normalizePath(value);
   return mockDirs.has(normalized) || mockFiles.has(normalized);
+}
+
+function removeMockPath(target: string): void {
+  const normalized = normalizePath(target);
+  if (mockRmSyncThrowOnceFor && normalized.includes(mockRmSyncThrowOnceFor)) {
+    mockRmSyncThrowOnceFor = null;
+    const error = new Error(`EPERM, Permission denied: ${target}`) as NodeJS.ErrnoException;
+    error.code = "EPERM";
+    throw error;
+  }
+
+  mockFiles.delete(normalized);
+  for (const filePath of Array.from(mockFiles.keys())) {
+    if (filePath.startsWith(`${normalized}/`)) {
+      mockFiles.delete(filePath);
+    }
+  }
+  for (const dirPath of Array.from(mockDirs)) {
+    if (dirPath === normalized || dirPath.startsWith(`${normalized}/`)) {
+      mockDirs.delete(dirPath);
+    }
+  }
 }
 
 function listDirEntries(dir: string): Array<{ name: string; isDirectory: boolean }> {
@@ -241,19 +264,9 @@ vi.mock("fs", () => ({
     unlinkSync: vi.fn().mockImplementation((p: string) => {
       mockFiles.delete(normalizePath(p));
     }),
+    chmodSync: vi.fn(),
     rmSync: vi.fn().mockImplementation((target: string) => {
-      const normalized = normalizePath(target);
-      mockFiles.delete(normalized);
-      for (const filePath of Array.from(mockFiles.keys())) {
-        if (filePath.startsWith(`${normalized}/`)) {
-          mockFiles.delete(filePath);
-        }
-      }
-      for (const dirPath of Array.from(mockDirs)) {
-        if (dirPath === normalized || dirPath.startsWith(`${normalized}/`)) {
-          mockDirs.delete(dirPath);
-        }
-      }
+      removeMockPath(target);
     }),
   },
   existsSync: vi.fn().mockImplementation((p: string) => pathExists(p)),
@@ -337,19 +350,9 @@ vi.mock("fs", () => ({
   unlinkSync: vi.fn().mockImplementation((p: string) => {
     mockFiles.delete(normalizePath(p));
   }),
+  chmodSync: vi.fn(),
   rmSync: vi.fn().mockImplementation((target: string) => {
-    const normalized = normalizePath(target);
-    mockFiles.delete(normalized);
-    for (const filePath of Array.from(mockFiles.keys())) {
-      if (filePath.startsWith(`${normalized}/`)) {
-        mockFiles.delete(filePath);
-      }
-    }
-    for (const dirPath of Array.from(mockDirs)) {
-      if (dirPath === normalized || dirPath.startsWith(`${normalized}/`)) {
-        mockDirs.delete(dirPath);
-      }
-    }
+    removeMockPath(target);
   }),
 }));
 
@@ -391,6 +394,7 @@ describe("SkillRegistry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFiles.clear();
+    mockRmSyncThrowOnceFor = null;
     mockDirs = new Set(["/", "/mock", "/mock/skills", "/mock/user", "/mock/user/data"]);
     mockFetch.mockReset();
     resetSkillRegistry();
@@ -636,6 +640,17 @@ describe("SkillRegistry", () => {
     });
 
     it("installs a skill bundle from a git repository", async () => {
+      const result = await registry.installFromGit("https://github.com/example/skill-repo");
+
+      expect(result.success).toBe(true);
+      expect(result.skill?.id).toBe("git-imported-skill");
+      expect(mockFiles.has(managedPath("git-imported-skill.json"))).toBe(true);
+      expect(mockFiles.has(managedPath("git-imported-skill/SKILL.md"))).toBe(true);
+    });
+
+    it("does not fail a git install when temporary clone cleanup hits EPERM once", async () => {
+      mockRmSyncThrowOnceFor = ".tmp-skill-repo-";
+
       const result = await registry.installFromGit("https://github.com/example/skill-repo");
 
       expect(result.success).toBe(true);

--- a/src/electron/agent/skill-registry.ts
+++ b/src/electron/agent/skill-registry.ts
@@ -388,6 +388,59 @@ export class SkillRegistry {
     return path.join(this.managedSkillsDir, `.tmp-${safeHint}-${nonce}`);
   }
 
+  private makeWritableRecursive(targetPath: string): void {
+    const stat = fs.lstatSync(targetPath);
+    if (stat.isSymbolicLink()) {
+      return;
+    }
+
+    if (typeof fs.chmodSync === "function") {
+      fs.chmodSync(targetPath, stat.isDirectory() ? 0o700 : 0o600);
+    }
+
+    if (!stat.isDirectory()) {
+      return;
+    }
+
+    for (const entry of fs.readdirSync(targetPath, { withFileTypes: true })) {
+      this.makeWritableRecursive(path.join(targetPath, entry.name));
+    }
+  }
+
+  private removeTempDir(tempDir: string): void {
+    if (!fs.existsSync(tempDir)) {
+      return;
+    }
+
+    try {
+      fs.rmSync(tempDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+      });
+      return;
+    } catch (firstError) {
+      try {
+        this.makeWritableRecursive(tempDir);
+        fs.rmSync(tempDir, {
+          recursive: true,
+          force: true,
+          maxRetries: 5,
+          retryDelay: 100,
+        });
+      } catch (retryError) {
+        console.warn(
+          "[SkillRegistry] Failed to clean up temporary skill import directory:",
+          tempDir,
+          retryError instanceof Error ? retryError.message : retryError,
+          "initial error:",
+          firstError instanceof Error ? firstError.message : firstError,
+        );
+      }
+    }
+  }
+
   private isSkillMetadataFile(fileName: string): boolean {
     const lower = fileName.toLowerCase();
     return lower.endsWith(".security.json") || lower === "build-mode.json";
@@ -766,9 +819,7 @@ export class SkillRegistry {
         security: { state: "failed" },
       };
     } finally {
-      if (fs.existsSync(stageDir)) {
-        fs.rmSync(stageDir, { recursive: true, force: true });
-      }
+      this.removeTempDir(stageDir);
     }
   }
 
@@ -1487,9 +1538,7 @@ export class SkillRegistry {
         security: { state: "failed" },
       };
     } finally {
-      if (fs.existsSync(tempDir)) {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
+      this.removeTempDir(tempDir);
     }
   }
 
@@ -1547,9 +1596,7 @@ export class SkillRegistry {
         const skill = this.importSkillBundle(tempDir, normalizedUrl);
         return await this.installImportedSkill(skill, { sourceDir: tempDir, source: "url" });
       } finally {
-        if (fs.existsSync(tempDir)) {
-          fs.rmSync(tempDir, { recursive: true, force: true });
-        }
+        this.removeTempDir(tempDir);
       }
     } catch (error) {
       return {
@@ -1615,9 +1662,7 @@ export class SkillRegistry {
         security: { state: "failed" },
       };
     } finally {
-      if (fs.existsSync(tempDir)) {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
+      this.removeTempDir(tempDir);
     }
   }
 


### PR DESCRIPTION
## Summary
- add resilient cleanup for temporary skill import directories
- retry Windows EPERM cleanup after making files writable
- add regression coverage for git skill installs when temp cleanup fails once

Fixes #91

## Test
- npx vitest run src/electron/agent/__tests__/skill-registry.test.ts