### PR TITLE
Add Linux server release package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,10 +267,145 @@ jobs:
             gh release upload "${release_tag}" "${artifact}" --repo "${GITHUB_REPOSITORY}" --clobber
           done
 
+  release-linux-server:
+    name: Release Linux server package
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    needs: hardening-release-gate
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Force HTTPS for GitHub git dependencies
+        run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Resolve release metadata
+        id: release_metadata
+        shell: bash
+        run: |
+          npm_version="$(node -p "require('./package.json').version")"
+
+          if [ "${GITHUB_REF_NAME}" != "${npm_version}" ] && [ "${GITHUB_REF_NAME}" != "v${npm_version}" ]; then
+            echo "Tag mismatch: GITHUB_REF_NAME=${GITHUB_REF_NAME} but package.json is ${npm_version}" >&2
+            exit 1
+          fi
+
+          release_tag="v${npm_version}"
+          if [ "${GITHUB_REF_NAME}" = "${npm_version}" ]; then
+            release_tag="v${npm_version}"
+          fi
+
+          echo "npm_version=${npm_version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes from changelog
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const version = process.env.NPM_VERSION;
+          const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+          const marker = `## [${version}]`;
+          const start = changelog.indexOf(marker);
+
+          if (start === -1) {
+            fs.writeFileSync(
+              'release-notes.md',
+              `## ${version}\n\nNo changelog entry found for ${version}.\n`
+            );
+            process.exit(0);
+          }
+
+          const tail = changelog.slice(start + marker.length);
+          const nextMatch = tail.match(/\n## \[/);
+          const end = nextMatch ? start + marker.length + nextMatch.index : changelog.length;
+          const entry = changelog.slice(start, end).trim();
+          fs.writeFileSync('release-notes.md', `${entry}\n`);
+          NODE
+        env:
+          NPM_VERSION: ${{ steps.release_metadata.outputs.npm_version }}
+
+      - name: Prepare draft GitHub release for packaging
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.release_metadata.outputs.release_tag }}"
+          npm_version="${{ steps.release_metadata.outputs.npm_version }}"
+          release_title="Release ${npm_version}"
+
+          if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Found existing release tag: ${release_tag}"
+            gh release edit "${release_tag}" --repo "${GITHUB_REPOSITORY}" --title "${release_title}" --notes-file release-notes.md --draft=true
+          elif gh release create "${release_tag}" --repo "${GITHUB_REPOSITORY}" --target "${GITHUB_SHA}" --title "${release_title}" --notes-file release-notes.md --draft; then
+            echo "Created draft release: ${release_tag}"
+          else
+            echo "Release create failed (likely concurrent create); retrying edit."
+            gh release edit "${release_tag}" --repo "${GITHUB_REPOSITORY}" --title "${release_title}" --notes-file release-notes.md --draft=true
+          fi
+
+      - name: Package Linux server tarball
+        run: npm run package:linux:server
+
+      - name: Smoke test Linux server tarball
+        run: npm run package:linux:server:smoke
+
+      - name: Verify expected Linux server artifacts exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          server_artifacts=(release/cowork-os-server-linux-x64-v*.tar.gz)
+          server_checksums=(release/cowork-os-server-linux-x64-v*.tar.gz.sha256)
+          if [ "${#server_artifacts[@]}" -ne 1 ]; then
+            echo "Expected exactly one Linux server tarball in release/." >&2
+            exit 1
+          fi
+          if [ "${#server_checksums[@]}" -ne 1 ]; then
+            echo "Expected exactly one Linux server checksum in release/." >&2
+            exit 1
+          fi
+          (cd release && sha256sum --check "$(basename "${server_checksums[0]}")")
+          printf 'Linux server artifacts:\n'
+          printf '  %s\n' "${server_artifacts[@]}" "${server_checksums[@]}"
+
+      - name: Upload Linux server release artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          release_tag="${{ steps.release_metadata.outputs.release_tag }}"
+          artifacts=(release/cowork-os-server-linux-x64-v*.tar.gz release/cowork-os-server-linux-x64-v*.tar.gz.sha256)
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No Linux server release artifacts found to upload." >&2
+            exit 1
+          fi
+          for artifact in "${artifacts[@]}"; do
+            echo "Uploading ${artifact}"
+            gh release upload "${release_tag}" "${artifact}" --repo "${GITHUB_REPOSITORY}" --clobber
+          done
+
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-latest
-    needs: release
+    needs:
+      - release
+      - release-linux-server
     timeout-minutes: 45
     steps:
       - name: Checkout code
