### PR TITLE
Fix custom provider credential normalization

### DIFF
--- a/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
+++ b/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
@@ -201,6 +201,58 @@ describe("LLMProviderFactory custom provider config resolution", () => {
     expect(saveSpy).toHaveBeenCalled();
   });
 
+  it("trims pasted compatible-provider credentials before connection testing", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+      }),
+    } as Response);
+
+    const provider = LLMProviderFactory.createProviderFromConfig({
+      type: "anthropic-compatible",
+      model: " moonshotai/kimi-k2.6:thinking \n",
+      providerApiKey: " nano-key\r\n",
+      providerBaseUrl: " https://nano-gpt.com/api/v1/ \n",
+    } as Any);
+
+    await expect(provider.testConnection()).resolves.toEqual({ success: true });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://nano-gpt.com/api/v1/messages",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-api-key": "nano-key",
+        }),
+      }),
+    );
+
+    fetchSpy.mockClear();
+
+    const openaiCompatibleProvider = LLMProviderFactory.createProviderFromConfig({
+      type: "openai-compatible",
+      model: " openai/gpt-5.2 \n",
+      openaiCompatibleApiKey: " nano-openai-key\r\n",
+      openaiCompatibleBaseUrl: " https://nano-gpt.com/api/v1 \n",
+    } as Any);
+
+    await expect(openaiCompatibleProvider.testConnection()).resolves.toEqual({
+      success: true,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://nano-gpt.com/api/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer nano-openai-key",
+        }),
+      }),
+    );
+  });
+
   it("adds documented Z.AI coding-plan models to partial refresh results", async () => {
     vi.spyOn(LLMProviderFactory, "loadSettings").mockReturnValue({
       providerType: "zai",

--- a/src/electron/agent/llm/provider-factory.ts
+++ b/src/electron/agent/llm/provider-factory.ts
@@ -592,6 +592,61 @@ function normalizeSecret(value?: string): string | undefined {
   return trimmed;
 }
 
+function normalizeOptionalString(value?: string): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function normalizeProviderConfig(config: LLMProviderConfig): LLMProviderConfig {
+  return {
+    ...config,
+    model: config.model.trim(),
+    anthropicApiKey: normalizeSecret(config.anthropicApiKey),
+    awsRegion: normalizeOptionalString(config.awsRegion),
+    awsAccessKeyId: normalizeSecret(config.awsAccessKeyId),
+    awsSecretAccessKey: normalizeSecret(config.awsSecretAccessKey),
+    awsSessionToken: normalizeSecret(config.awsSessionToken),
+    awsProfile: normalizeOptionalString(config.awsProfile),
+    ollamaBaseUrl: normalizeOptionalString(config.ollamaBaseUrl),
+    ollamaApiKey: normalizeSecret(config.ollamaApiKey),
+    geminiApiKey: normalizeSecret(config.geminiApiKey),
+    openrouterApiKey: normalizeSecret(config.openrouterApiKey),
+    openrouterBaseUrl: normalizeOptionalString(config.openrouterBaseUrl),
+    openaiApiKey: normalizeSecret(config.openaiApiKey),
+    openaiAccessToken: normalizeSecret(config.openaiAccessToken),
+    openaiRefreshToken: normalizeSecret(config.openaiRefreshToken),
+    azureApiKey: normalizeSecret(config.azureApiKey),
+    azureEndpoint: normalizeOptionalString(config.azureEndpoint),
+    azureDeployment: normalizeOptionalString(config.azureDeployment),
+    azureApiVersion: normalizeOptionalString(config.azureApiVersion),
+    azureAnthropicApiKey: normalizeSecret(config.azureAnthropicApiKey),
+    azureAnthropicEndpoint: normalizeOptionalString(
+      config.azureAnthropicEndpoint,
+    ),
+    azureAnthropicDeployment: normalizeOptionalString(
+      config.azureAnthropicDeployment,
+    ),
+    azureAnthropicApiVersion: normalizeOptionalString(
+      config.azureAnthropicApiVersion,
+    ),
+    groqApiKey: normalizeSecret(config.groqApiKey),
+    groqBaseUrl: normalizeOptionalString(config.groqBaseUrl),
+    xaiApiKey: normalizeSecret(config.xaiApiKey),
+    xaiBaseUrl: normalizeOptionalString(config.xaiBaseUrl),
+    kimiApiKey: normalizeSecret(config.kimiApiKey),
+    kimiBaseUrl: normalizeOptionalString(config.kimiBaseUrl),
+    piProvider: normalizeOptionalString(config.piProvider),
+    piApiKey: normalizeSecret(config.piApiKey),
+    openaiCompatibleApiKey: normalizeSecret(config.openaiCompatibleApiKey),
+    openaiCompatibleBaseUrl: normalizeOptionalString(
+      config.openaiCompatibleBaseUrl,
+    ),
+    providerApiKey: normalizeSecret(config.providerApiKey),
+    providerBaseUrl: normalizeOptionalString(config.providerBaseUrl),
+  };
+}
+
 function resolveAnthropicCredential(
   anthropic?:
     | LLMSettings["anthropic"]
@@ -1995,6 +2050,7 @@ export class LLMProviderFactory {
    * Create a provider from explicit config
    */
   static createProviderFromConfig(config: LLMProviderConfig): LLMProvider {
+    config = normalizeProviderConfig(config);
     const customEntry = getCustomProviderEntry(config.type);
     if (customEntry) {
       const resolvedType = resolveCustomProviderId(config.type);

--- a/src/electron/ipc/__tests__/llm-settings-save.test.ts
+++ b/src/electron/ipc/__tests__/llm-settings-save.test.ts
@@ -234,6 +234,43 @@ describe("buildSavedLLMSettings", () => {
     });
   });
 
+  it("trims pasted provider credentials before saving", () => {
+    const existingSettings: LLMSettingsData = {
+      providerType: "anthropic-compatible",
+      modelKey: "sonnet-4-5",
+    };
+
+    const validated: LLMSettingsData = {
+      providerType: "anthropic-compatible",
+      modelKey: "sonnet-4-5",
+      openaiCompatible: {
+        apiKey: " nano-openai-key\r\n",
+        baseUrl: " https://nano-gpt.com/api/v1/ ",
+        model: " openai/gpt-5.2 ",
+      },
+      customProviders: {
+        "anthropic-compatible": {
+          apiKey: "\r\nnano-anthropic-key ",
+          baseUrl: " https://nano-gpt.com/api/v1 ",
+          model: "\tmoonshotai/kimi-k2.6:thinking\n",
+        },
+      },
+    };
+
+    const saved = buildSavedLLMSettings(validated, existingSettings);
+
+    expect(saved.openaiCompatible).toMatchObject({
+      apiKey: "nano-openai-key",
+      baseUrl: "https://nano-gpt.com/api/v1/",
+      model: "openai/gpt-5.2",
+    });
+    expect(saved.customProviders?.["anthropic-compatible"]).toMatchObject({
+      apiKey: "nano-anthropic-key",
+      baseUrl: "https://nano-gpt.com/api/v1",
+      model: "moonshotai/kimi-k2.6:thinking",
+    });
+  });
+
   it("persists hidden prompt-caching settings without disturbing provider settings", () => {
     const existingSettings: LLMSettingsData = {
       providerType: "anthropic",

--- a/src/electron/ipc/llm-settings-save.ts
+++ b/src/electron/ipc/llm-settings-save.ts
@@ -13,6 +13,54 @@ function mergeProviderSettings<T extends object>(
   };
 }
 
+function cleanString(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+const PROVIDER_STRING_KEYS = [
+  "apiKey",
+  "subscriptionToken",
+  "baseUrl",
+  "model",
+  "provider",
+  "endpoint",
+  "deployment",
+  "apiVersion",
+  "region",
+  "accessKeyId",
+  "secretAccessKey",
+  "sessionToken",
+  "profile",
+] as const;
+
+function cleanProviderSettings<T extends object>(
+  settings?: T,
+): T | undefined {
+  if (!settings) return undefined;
+  const cleaned = { ...settings };
+  const mutableCleaned = cleaned as Record<string, unknown>;
+  for (const key of PROVIDER_STRING_KEYS) {
+    const value = mutableCleaned[key];
+    if (typeof value === "string") {
+      mutableCleaned[key] = cleanString(value);
+    }
+  }
+  return cleaned;
+}
+
+function cleanCustomProviders(
+  providers?: LLMSettingsData["customProviders"],
+): LLMSettingsData["customProviders"] | undefined {
+  if (!providers) return undefined;
+  const cleaned: NonNullable<LLMSettingsData["customProviders"]> = {};
+  for (const [providerId, providerConfig] of Object.entries(providers)) {
+    cleaned[providerId] = cleanProviderSettings(providerConfig) ?? {};
+  }
+  return cleaned;
+}
+
 function normalizeAzureSettings(
   incoming?: LLMSettingsData["azure"],
   existing?: LLMSettingsData["azure"],
@@ -112,28 +160,45 @@ export function buildSavedLLMSettings(
       ? validated.failoverPrimaryRetryCooldownSeconds
       : existingSettings.failoverPrimaryRetryCooldownSeconds,
     promptCaching: validated.promptCaching ?? existingSettings.promptCaching,
-    anthropic: mergeProviderSettings(validated.anthropic, existingSettings.anthropic),
-    bedrock: mergeProviderSettings(validated.bedrock, existingSettings.bedrock),
-    ollama: mergeProviderSettings(validated.ollama, existingSettings.ollama),
-    gemini: mergeProviderSettings(validated.gemini, existingSettings.gemini),
-    openrouter: mergeProviderSettings(
-      validated.openrouter,
-      existingSettings.openrouter,
+    anthropic: cleanProviderSettings(
+      mergeProviderSettings(validated.anthropic, existingSettings.anthropic),
     ),
-    openai: openaiSettings,
+    bedrock: cleanProviderSettings(
+      mergeProviderSettings(validated.bedrock, existingSettings.bedrock),
+    ),
+    ollama: cleanProviderSettings(
+      mergeProviderSettings(validated.ollama, existingSettings.ollama),
+    ),
+    gemini: cleanProviderSettings(
+      mergeProviderSettings(validated.gemini, existingSettings.gemini),
+    ),
+    openrouter: cleanProviderSettings(
+      mergeProviderSettings(validated.openrouter, existingSettings.openrouter),
+    ),
+    openai: cleanProviderSettings(openaiSettings),
     azure: normalizeAzureSettings(validated.azure, existingSettings.azure),
     azureAnthropic: normalizeAzureAnthropicSettings(
       validated.azureAnthropic,
       existingSettings.azureAnthropic,
     ),
-    groq: mergeProviderSettings(validated.groq, existingSettings.groq),
-    xai: mergeProviderSettings(validated.xai, existingSettings.xai),
-    kimi: mergeProviderSettings(validated.kimi, existingSettings.kimi),
-    openaiCompatible: mergeProviderSettings(
-      validated.openaiCompatible,
-      existingSettings.openaiCompatible,
+    groq: cleanProviderSettings(
+      mergeProviderSettings(validated.groq, existingSettings.groq),
     ),
-    customProviders: validated.customProviders ?? existingSettings.customProviders,
+    xai: cleanProviderSettings(
+      mergeProviderSettings(validated.xai, existingSettings.xai),
+    ),
+    kimi: cleanProviderSettings(
+      mergeProviderSettings(validated.kimi, existingSettings.kimi),
+    ),
+    openaiCompatible: cleanProviderSettings(
+      mergeProviderSettings(
+        validated.openaiCompatible,
+        existingSettings.openaiCompatible,
+      ),
+    ),
+    customProviders: cleanCustomProviders(
+      validated.customProviders ?? existingSettings.customProviders,
+    ),
     imageGeneration: validated.imageGeneration ?? existingSettings.imageGeneration,
     videoGeneration: validated.videoGeneration ?? existingSettings.videoGeneration,
     cachedAnthropicModels: existingSettings.cachedAnthropicModels,


### PR DESCRIPTION
## Summary

Fixes #96.

This normalizes pasted custom-provider credentials and routing fields before testing or saving LLM provider settings. NanoGPT-compatible keys pasted with trailing newlines or spaces were sent to compatible providers verbatim, which can make NanoGPT return `Invalid session` even when the visible key looks correct.

## Changes

- Trim provider API keys, base URLs, model names, and related routing fields before creating LLM providers for connection tests.
- Trim provider settings before persisting LLM configuration so future tests/runs use normalized values.
- Add regression coverage for OpenAI-compatible and Anthropic-compatible custom provider connection tests and saved settings.

## Validation

- `npx vitest run src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts src/electron/ipc/__tests__/llm-settings-save.test.ts`
- `npx tsc -p tsconfig.electron.json`