@@ -301,7 +436,9 @@ jobs:
   publish-github-packages:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
-    needs: release
+    needs:
+      - release
+      - release-linux-server
     timeout-minutes: 45
     steps:
       - name: Checkout code
@@ -344,6 +481,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release
+      - release-linux-server
       - publish-npm
       - publish-github-packages
     timeout-minutes: 15

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -2,6 +2,7 @@
 
 CoWork OS supports **Linux headless/server deployments**. This is intended for:
 
+- Packaged Linux server releases from GitHub Releases
 - VPS installs (systemd)
 - Docker installs (single host)
 - “No desktop UI required” operation
@@ -35,6 +36,7 @@ Pick one of these. They all run the same underlying agent runtime, DB, and setti
 
 | Option | Best For | What You Get | What You Don’t |
 |---|---|---|---|
+| **Packaged server release** | Production VPS installs | Prebuilt Node-only daemon tarball, systemd templates, no source build | Linux x64/glibc only in the first release |
 | **Node-only daemon** (recommended) | VPS/headless | No GUI deps, simplest ops | Desktop-only features (Live Canvas, clipboard, desktop screenshots, etc.) |
 | **Headless Electron daemon** | Max parity with desktop runtime | More desktop parity | Heavier deps (Electron + Xvfb on Linux) |
 | **Docker** (Node-only or Electron) | “Just run it” installs | Easy persistence via volumes | You still access it via Control Plane (web/CLI) |

--- a/docs/vps-linux.md
+++ b/docs/vps-linux.md
@@ -82,7 +82,7 @@ ssh -N -L 28789:127.0.0.1:18789 user@your-vps
 - `http://127.0.0.1:18789/` (or `http://127.0.0.1:28789/` if you used 28789)
 - Paste the Control Plane token printed in step 3
 
-This quick start is great for first run/testing. For always-on production, continue with **Option A (Docker)** or **Option B (Systemd)** below.
+This quick start is great for first run/testing. For always-on production, continue with **Option A (Packaged Server Release)**, **Option B (Docker)**, or **Option C (Systemd from Source)** below.
 
 ### Common First-Run Errors
 
@@ -94,7 +94,69 @@ This quick start is great for first run/testing. For always-on production, conti
   You are likely on an older broken npm publish that missed daemon build artifacts. Upgrade and retry:
   `npm install cowork-os@latest --no-audit --no-fund`
 
-## Option A: Docker (Headless Electron)
+## Option A: Packaged Server Release (Node-Only)
+
+Use this path when you want a GitHub release artifact that does not require cloning the repo or building TypeScript on the server.
+
+1. Install OS deps (Debian/Ubuntu):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  ca-certificates curl tar \
+  python3 make g++
+```
+
+2. Install Node.js 24 if it is not already installed:
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+sudo apt-get install -y nodejs
+node -v
+```
+
+3. Download the Linux server tarball and checksum from the GitHub release:
+
+```bash
+version=0.5.42
+curl -LO "https://github.com/CoWork-OS/CoWork-OS/releases/download/v${version}/cowork-os-server-linux-x64-v${version}.tar.gz"
+curl -LO "https://github.com/CoWork-OS/CoWork-OS/releases/download/v${version}/cowork-os-server-linux-x64-v${version}.tar.gz.sha256"
+sha256sum --check "cowork-os-server-linux-x64-v${version}.tar.gz.sha256"
+```
+
+Replace `0.5.42` with the version you are installing.
+
+4. Install under `/opt/cowork-os`:
+
+```bash
+sudo mkdir -p /opt/cowork-os
+sudo tar -xzf "cowork-os-server-linux-x64-v${version}.tar.gz" -C /opt/cowork-os --strip-components=1
+```
+
+5. Create a dedicated user + data dir:
+
+```bash
+sudo useradd -r -m -s /usr/sbin/nologin cowork || true
+sudo mkdir -p /var/lib/cowork-os /srv/cowork/workspace
+sudo chown -R cowork:cowork /var/lib/cowork-os /srv/cowork/workspace /opt/cowork-os
+```
+
+6. Install the systemd unit + env file templates:
+
+```bash
+sudo cp /opt/cowork-os/deploy/systemd/cowork-os.env.example /etc/cowork-os.env
+sudo $EDITOR /etc/cowork-os.env
+
+sudo cp /opt/cowork-os/deploy/systemd/cowork-os-node.service /etc/systemd/system/cowork-os-node.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now cowork-os-node
+
+sudo journalctl -u cowork-os-node -f
+```
+
+The packaged release uses `bin/coworkd-node.js` by default. It does not launch the desktop UI or require Xvfb.
+
+## Option B: Docker (Headless Electron)
 
 This repo includes a headless Docker image that runs CoWork OS as a daemon.
 
@@ -155,7 +217,7 @@ If you need to print it again later, restart with:
 - `COWORK_PRINT_CONTROL_PLANE_TOKEN=1` (env) or
 - `--print-control-plane-token` (flag)
 
-## Option B: Systemd (Node-Only Daemon)
+## Option C: Systemd from Source (Node-Only Daemon)
 
 This is the simplest non-Docker setup when you don’t want to install Xvfb/Electron GUI deps.
 
@@ -168,7 +230,7 @@ sudo apt-get install -y --no-install-recommends \
   python3 make g++
 ```
 
-2. Install Node.js (22+ recommended) and build CoWork OS:
+2. Install Node.js 24 and build CoWork OS:
 
 ```bash
 git clone https://github.com/CoWork-OS/CoWork-OS.git /opt/cowork-os
@@ -227,7 +289,7 @@ If you don’t need browser automation, you can ignore this and rely on `web_fet
 If you’re running under Docker and want Playwright inside the container, you’ll want a container image that includes
 the required libraries. (We can add an optional “Playwright-ready” Docker profile/image next.)
 
-## Option C: Systemd (Headless Electron)
+## Option D: Systemd from Source (Headless Electron)
 
 This is a good fit when you don’t want Docker.
 
@@ -250,7 +312,7 @@ sudo apt-get install -y --no-install-recommends \
   libexpat1 libglib2.0-0 libsecret-1-0
 ```
 
-2. Install Node.js (22+ recommended) and build CoWork OS:
+2. Install Node.js 24 and build CoWork OS:
 
 ```bash
 git clone https://github.com/CoWork-OS/CoWork-OS.git /opt/cowork-os

--- a/package.json
+++ b/package.json
@@ -106,6 +106,8 @@
     "package:win:x64": "node scripts/run_electron_builder.mjs --win --x64 --publish never && node scripts/release-artifact-names.mjs && node scripts/release-artifact-names.mjs --check",
     "package:mac": "node scripts/package-mac-with-env.mjs",
     "package:mac:unsigned": "cross-env COWORK_MAC_UNSIGNED=1 node scripts/package-mac-with-env.mjs",
+    "package:linux:server": "npm run build:daemon && npm run build:connectors && node scripts/package-linux-server.mjs",
+    "package:linux:server:smoke": "node scripts/smoke-linux-server-package.mjs",
     "fmt": "oxfmt --write src",
     "fmt:check": "oxfmt --check src",
     "lint": "oxlint src -c .oxlintrc.json --tsconfig tsconfig.json",

--- a/scripts/package-linux-server.mjs
+++ b/scripts/package-linux-server.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const RELEASE_DIR = path.join(ROOT, "release");
+const SERVER_DEPENDENCY_EXCLUDES = new Set(["@electron/rebuild"]);
+const REQUIRED_PATHS = [
+  "bin/coworkd-node.js",
+  "bin/coworkctl.js",
+  "dist/daemon/daemon/main.js",
+  "deploy/systemd/cowork-os-node.service",
+  "deploy/systemd/cowork-os.env.example",
+];
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? ROOT,
+    env: options.env ?? process.env,
+    stdio: options.stdio ?? "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) throw result.error;
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status ?? 1}`);
+  }
+
+  return result;
+}
+
+async function exists(targetPath) {
+  try {
+    await fsp.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function copyIfPresent(fromRelative, toRoot) {
+  const from = path.join(ROOT, fromRelative);
+  if (!(await exists(from))) return false;
+  await fsp.cp(from, path.join(toRoot, fromRelative), {
+    recursive: true,
+    force: true,
+    dereference: false,
+  });
+  return true;
+}
+
+function getConnectorPackageNames(pkg) {
+  const buildConnectorsScript = pkg.scripts?.["build:connectors"];
+  if (typeof buildConnectorsScript !== "string" || buildConnectorsScript.length === 0) {
+    throw new Error("Missing package.json scripts.build:connectors; cannot derive server connector package list.");
+  }
+
+  const names = new Set();
+  const connectorPattern = /connectors\/([^/\s"']+)\/tsconfig\.json/g;
+  for (const match of buildConnectorsScript.matchAll(connectorPattern)) {
+    names.add(match[1]);
+  }
+
+  if (names.size === 0) {
+    throw new Error("Could not derive connector package list from package.json scripts.build:connectors.");
+  }
+
+  return [...names].sort();
+}
+
+async function copyConnectorRuntimeFiles(toRoot, connectorPackageNames) {
+  const connectorsRoot = path.join(ROOT, "connectors");
+  if (!(await exists(connectorsRoot))) {
+    throw new Error("Missing connectors directory. Run npm run build:connectors first.");
+  }
+
+  const missing = [];
+  for (const connectorName of connectorPackageNames) {
+    const connectorRoot = path.join(connectorsRoot, connectorName);
+    const packageJsonPath = path.join(connectorRoot, "package.json");
+    const distIndexPath = path.join(connectorRoot, "dist", "index.js");
+
+    if (!(await exists(packageJsonPath))) {
+      missing.push(`${connectorName}/package.json`);
+    }
+    if (!(await exists(distIndexPath))) {
+      missing.push(`${connectorName}/dist/index.js`);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required connector runtime files:\n${missing
+        .map((item) => `  - connectors/${item}`)
+        .join("\n")}\nRun npm run build:connectors first.`
+    );
+  }
+
+  for (const connectorName of connectorPackageNames) {
+    const connectorRoot = path.join(connectorsRoot, connectorName);
+    const targetRoot = path.join(toRoot, "connectors", connectorName);
+    for (const name of ["dist", "README.md", "package.json"]) {
+      const source = path.join(connectorRoot, name);
+      if (await exists(source)) {
+        await fsp.cp(source, path.join(targetRoot, name), {
+          recursive: true,
+          force: true,
+          dereference: false,
+        });
+      }
+    }
+  }
+}
+
+function prunePackageJsonForServer(pkg) {
+  const serverPkg = {
+    name: pkg.name,
+    version: pkg.version,
+    description: pkg.description,
+    license: pkg.license,
+    homepage: pkg.homepage,
+    repository: pkg.repository,
+    bugs: pkg.bugs,
+    overrides: pkg.overrides,
+    bundleDependencies: pkg.bundleDependencies,
+    main: "dist/daemon/daemon/main.js",
+    bin: {
+      coworkctl: "bin/coworkctl.js",
+      "coworkd-node": "bin/coworkd-node.js",
+    },
+    engines: pkg.engines,
+    dependencies: {},
+    optionalDependencies: pkg.optionalDependencies ?? {},
+  };
+
+  for (const [name, version] of Object.entries(pkg.dependencies ?? {})) {
+    if (!SERVER_DEPENDENCY_EXCLUDES.has(name)) {
+      serverPkg.dependencies[name] = version;
+    }
+  }
+
+  return serverPkg;
+}
+
+async function assertElectronBinaryInstalled(packageRoot) {
+  const packageRequire = createRequire(path.join(packageRoot, "package.json"));
+  const electronPath = packageRequire("electron");
+  if (typeof electronPath !== "string" || electronPath.length === 0) {
+    throw new Error("Expected require('electron') to resolve to an Electron binary path.");
+  }
+
+  const stat = await fsp.stat(electronPath).catch(() => null);
+  if (!stat?.isFile()) {
+    throw new Error(`Electron binary was not installed at ${electronPath}.`);
+  }
+}
+
+async function writeInstallNotes(packageRoot, version) {
+  const content = `# CoWork OS Linux Server Package
+
+Version: ${version}
+
+This package runs the Node-only headless daemon. It does not launch the desktop UI or require Xvfb.
+
+Quick start:
+
+\`\`\`bash
+export COWORK_USER_DATA_DIR=/var/lib/cowork-os
+export COWORK_IMPORT_ENV_SETTINGS=1
+export OPENAI_API_KEY=your_key_here
+node bin/coworkd-node.js --print-control-plane-token
+\`\`\`
+
+For an always-on service, use:
+
+- deploy/systemd/cowork-os-node.service
+- deploy/systemd/cowork-os.env.example
+
+See docs/vps-linux.md and docs/self-hosting.md for full setup, SSH tunnel, and Control Plane instructions.
+`;
+
+  await fsp.writeFile(path.join(packageRoot, "INSTALL.md"), content);
+}
+
+async function assertRequiredBuildOutputs() {
+  const missing = [];
+  for (const relativePath of REQUIRED_PATHS) {
+    if (!(await exists(path.join(ROOT, relativePath)))) {
+      missing.push(relativePath);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required files for Linux server package:\n${missing
+        .map((item) => `  - ${item}`)
+        .join("\n")}\nRun npm run build:daemon && npm run build:connectors first.`
+    );
+  }
+}
+
+async function sha256File(filePath) {
+  const hash = createHash("sha256");
+  const stream = fs.createReadStream(filePath);
+  for await (const chunk of stream) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+async function main() {
+  if (process.platform !== "linux" || process.arch !== "x64") {
+    throw new Error("Linux server packages must be built on linux x64 so native modules match the target.");
+  }
+
+  await assertRequiredBuildOutputs();
+
+  const pkg = JSON.parse(await fsp.readFile(path.join(ROOT, "package.json"), "utf8"));
+  const version = pkg.version;
+  const connectorPackageNames = getConnectorPackageNames(pkg);
+  const packageName = `cowork-os-server-linux-x64-v${version}`;
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "cowork-linux-server-package-"));
+  const packageRoot = path.join(tempRoot, packageName);
+
+  try {
+    await fsp.mkdir(packageRoot, { recursive: true });
+
+    await fsp.writeFile(
+      path.join(packageRoot, "package.json"),
+      `${JSON.stringify(prunePackageJsonForServer(pkg), null, 2)}\n`
+    );
+    await copyIfPresent("package-lock.json", packageRoot);
+
+    for (const relativePath of ["README.md", "CHANGELOG.md", "LICENSE"]) {
+      await copyIfPresent(relativePath, packageRoot);
+    }
+
+    for (const relativePath of [
+      "bin/coworkd-node.js",
+      "bin/coworkctl.js",
+      "dist/daemon",
+      "deploy/systemd",
+      "resources",
+      "docs/vps-linux.md",
+      "docs/self-hosting.md",
+      "docs/node-daemon.md",
+      "docs/remote-access.md",
+    ]) {
+      await copyIfPresent(relativePath, packageRoot);
+    }
+
+    await copyConnectorRuntimeFiles(packageRoot, connectorPackageNames);
+    await writeInstallNotes(packageRoot, version);
+
+    await fsp.chmod(path.join(packageRoot, "bin", "coworkd-node.js"), 0o755);
+    await fsp.chmod(path.join(packageRoot, "bin", "coworkctl.js"), 0o755);
+
+    run("npm", ["install", "--omit=dev", "--include=optional", "--ignore-scripts", "--no-audit", "--no-fund"], {
+      cwd: packageRoot,
+    });
+    run(process.execPath, ["node_modules/electron/install.js"], { cwd: packageRoot });
+    await assertElectronBinaryInstalled(packageRoot);
+    run("npm", ["rebuild", "--ignore-scripts=false", "better-sqlite3"], { cwd: packageRoot });
+
+    await fsp.mkdir(RELEASE_DIR, { recursive: true });
+    const tarballPath = path.join(RELEASE_DIR, `${packageName}.tar.gz`);
+    const checksumPath = `${tarballPath}.sha256`;
+
+    await fsp.rm(tarballPath, { force: true });
+    await fsp.rm(checksumPath, { force: true });
+
+    run("tar", ["-czf", tarballPath, "-C", tempRoot, packageName]);
+
+    const checksum = await sha256File(tarballPath);
+    await fsp.writeFile(checksumPath, `${checksum}  ${path.basename(tarballPath)}\n`);
+
+    console.log(`[linux-server-package] Wrote ${tarballPath}`);
+    console.log(`[linux-server-package] Wrote ${checksumPath}`);
+  } finally {
+    await fsp.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(`[linux-server-package] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/scripts/smoke-linux-server-package.mjs
+++ b/scripts/smoke-linux-server-package.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const RELEASE_DIR = path.join(ROOT, "release");
+const REQUIRED_FILES = [
+  "package.json",
+  "INSTALL.md",
+  "bin/coworkd-node.js",
+  "bin/coworkctl.js",
+  "dist/daemon/daemon/main.js",
+  "deploy/systemd/cowork-os-node.service",
+  "deploy/systemd/cowork-os.env.example",
+  "docs/vps-linux.md",
+  "resources/branding/cowork-os-app-logo.png",
+  "resources/persona-templates/software-engineer.json",
+  "node_modules/better-sqlite3/package.json",
+  "node_modules/electron/package.json",
+];
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? ROOT,
+    env: options.env ?? process.env,
+    encoding: "utf8",
+    stdio: options.stdio ?? "pipe",
+    shell: process.platform === "win32",
+  });
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  if (result.error) throw result.error;
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status ?? 1}`);
+  }
+
+  return result;
+}
+
+async function findTarball() {
+  const explicitPath = process.argv[2];
+  if (explicitPath) return path.resolve(explicitPath);
+
+  const names = await fs.readdir(RELEASE_DIR);
+  const candidates = names
+    .filter((name) => /^cowork-os-server-linux-x64-v.+\.tar\.gz$/.test(name))
+    .sort()
+    .reverse();
+
+  if (candidates.length === 0) {
+    throw new Error(`No Linux server tarball found in ${RELEASE_DIR}`);
+  }
+
+  return path.join(RELEASE_DIR, candidates[0]);
+}
+
+async function assertElectronBinaryInstalled(packageRoot) {
+  const packageRequire = createRequire(path.join(packageRoot, "package.json"));
+  const electronPath = packageRequire("electron");
+  if (typeof electronPath !== "string" || electronPath.length === 0) {
+    throw new Error("Expected require('electron') to resolve to an Electron binary path.");
+  }
+
+  const stat = await fs.stat(electronPath).catch(() => null);
+  if (!stat?.isFile()) {
+    throw new Error(`Electron binary was not installed at ${electronPath}.`);
+  }
+
+  await fs.access(electronPath, fsConstants.X_OK);
+}
+
+async function waitForHealth(port, child, timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Daemon exited before health check passed with code ${child.exitCode}`);
+    }
+
+    try {
+      const statusCode = await new Promise((resolve, reject) => {
+        const request = http.get(
+          {
+            hostname: "127.0.0.1",
+            port,
+            path: "/health",
+            timeout: 1500,
+          },
+          (response) => {
+            response.resume();
+            resolve(response.statusCode ?? 0);
+          }
+        );
+        request.on("timeout", () => {
+          request.destroy(new Error("health request timed out"));
+        });
+        request.on("error", reject);
+      });
+
+      if (statusCode >= 200 && statusCode < 300) return;
+      lastError = new Error(`health returned ${statusCode}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`Timed out waiting for /health: ${lastError?.message ?? "unknown error"}`);
+}
+
+async function main() {
+  if (process.platform !== "linux" || process.arch !== "x64") {
+    console.log("[linux-server-smoke] Skipping: smoke test requires linux x64.");
+    return;
+  }
+
+  const tarballPath = await findTarball();
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-linux-server-smoke-"));
+  let daemon = null;
+
+  try {
+    run("tar", ["-xzf", tarballPath, "-C", tempRoot]);
+    const entries = await fs.readdir(tempRoot);
+    const packageRoot = path.join(tempRoot, entries[0]);
+
+    for (const relativePath of REQUIRED_FILES) {
+      await fs.access(path.join(packageRoot, relativePath));
+    }
+
+    run(process.execPath, ["bin/coworkd-node.js", "--help"], { cwd: packageRoot });
+    await assertElectronBinaryInstalled(packageRoot);
+    run(
+      process.execPath,
+      [
+        "-e",
+        "const Database=require('better-sqlite3'); const db=new Database(':memory:'); db.close(); console.log('better-sqlite3 ok')",
+      ],
+      { cwd: packageRoot }
+    );
+
+    const port = 20000 + Math.floor(Math.random() * 20000);
+    const userDataDir = path.join(tempRoot, "data");
+    await fs.mkdir(userDataDir, { recursive: true });
+
+    daemon = spawn(process.execPath, ["bin/coworkd-node.js"], {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        COWORK_USER_DATA_DIR: userDataDir,
+        COWORK_CONTROL_PLANE_HOST: "127.0.0.1",
+        COWORK_CONTROL_PLANE_PORT: String(port),
+        COWORK_IMPORT_ENV_SETTINGS: "0",
+      },
+      stdio: "inherit",
+    });
+
+    await waitForHealth(port, daemon);
+    console.log(`[linux-server-smoke] Health check passed for ${path.basename(tarballPath)}`);
+  } finally {
+    if (daemon && daemon.exitCode === null) {
+      daemon.kill("SIGTERM");
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      if (daemon.exitCode === null) daemon.kill("SIGKILL");
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(`[linux-server-smoke] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Linux x64 server tarball packaging script and smoke test for the Node-only daemon
- publish the tarball and checksum from the release workflow before final release publishing
- document packaged server install flow for VPS/systemd deployments

## Validation
- node --check scripts/package-linux-server.mjs
- node --check scripts/smoke-linux-server-package.mjs
- release workflow YAML parse
- npm run build:daemon
- npm run build:connectors

Closes #99