### PR TITLE
[codex] Add Windows computer use support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ CoWork OS is a local-first desktop runtime and AI workbench for task execution, 
 
 - **Electron main process**: task orchestration, agent runtime, heartbeat orchestration, IPC, and tool execution
 - **React renderer**: desktop UI, Mission Control, task timeline, settings, and monitoring surfaces
-- **Tool and connector layer**: file, shell, browser, web, native integrations, document generation/compilation tools including source-first LaTeX PDF compilation, MCP connectors, remote execution, and **macOS computer use** (`screenshot`, `click`, `type_text`, and related tools) as a governed desktop-GUI lane (helper-targeted permissions, single-session lock, policy-gated routing). See [Computer use (macOS)](computer-use.md).
+- **Tool and connector layer**: file, shell, browser, web, native integrations, document generation/compilation tools including source-first LaTeX PDF compilation, MCP connectors, remote execution, and **computer use** (`screenshot`, `click`, `type_text`, and related tools) as a governed desktop-GUI lane (platform helper, single-session lock, policy-gated routing). See [Computer use](computer-use.md).
 - **Composer mention layer**: the renderer and Electron preload expose a grouped `@` autocomplete for Agents, configured Integrations, and Files. Integration mentions are resolved locally, render as rich chips, persist in task/session metadata, and inject soft routing guidance into the executor without changing permissions or `allowedTools`. See [Composer Mentions](composer-mentions.md).
 - **Message shortcut layer**: the renderer exposes one `/` picker for deterministic app commands and skill-backed workflow shortcuts. Shared app command parsing handles `/schedule`, `/clear`, `/plan`, `/cost`, `/compact`, `/doctor`, and `/undo`; plugin-pack aliases resolve to target skill IDs before generic skill slash execution. See [Message Box Shortcuts](message-box-shortcuts.md).
 - **Chronicle screen-context lane**: desktop-only passive recent-screen capture, local ranking/OCR enrichment, source resolution, provenance-aware `screen_context_resolve` tool exposure, and promotion of task-used observations into workspace-backed `screen_context` evidence plus optional linked background memory generation. See [Chronicle](chronicle.md).
@@ -85,9 +85,9 @@ See [Skills Runtime Model](skills-runtime-model.md) for the detailed contract.
 - `docs/`: product and architecture documentation
 - `.cowork/`: local workspace operating context
 
-## Computer use (macOS)
+## Computer use
 
-Native GUI control is implemented in the main process (`src/electron/computer-use/`, `src/electron/agent/tools/computer-use-tools.ts`) with a persistent helper runtime, helper-targeted permission bootstrap, and a **singleton session** that coordinates single-task ownership plus **Esc** abort. Tool policy and the executor only expose the computer-use lane when **native desktop GUI intent** is detected so routine web and repo work stays on browser and shell paths. Product-level behavior, permissions, and troubleshooting are documented in [Computer use (macOS)](computer-use.md).
+Native GUI control is implemented in the main process (`src/electron/computer-use/`, `src/electron/agent/tools/computer-use-tools.ts`) with a persistent platform helper runtime and a **singleton session** that coordinates single-task ownership plus **Esc** abort. macOS uses helper-targeted permission bootstrap; Windows uses a bundled Win32 helper for visible, non-minimized windows. Tool policy and the executor only expose the computer-use lane when **native desktop GUI intent** is detected so routine web and repo work stays on browser and shell paths. Product-level behavior, permissions, and troubleshooting are documented in [Computer use](computer-use.md).
 
 ## Chronicle
 

--- a/docs/chronicle.md
+++ b/docs/chronicle.md
@@ -185,7 +185,7 @@ Chronicle should be treated as **context evidence**, not as an authority overrid
 
 - [Features](features.md)
 - [Getting Started](getting-started.md)
-- [Computer use (macOS)](computer-use.md)
+- [Computer use](computer-use.md)
 - [Mission Control](mission-control.md)
 - [Workspace Memory Flow](workspace-memory-flow.md)
 - [Operator Runtime Visibility](operator-runtime-visibility.md)

--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -1,8 +1,8 @@
-# Computer use (macOS)
+# Computer use
 
-Computer use lets the agent drive **native macOS applications** through real mouse, keyboard, and screen capture—when integrations, browser automation, and shell are not the right tool for the job.
+Computer use lets the agent drive **native desktop applications** on macOS and Windows through real mouse, keyboard, and screen capture—when integrations, browser automation, and shell are not the right tool for the job.
 
-This page is the **authoritative product guide** for the feature. For a short summary, see [Features → Computer use](features.md#computer-use-macos).
+This page is the **authoritative product guide** for the feature. For a short summary, see [Features → Computer use](features.md#computer-use).
 
 ## What it is for
 
@@ -25,8 +25,9 @@ The planner and tool policy treat the computer-use lane as a **controlled, last-
 
 ## Platform requirements
 
-- **macOS only** today. The computer-use tool family is not available on Windows or Linux builds in the same form.
-- **The bundled helper binary receives macOS permissions** (see below). Granting Accessibility or Screen Recording to Terminal or another helper does not substitute.
+- **macOS and Windows desktop builds** are supported. Linux/headless builds do not expose this tool family.
+- **macOS** uses a bundled Swift helper with Accessibility and Screen Recording permissions.
+- **Windows v1** uses a bundled PowerShell/Win32 helper for visible, non-minimized windows. Some protected or elevated apps may block capture or input unless CoWork is running with comparable privileges.
 
 ## macOS permissions
 
@@ -44,6 +45,17 @@ Two system permissions gate computer use:
 3. After changing **Screen Recording**, **quit and restart CoWork OS** if capture still fails—macOS sometimes caches the old state until restart.
 
 If a tool returns an error mentioning screen capture timeout or permission, re-check Screen Recording for this app and restart.
+
+## Windows behavior
+
+Windows computer use targets one visible, non-minimized top-level window at a time. The helper enumerates native windows, captures the selected window region, and sends mouse/keyboard input through Win32 APIs.
+
+Known v1 limits:
+
+- Minimized windows are not controlled; restore the target window first.
+- Apps running as administrator may require CoWork to run as administrator.
+- Some games, protected apps, or anti-cheat surfaces may block capture or input.
+- If background capture/control is unavailable, actions may briefly use the foreground mouse and keyboard.
 
 ## Session model (one active session)
 
@@ -79,7 +91,7 @@ Key contract details:
 
 ## Related tools: `open_application`
 
-`open_application` can launch macOS apps by name or bundle id. For **native GUI workflows**, policy may allow `open_application` in the same steps as `screenshot`/`click`/`type_text` so the agent can start the target app before driving it. That is separate from **shell**-based AppleScript or one-off scripts: when the goal is **GUI interaction**, the product steers toward the dedicated computer-use tools (and `open_application` when needed) rather than `run_applescript` as a first choice.
+`open_application` can launch native apps by name or bundle id/path where supported. For **native GUI workflows**, policy may allow `open_application` in the same steps as `screenshot`/`click`/`type_text` so the agent can start the target app before driving it. On macOS, that is separate from **shell**-based AppleScript or one-off scripts: when the goal is **GUI interaction**, the product steers toward the dedicated computer-use tools (and `open_application` when needed) rather than `run_applescript` as a first choice.
 
 ## Routing and planner behavior (operator mental model)
 
@@ -96,7 +108,7 @@ Rough order the stack encourages:
 ## Settings checklist
 
 1. **Built-in tools**: Confirm the `computer_use` category is enabled if you want the agent to use this lane at all.
-2. **Permissions**: Accessibility + Screen Recording granted for the helper binary; restart after Screen Recording changes if needed.
+2. **Permissions / platform status**: On macOS, Accessibility + Screen Recording granted for the helper binary; restart after Screen Recording changes if needed. On Windows, confirm the helper is installed and the target window is visible/non-minimized.
 3. **Operational model**: Expect a foreground-first controlled-window loop centered on `screenshot()` and the latest `captureId`.
 4. **Chronicle**: If your goal is contextual screen understanding rather than GUI control, enable **Settings > Memory Hub > Chronicle**, keep the dedicated **Chronicle** built-in tool category enabled, and test `screen_context_resolve` before forcing a computer-use flow.
 
@@ -105,21 +117,21 @@ Rough order the stack encourages:
 Computer use is **high trust**: a mistaken or malicious task could operate any UI your user can reach. Mitigations include:
 
 - Esc abort and single-session sequential execution
-- Helper-targeted permissions with inline bootstrap
+- Helper-targeted permissions with inline bootstrap on macOS; visible-window constraints on Windows
 - Policy that keeps the computer-use lane off the default path unless GUI intent is clear
 - Blocklisted key combinations that could disrupt the session or OS
 
-For how this fits the wider tool-risk model, see [Security guide → Computer use](security-guide.md#computer-use-macos-security).
+For how this fits the wider tool-risk model, see [Security guide → Computer use](security-guide.md#computer-use-security).
 
 ## Troubleshooting
 
 | Symptom | Things to check |
 |---------|------------------|
-| Screenshot or capture errors / timeouts | Screen Recording for the helper path shown in settings; restart app after granting. |
-| Clicks or keys do nothing | Accessibility trust for the helper path shown in settings; no other app stealing focus unexpectedly. |
+| Screenshot or capture errors / timeouts | macOS: Screen Recording for the helper path shown in settings; restart app after granting. Windows: target window visible, non-minimized, and not protected/elevated above CoWork. |
+| Clicks or keys do nothing | macOS: Accessibility trust for the helper path shown in settings. Windows: target app is not elevated/protected and no other app is stealing focus. |
 | Agent uses shell or browser instead of desktop | Task may not read as native GUI; rephrase with explicit app/window/dialog language, or ensure built-in `computer_use` is enabled. |
 | Agent asks for a screenshot when the task is really “what is this on screen?” | This may be a Chronicle case rather than a computer-use case; enable Chronicle and test `screen_context_resolve` with a clear on-screen prompt first. |
-| Permission bootstrap repeats | Re-check that both Accessibility and Screen Recording are granted to the helper binary, not just to CoWork OS or Terminal. |
+| Permission bootstrap repeats | macOS: re-check that both Accessibility and Screen Recording are granted to the helper binary, not just to CoWork OS or Terminal. |
 | Session feels “stuck” | Use **Esc** to abort the computer-use session, then cancel or adjust the task. |
 
 ## Implementation map (for contributors)
@@ -127,7 +139,7 @@ For how this fits the wider tool-risk model, see [Security guide → Computer us
 | Area | Location |
 |------|----------|
 | Tool definitions and execution | `src/electron/agent/tools/computer-use-tools.ts` |
-| Helper runtime + permissions | `src/electron/computer-use/helper-runtime.ts`, `resources/computer-use/bridge.swift` |
+| Helper runtime + providers | `src/electron/computer-use/helper-runtime.ts`, `src/electron/computer-use/provider.ts`, `resources/computer-use/bridge.swift`, `resources/computer-use/bridge.ps1` |
 | Session lifecycle | `src/electron/computer-use/session-manager.ts`, `shortcut-guard.ts` |
 | Policy / routing | `src/electron/agent/tool-policy-engine.ts`, `src/electron/agent/executor.ts` |
 | Settings / IPC | `src/renderer/components/ComputerUseSettings.tsx`, IPC handlers |

--- a/docs/features.md
+++ b/docs/features.md
@@ -119,12 +119,12 @@ CoWork includes `llm-wiki` as a bundled first-class research-vault workflow insp
 
 See [LLM Wiki](llm-wiki.md) for command syntax, layout, modes, and analyzer behavior.
 
-### Computer use (macOS)
+### Computer use
 
-Desktop automation for **native apps** when MCP, browser automation, and shell are not enough. **Full guide:** [Computer use (macOS)](computer-use.md).
+Desktop automation for **native apps** on macOS and Windows when MCP, browser automation, and shell are not enough. **Full guide:** [Computer use](computer-use.md).
 
 - **Session lifecycle**: One active computer-use session at a time; global **Esc** abort; cleanup when the task finishes or the session ends.
-- **Helper-targeted permissions**: Accessibility and Screen Recording are granted to the bundled helper binary through inline bootstrap and surfaced in **Settings → Tools**; restarting the app may be needed after Screen Recording changes.
+- **Platform helpers**: macOS uses helper-targeted Accessibility and Screen Recording permissions; Windows v1 controls visible, non-minimized windows through a bundled Win32 helper.
 - **Built-in tools category**: Enable/disable and priority for the `computer_use` tool family alongside other built-in categories.
 - **Policy & planning**: Tool availability defers the computer-use lane unless the task signals native/desktop GUI intent; executor guidance treats computer use as last resort after integrations, `browser_*`, and shell. For native GUI tasks, routing prefers **`screenshot`**, **`click`**, **`type_text`**, **`keypress`**, and related tools (plus **`open_application`** when launching the app) over **`run_applescript`** / fragile shell GUI hacks.
 - **Tools**: `screenshot`, `click`, `double_click`, `move_mouse`, `drag`, `scroll`, `type_text`, `keypress`, `wait` (with blocklisted dangerous key chords).

--- a/docs/operator-runtime-visibility.md
+++ b/docs/operator-runtime-visibility.md
@@ -77,7 +77,7 @@ Operator Runtime Visibility is an observability and operator-experience upgrade,
 
 CoWork OS still centers on:
 
-- desktop control plane (including **macOS computer use**: governed `screenshot`/`click`/`type_text` sessions with helper-targeted permissions and **Esc** abort — see [Computer use (macOS)](computer-use.md))
+- desktop control plane (including **computer use**: governed `screenshot`/`click`/`type_text` sessions with platform helpers and **Esc** abort — see [Computer use](computer-use.md))
 - channels and inbox
 - devices and remote execution
 - governed automation and approvals
@@ -94,7 +94,7 @@ Chronicle is part of this visibility story:
 
 ## Related docs
 
-- [Computer use (macOS)](computer-use.md)
+- [Computer use](computer-use.md)
 - [Chronicle](chronicle.md)
 - [Features](features.md)
 - [Skills Runtime Model](skills-runtime-model.md)

--- a/docs/security-guide.md
+++ b/docs/security-guide.md
@@ -537,16 +537,17 @@ Ordinary uploaded-PDF reading uses the local `parse_document` extraction path. T
 
 High-autonomy modes and session "Approve all" do not silently bypass this export/egress lane.
 
-The computer-use family (`screenshot`, `click`, `type_text`, `keypress`, and related tools on macOS) is **not** low-risk read-only automation: it can drive arbitrary UI the operator can reach. Treat it as **high trust** and keep the `computer_use` built-in category disabled unless you need it. See [Computer use (macOS)](computer-use.md).
+The computer-use family (`screenshot`, `click`, `type_text`, `keypress`, and related tools on macOS and Windows) is **not** low-risk read-only automation: it can drive arbitrary UI the operator can reach. Treat it as **high trust** and keep the `computer_use` built-in category disabled unless you need it. See [Computer use](computer-use.md).
 
-### Computer use (macOS) security
+### Computer use security
 
 - **Helper-targeted macOS permissions**: Accessibility and Screen Recording are granted to the bundled helper runtime, with inline bootstrap at task time and settings shortcuts for recovery.
+- **Windows visible-window constraint**: Windows v1 only targets visible, non-minimized windows and may require comparable privilege for elevated apps.
 - **Safety UX**: Active sessions use a single-session lock, **Esc** abort, and shortcut guarding to reduce accidental cross-window effects and disruptive global hotkeys during automation.
 - **Tool gating**: Policy defers the computer-use lane unless the task signals **native desktop GUI intent**, so gateway and general tasks default to safer tool lanes.
 - **Key chord blocklist**: Certain OS-level shortcuts are rejected at the tool layer to avoid session or system disruption.
 
-Full operator and troubleshooting guidance: [Computer use (macOS)](computer-use.md).
+Full operator and troubleshooting guidance: [Computer use](computer-use.md).
 
 ### Monotonic Policy Precedence (Deny-Wins)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,13 +50,15 @@ If you see `Killed: 9` during `npm run setup`, macOS terminated a native build d
 npm run setup
 ```
 
-## Computer use (macOS) issues
+## Computer use issues
 
-If **screenshots fail or time out**, grant **Screen Recording** for the helper path shown in **Settings → Tools → Computer use**, then **quit and restart** the app. If **clicks or typing do nothing**, enable **Accessibility** for that helper path the same way.
+If **screenshots fail or time out** on macOS, grant **Screen Recording** for the helper path shown in **Settings → Tools → Computer use**, then **quit and restart** the app. If **clicks or typing do nothing**, enable **Accessibility** for that helper path the same way.
+
+On Windows, keep the target window visible and non-minimized. If the target app is running as administrator, run CoWork with comparable privileges; protected apps may block capture or input.
 
 If the agent **never uses** the computer-use tools, confirm **Settings → Tools → Built-in tools** includes the **computer use** category, and phrase tasks as **native app / window / dialog** work (not pure browser or CLI tasks).
 
-See the full guide: [Computer use (macOS)](computer-use.md).
+See the full guide: [Computer use](computer-use.md).
 
 ## Inbox Agent issues
 
@@ -338,7 +340,7 @@ Look for lines such as:
 - `Chronicle initialized (enabled=true, mode=hybrid)`
 - `screen_context_resolve`
 
-If those never appear, see [Chronicle](chronicle.md) and [Computer use (macOS)](computer-use.md).
+If those never appear, see [Chronicle](chronicle.md) and [Computer use](computer-use.md).
 
 ## Windows native setup fails (`better-sqlite3`)
 

--- a/resources/computer-use/bridge.ps1
+++ b/resources/computer-use/bridge.ps1
@@ -1,0 +1,485 @@
+$ErrorActionPreference = "Stop"
+
+Add-Type -ReferencedAssemblies @("System.Drawing", "System.Windows.Forms") -TypeDefinition @"
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+public static class WinComputerUse {
+  private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct RECT {
+    public int Left;
+    public int Top;
+    public int Right;
+    public int Bottom;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct INPUT {
+    public int type;
+    public InputUnion U;
+  }
+
+  [StructLayout(LayoutKind.Explicit)]
+  private struct InputUnion {
+    [FieldOffset(0)] public MOUSEINPUT mi;
+    [FieldOffset(0)] public KEYBDINPUT ki;
+    [FieldOffset(0)] public HARDWAREINPUT hi;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct MOUSEINPUT {
+    public int dx;
+    public int dy;
+    public uint mouseData;
+    public uint dwFlags;
+    public uint time;
+    public IntPtr dwExtraInfo;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct KEYBDINPUT {
+    public ushort wVk;
+    public ushort wScan;
+    public uint dwFlags;
+    public uint time;
+    public IntPtr dwExtraInfo;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct HARDWAREINPUT {
+    public uint uMsg;
+    public ushort wParamL;
+    public ushort wParamH;
+  }
+
+  [DllImport("user32.dll")] private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+  [DllImport("user32.dll")] private static extern bool IsWindow(IntPtr hWnd);
+  [DllImport("user32.dll")] private static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll")] private static extern bool IsIconic(IntPtr hWnd);
+  [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
+  [DllImport("user32.dll")] private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+  [DllImport("user32.dll")] private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+  [DllImport("user32.dll")] private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+  [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+  [DllImport("user32.dll")] private static extern bool SetCursorPos(int x, int y);
+  [DllImport("user32.dll")] private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+  [DllImport("user32.dll")] private static extern short VkKeyScan(char ch);
+  [DllImport("user32.dll")] private static extern IntPtr GetAncestor(IntPtr hWnd, uint gaFlags);
+
+  private const int INPUT_MOUSE = 0;
+  private const int INPUT_KEYBOARD = 1;
+  private const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+  private const uint MOUSEEVENTF_LEFTUP = 0x0004;
+  private const uint MOUSEEVENTF_RIGHTDOWN = 0x0008;
+  private const uint MOUSEEVENTF_RIGHTUP = 0x0010;
+  private const uint MOUSEEVENTF_MIDDLEDOWN = 0x0020;
+  private const uint MOUSEEVENTF_MIDDLEUP = 0x0040;
+  private const uint MOUSEEVENTF_WHEEL = 0x0800;
+  private const uint MOUSEEVENTF_HWHEEL = 0x1000;
+  private const uint KEYEVENTF_KEYUP = 0x0002;
+  private const uint KEYEVENTF_UNICODE = 0x0004;
+  private const int SW_RESTORE = 9;
+  private const uint GA_ROOT = 2;
+
+  public static Dictionary<string, object> CheckPermissions() {
+    return new Dictionary<string, object> {
+      {"accessibility", true},
+      {"screenRecording", true}
+    };
+  }
+
+  public static List<Dictionary<string, object>> ListApps() {
+    Dictionary<int, Dictionary<string, object>> apps = new Dictionary<int, Dictionary<string, object>>();
+    IntPtr foreground = GetForegroundWindow();
+    EnumWindows(delegate(IntPtr hwnd, IntPtr lparam) {
+      if (!IsCandidateWindow(hwnd)) return true;
+      uint rawPid;
+      GetWindowThreadProcessId(hwnd, out rawPid);
+      int pid = unchecked((int)rawPid);
+      if (pid <= 0 || apps.ContainsKey(pid)) return true;
+      string name = "Unknown App";
+      try { name = Process.GetProcessById(pid).ProcessName; } catch {}
+      apps[pid] = new Dictionary<string, object> {
+        {"appName", name},
+        {"pid", pid},
+        {"isFrontmost", hwnd == foreground}
+      };
+      return true;
+    }, IntPtr.Zero);
+    return new List<Dictionary<string, object>>(apps.Values);
+  }
+
+  public static List<Dictionary<string, object>> ListWindows(int pid) {
+    List<Dictionary<string, object>> windows = new List<Dictionary<string, object>>();
+    IntPtr foreground = GetForegroundWindow();
+    IntPtr main = IntPtr.Zero;
+    try { main = Process.GetProcessById(pid).MainWindowHandle; } catch {}
+    EnumWindows(delegate(IntPtr hwnd, IntPtr lparam) {
+      if (!IsWindow(hwnd)) return true;
+      uint rawPid;
+      GetWindowThreadProcessId(hwnd, out rawPid);
+      if (unchecked((int)rawPid) != pid) return true;
+      RECT rect;
+      if (!GetWindowRect(hwnd, out rect)) return true;
+      int width = Math.Max(0, rect.Right - rect.Left);
+      int height = Math.Max(0, rect.Bottom - rect.Top);
+      if (width <= 0 || height <= 0) return true;
+      string title = GetTitle(hwnd);
+      bool visible = IsWindowVisible(hwnd);
+      bool minimized = IsIconic(hwnd);
+      windows.Add(new Dictionary<string, object> {
+        {"windowId", hwnd.ToInt64()},
+        {"title", title},
+        {"framePoints", new Dictionary<string, object> {
+          {"x", rect.Left},
+          {"y", rect.Top},
+          {"w", width},
+          {"h", height}
+        }},
+        {"scaleFactor", 1},
+        {"isMinimized", minimized},
+        {"isOnscreen", visible && !minimized},
+        {"isMain", main != IntPtr.Zero && hwnd == main},
+        {"isFocused", hwnd == foreground}
+      });
+      return true;
+    }, IntPtr.Zero);
+    return windows;
+  }
+
+  public static Dictionary<string, object> GetFrontmost() {
+    IntPtr hwnd = GetForegroundWindow();
+    if (hwnd == IntPtr.Zero) throw new Exception("window_not_found: No foreground window is available.");
+    uint rawPid;
+    GetWindowThreadProcessId(hwnd, out rawPid);
+    int pid = unchecked((int)rawPid);
+    string appName = "Unknown App";
+    try { appName = Process.GetProcessById(pid).ProcessName; } catch {}
+    return new Dictionary<string, object> {
+      {"appName", appName},
+      {"pid", pid},
+      {"windowTitle", GetTitle(hwnd)},
+      {"windowId", hwnd.ToInt64()}
+    };
+  }
+
+  public static Dictionary<string, object> Screenshot(long windowId) {
+    IntPtr hwnd = new IntPtr(windowId);
+    ActivateWindow(windowId);
+    RequireForeground(hwnd);
+    RECT rect = RequireWindowRect(hwnd);
+    int width = rect.Right - rect.Left;
+    int height = rect.Bottom - rect.Top;
+    using (Bitmap bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb))
+    using (Graphics graphics = Graphics.FromImage(bitmap))
+    using (MemoryStream stream = new MemoryStream()) {
+      graphics.CopyFromScreen(rect.Left, rect.Top, 0, 0, new Size(width, height), CopyPixelOperation.SourceCopy);
+      bitmap.Save(stream, ImageFormat.Png);
+      return new Dictionary<string, object> {
+        {"pngBase64", Convert.ToBase64String(stream.ToArray())},
+        {"width", width},
+        {"height", height},
+        {"scaleFactor", 1}
+      };
+    }
+  }
+
+  public static void ActivateWindow(long windowId) {
+    IntPtr hwnd = new IntPtr(windowId);
+    if (!IsWindow(hwnd)) throw new Exception("window_not_found: The target window no longer exists.");
+    if (IsIconic(hwnd)) ShowWindow(hwnd, SW_RESTORE);
+    SetForegroundWindow(hwnd);
+    for (int i = 0; i < 10; i++) {
+      Thread.Sleep(50);
+      if (IsForegroundWindow(hwnd)) return;
+      SetForegroundWindow(hwnd);
+    }
+    throw new Exception("window_not_foreground: Could not bring the target window to the foreground safely.");
+  }
+
+  public static void ActivateProcess(int pid) {
+    List<Dictionary<string, object>> windows = ListWindows(pid);
+    if (windows.Count == 0) throw new Exception("window_not_found: No visible window is available for the target process.");
+    Dictionary<string, object> chosen = windows[0];
+    foreach (Dictionary<string, object> candidate in windows) {
+      if (candidate.ContainsKey("isFocused") && (bool)candidate["isFocused"]) { chosen = candidate; break; }
+      if (candidate.ContainsKey("isMain") && (bool)candidate["isMain"]) { chosen = candidate; }
+    }
+    ActivateWindow(Convert.ToInt64(chosen["windowId"]));
+  }
+
+  public static void MouseClick(long windowId, double x, double y, string button, int clickCount) {
+    Point p = ToScreenPoint(windowId, x, y);
+    ActivateWindow(windowId);
+    if (button == "back" || button == "forward") {
+      throw new Exception("unsupported_button: Windows computer use does not support back/forward mouse buttons yet.");
+    }
+    SetCursorPos(p.X, p.Y);
+    uint down = MOUSEEVENTF_LEFTDOWN;
+    uint up = MOUSEEVENTF_LEFTUP;
+    if (button == "right") { down = MOUSEEVENTF_RIGHTDOWN; up = MOUSEEVENTF_RIGHTUP; }
+    if (button == "wheel") { down = MOUSEEVENTF_MIDDLEDOWN; up = MOUSEEVENTF_MIDDLEUP; }
+    int count = Math.Max(1, clickCount);
+    for (int i = 0; i < count; i++) {
+      MouseInput(down, 0);
+      MouseInput(up, 0);
+      Thread.Sleep(60);
+    }
+  }
+
+  public static void MouseMove(long windowId, double x, double y) {
+    Point p = ToScreenPoint(windowId, x, y);
+    SetCursorPos(p.X, p.Y);
+  }
+
+  public static void MouseDrag(long windowId, double[][] path) {
+    if (path == null || path.Length < 2) throw new Exception("invalid_args: Drag requires at least two points.");
+    Point first = ToScreenPoint(windowId, path[0][0], path[0][1]);
+    ActivateWindow(windowId);
+    SetCursorPos(first.X, first.Y);
+    MouseInput(MOUSEEVENTF_LEFTDOWN, 0);
+    Thread.Sleep(50);
+    for (int i = 1; i < path.Length; i++) {
+      Point next = ToScreenPoint(windowId, path[i][0], path[i][1]);
+      SetCursorPos(next.X, next.Y);
+      Thread.Sleep(20);
+    }
+    MouseInput(MOUSEEVENTF_LEFTUP, 0);
+  }
+
+  public static void ScrollAtPoint(long windowId, double x, double y, int scrollX, int scrollY) {
+    Point p = ToScreenPoint(windowId, x, y);
+    ActivateWindow(windowId);
+    SetCursorPos(p.X, p.Y);
+    if (scrollY != 0) MouseInput(MOUSEEVENTF_WHEEL, unchecked((uint)(scrollY * 120)));
+    if (scrollX != 0) MouseInput(MOUSEEVENTF_HWHEEL, unchecked((uint)(scrollX * 120)));
+  }
+
+  public static void TypeText(long windowId, string text) {
+    ActivateWindow(windowId);
+    foreach (char ch in text ?? "") {
+      if (ch == '\n') {
+        SendVk(0x0D, false);
+        SendVk(0x0D, true);
+      } else {
+        SendUnicode(ch, false);
+        SendUnicode(ch, true);
+      }
+      Thread.Sleep(2);
+    }
+  }
+
+  public static void KeyPress(long windowId, string keyText, string[] modifiers) {
+    ActivateWindow(windowId);
+    List<ushort> mods = new List<ushort>();
+    if (modifiers != null) {
+      foreach (string mod in modifiers) {
+        ushort vk = ModifierToVk(mod);
+        if (vk != 0) mods.Add(vk);
+      }
+    }
+    ushort key = KeyToVk(keyText);
+    foreach (ushort mod in mods) SendVk(mod, false);
+    SendVk(key, false);
+    SendVk(key, true);
+    for (int i = mods.Count - 1; i >= 0; i--) SendVk(mods[i], true);
+  }
+
+  public static Dictionary<string, object> FalseResult(string reason) {
+    return new Dictionary<string, object> {
+      {"pressed", false},
+      {"focused", false},
+      {"exists", false},
+      {"found", false},
+      {"reason", reason}
+    };
+  }
+
+  private static bool IsCandidateWindow(IntPtr hwnd) {
+    if (!IsWindowVisible(hwnd) || IsIconic(hwnd)) return false;
+    RECT rect;
+    if (!GetWindowRect(hwnd, out rect)) return false;
+    if ((rect.Right - rect.Left) <= 0 || (rect.Bottom - rect.Top) <= 0) return false;
+    return GetTitle(hwnd).Trim().Length > 0;
+  }
+
+  private static string GetTitle(IntPtr hwnd) {
+    StringBuilder sb = new StringBuilder(512);
+    GetWindowText(hwnd, sb, sb.Capacity);
+    return sb.ToString();
+  }
+
+  private static RECT RequireWindowRect(IntPtr hwnd) {
+    if (!IsWindow(hwnd)) throw new Exception("window_not_found: The target window no longer exists.");
+    if (IsIconic(hwnd)) throw new Exception("window_minimized: Windows computer use requires the target window to be visible and non-minimized.");
+    RECT rect;
+    if (!GetWindowRect(hwnd, out rect)) throw new Exception("window_not_found: Could not read the target window bounds.");
+    if ((rect.Right - rect.Left) <= 0 || (rect.Bottom - rect.Top) <= 0) {
+      throw new Exception("screenshot_failed: The target window has empty bounds.");
+    }
+    return rect;
+  }
+
+  private static Point ToScreenPoint(long windowId, double x, double y) {
+    RECT rect = RequireWindowRect(new IntPtr(windowId));
+    return new Point(rect.Left + (int)Math.Round(x), rect.Top + (int)Math.Round(y));
+  }
+
+  private static bool IsForegroundWindow(IntPtr hwnd) {
+    IntPtr foreground = GetForegroundWindow();
+    if (foreground == IntPtr.Zero) return false;
+    if (foreground == hwnd) return true;
+    return GetAncestor(foreground, GA_ROOT) == hwnd;
+  }
+
+  private static void RequireForeground(IntPtr hwnd) {
+    if (!IsForegroundWindow(hwnd)) {
+      throw new Exception("window_not_foreground: Refusing to capture or act because the target window is not foreground.");
+    }
+  }
+
+  private static void MouseInput(uint flags, uint data) {
+    INPUT input = new INPUT();
+    input.type = INPUT_MOUSE;
+    input.U.mi = new MOUSEINPUT { dx = 0, dy = 0, mouseData = data, dwFlags = flags, time = 0, dwExtraInfo = IntPtr.Zero };
+    SendInput(1, new INPUT[] { input }, Marshal.SizeOf(typeof(INPUT)));
+  }
+
+  private static void SendVk(ushort vk, bool up) {
+    INPUT input = new INPUT();
+    input.type = INPUT_KEYBOARD;
+    input.U.ki = new KEYBDINPUT { wVk = vk, wScan = 0, dwFlags = up ? KEYEVENTF_KEYUP : 0, time = 0, dwExtraInfo = IntPtr.Zero };
+    SendInput(1, new INPUT[] { input }, Marshal.SizeOf(typeof(INPUT)));
+  }
+
+  private static void SendUnicode(char ch, bool up) {
+    INPUT input = new INPUT();
+    input.type = INPUT_KEYBOARD;
+    input.U.ki = new KEYBDINPUT { wVk = 0, wScan = ch, dwFlags = KEYEVENTF_UNICODE | (up ? KEYEVENTF_KEYUP : 0), time = 0, dwExtraInfo = IntPtr.Zero };
+    SendInput(1, new INPUT[] { input }, Marshal.SizeOf(typeof(INPUT)));
+  }
+
+  private static ushort ModifierToVk(string key) {
+    string lower = (key ?? "").Trim().ToLowerInvariant();
+    if (lower == "ctrl" || lower == "control") return 0x11;
+    if (lower == "shift") return 0x10;
+    if (lower == "alt" || lower == "option") return 0x12;
+    if (lower == "win" || lower == "windows" || lower == "cmd" || lower == "command") return 0x5B;
+    return 0;
+  }
+
+  private static ushort KeyToVk(string key) {
+    string lower = (key ?? "").Trim().ToLowerInvariant();
+    if (lower == "return" || lower == "enter") return 0x0D;
+    if (lower == "escape" || lower == "esc") return 0x1B;
+    if (lower == "tab") return 0x09;
+    if (lower == "space") return 0x20;
+    if (lower == "backspace") return 0x08;
+    if (lower == "delete") return 0x2E;
+    if (lower == "up") return 0x26;
+    if (lower == "down") return 0x28;
+    if (lower == "left") return 0x25;
+    if (lower == "right") return 0x27;
+    if (lower == "home") return 0x24;
+    if (lower == "end") return 0x23;
+    if (lower == "pageup") return 0x21;
+    if (lower == "pagedown") return 0x22;
+    if (lower.Length >= 2 && lower[0] == 'f') {
+      int n;
+      if (Int32.TryParse(lower.Substring(1), out n) && n >= 1 && n <= 24) return (ushort)(0x70 + n - 1);
+    }
+    if (lower.Length == 1) {
+      char ch = lower[0];
+      if (ch >= 'a' && ch <= 'z') return (ushort)Char.ToUpperInvariant(ch);
+      if (ch >= '0' && ch <= '9') return (ushort)ch;
+      short vk = VkKeyScan(ch);
+      if (vk != -1) return (ushort)(vk & 0xff);
+    }
+    throw new Exception("invalid_args: Could not resolve key '" + key + "'.");
+  }
+}
+"@
+
+function Write-BridgeResponse {
+  param(
+    [string]$Id,
+    [bool]$Ok,
+    [object]$Result,
+    [string]$Message,
+    [string]$Code
+  )
+
+  if ($Ok) {
+    $payload = @{ id = $Id; ok = $true; result = $Result }
+  } else {
+    $payload = @{ id = $Id; ok = $false; error = @{ message = $Message; code = $Code } }
+  }
+  [Console]::Out.WriteLine(($payload | ConvertTo-Json -Compress -Depth 12))
+  [Console]::Out.Flush()
+}
+
+function Get-ErrorCode {
+  param([string]$Message)
+  if ($Message -match "(^|[^a-z_])([a-z]+(?:_[a-z]+)+):") { return $Matches[2] }
+  return "internal_error"
+}
+
+while ($true) {
+  $line = [Console]::In.ReadLine()
+  if ($null -eq $line) { break }
+  if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+  $id = "invalid"
+  try {
+    $request = $line | ConvertFrom-Json
+    if ($request.id) { $id = [string]$request.id }
+    switch ([string]$request.cmd) {
+      "checkPermissions" { $result = [WinComputerUse]::CheckPermissions() }
+      "openPermissionPane" { $result = @{ opened = $false; reason = "Windows does not expose macOS-style computer-use permission panes." } }
+      "listApps" { $result = [WinComputerUse]::ListApps() }
+      "listWindows" { $result = [WinComputerUse]::ListWindows([int]$request.pid) }
+      "getFrontmost" { $result = [WinComputerUse]::GetFrontmost() }
+      "screenshot" { $result = [WinComputerUse]::Screenshot([long]$request.windowId) }
+      "activateApp" { [WinComputerUse]::ActivateProcess([int]$request.pid); $result = @{} }
+      "raiseWindow" { [WinComputerUse]::ActivateWindow([long]$request.windowId); $result = @{} }
+      "unminimizeWindow" { [WinComputerUse]::ActivateWindow([long]$request.windowId); $result = @{} }
+      "mouseClick" { [WinComputerUse]::MouseClick([long]$request.windowId, [double]$request.x, [double]$request.y, [string]$request.button, [int]$request.clickCount); $result = @{} }
+      "mouseMove" { [WinComputerUse]::MouseMove([long]$request.windowId, [double]$request.x, [double]$request.y); $result = @{} }
+      "mouseDrag" {
+        $points = @()
+        foreach ($point in @($request.path)) {
+          $points += ,([double[]]@([double]$point.x, [double]$point.y))
+        }
+        [WinComputerUse]::MouseDrag([long]$request.windowId, [double[][]]$points)
+        $result = @{}
+      }
+      "scrollAtPoint" { [WinComputerUse]::ScrollAtPoint([long]$request.windowId, [double]$request.x, [double]$request.y, [int]$request.scrollX, [int]$request.scrollY); $result = @{} }
+      "typeText" { [WinComputerUse]::TypeText([long]$request.windowId, [string]$request.text); $result = @{} }
+      "keyPress" { [WinComputerUse]::KeyPress([long]$request.windowId, [string]$request.keyText, [string[]]@($request.modifiers)); $result = @{} }
+      "axPressAtPoint" { $result = [WinComputerUse]::FalseResult("Windows provider uses SendInput for click actions.") }
+      "axFocusAtPoint" { $result = [WinComputerUse]::FalseResult("Windows provider uses SendInput for focus actions.") }
+      "axDescribeAtPoint" { $result = @{} }
+      "axFindTextInput" { $result = [WinComputerUse]::FalseResult("Windows UI Automation text targeting is not available in this helper path.") }
+      "axFocusTextInput" { $result = [WinComputerUse]::FalseResult("Windows UI Automation text targeting is not available in this helper path.") }
+      "axFindFocusableElement" { $result = [WinComputerUse]::FalseResult("Windows UI Automation focus targeting is not available in this helper path.") }
+      "axFindActionableElement" { $result = [WinComputerUse]::FalseResult("Windows UI Automation action targeting is not available in this helper path.") }
+      "focusedElement" { $result = [WinComputerUse]::FalseResult("Windows provider types through the active window focus.") }
+      "setValue" { $result = @{} }
+      default { throw "unknown_command: Unknown command '$($request.cmd)'" }
+    }
+    Write-BridgeResponse -Id $id -Ok $true -Result $result
+  } catch {
+    $message = $_.Exception.Message
+    Write-BridgeResponse -Id $id -Ok $false -Message $message -Code (Get-ErrorCode $message)
+  }
+}

--- a/src/electron/agent/__tests__/tool-policy-engine.test.ts
+++ b/src/electron/agent/__tests__/tool-policy-engine.test.ts
@@ -133,6 +133,14 @@ describe("evaluateToolAvailability computer_use", () => {
     expect(r.decision).toBe("allow");
   });
 
+  it("allows computer-use tools for Windows native app prompts", () => {
+    const r = evaluateToolAvailability("click", {
+      ...baseCtx,
+      taskText: "Open Notepad on Windows and click inside the editor.",
+    });
+    expect(r.decision).toBe("allow");
+  });
+
   it("still allows click when browser-ish text appears elsewhere in the prompt context", () => {
     const r = evaluateToolAvailability("click", {
       ...baseCtx,

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -21987,7 +21987,7 @@ ${this.getPlanningStepCountRule()}
 
 RESILIENCE RULES:
 - Do not stop at "cannot be done" when fallbacks exist.
-- Fallback chain: available tools -> custom skills -> MCP/API connectors -> browser automation (browser_*) for websites -> run_command for CLI/local commands -> screenshot/click/type_text/keypress and related computer-use tools for native macOS GUI tasks -> run_applescript only as an explicit AppleScript path or low-level fallback.
+- Fallback chain: available tools -> custom skills -> MCP/API connectors -> browser automation (browser_*) for websites -> run_command for CLI/local commands -> screenshot/click/type_text/keypress and related computer-use tools for native desktop GUI tasks -> run_applescript only as an explicit AppleScript path or low-level fallback.
 - Ask the user only when blocked by permissions/credentials/policy or missing required path after search.
 
 WORKSPACE + PATH DISCOVERY:

--- a/src/electron/agent/tool-policy-engine.ts
+++ b/src/electron/agent/tool-policy-engine.ts
@@ -204,7 +204,7 @@ const SYSTEM_INTENT_PATTERN =
   /\b(clipboard|screenshot|finder|application|open app|open url|environment variable|env var|applescript|desktop automation)\b/i;
 /** Native / full-desktop control — last resort after MCP, browser, and shell. */
 const COMPUTER_USE_INTENT_PATTERN =
-  /\b(computer use|desktop automation|native app|native macos|macos app|control my (mac|screen|desktop)|not in browser|gui only|ios simulator|simulator|xcode|system preferences|menu bar)\b/i;
+  /\b(computer use|desktop automation|native app|native desktop|native macos|macos app|native windows|windows app|control my (mac|pc|screen|desktop)|not in browser|gui only|ios simulator|simulator|xcode|system preferences|system settings|windows settings|menu bar|taskbar|explorer|notepad|calculator|installer dialog)\b/i;
 const SCREEN_CONTEXT_INTENT_PATTERN =
   /\b(failing one|on screen|latest draft|same doc|what is this|why is this failing|screen context|right side|left side|top right|top left|bottom right|bottom left)\b/i;
 const EXPLICIT_APPLESCRIPT_INTENT_PATTERN =

--- a/src/electron/agent/tools/__tests__/computer-use-platform.test.ts
+++ b/src/electron/agent/tools/__tests__/computer-use-platform.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ComputerUseTools } from "../computer-use-tools";
+import { setComputerUseProviderFactoryForTesting } from "../../../computer-use/provider";
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+  setComputerUseProviderFactoryForTesting(null);
+});
+
+describe("ComputerUseTools platform exposure", () => {
+  it("exposes computer-use tools on macOS", () => {
+    setPlatform("darwin");
+    const tools = ComputerUseTools.getToolDefinitions({ headless: false }).map((tool) => tool.name);
+    expect(tools).toContain("screenshot");
+    expect(tools).toContain("click");
+    expect(tools).toContain("type_text");
+  });
+
+  it("exposes computer-use tools on Windows", () => {
+    setPlatform("win32");
+    const tools = ComputerUseTools.getToolDefinitions({ headless: false }).map((tool) => tool.name);
+    expect(tools).toContain("screenshot");
+    expect(tools).toContain("click");
+    expect(tools).toContain("type_text");
+  });
+
+  it("hides computer-use tools in headless mode", () => {
+    setPlatform("win32");
+    expect(ComputerUseTools.getToolDefinitions({ headless: true })).toEqual([]);
+  });
+
+  it("hides computer-use tools on unsupported desktop platforms", () => {
+    setPlatform("linux");
+    expect(ComputerUseTools.getToolDefinitions({ headless: false })).toEqual([]);
+  });
+
+  it("resolves the helper through the provider interface", async () => {
+    setPlatform("win32");
+    const provider = {
+      ensureReadyWithInteractivePermissions: vi.fn().mockResolvedValue(undefined),
+      getFrontmost: vi.fn().mockResolvedValue({ appName: "Notepad", pid: 42, windowId: 100 }),
+      listWindows: vi.fn().mockResolvedValue([
+        {
+          windowId: 100,
+          title: "Untitled - Notepad",
+          framePoints: { x: 0, y: 0, w: 300, h: 200 },
+          scaleFactor: 1,
+          isMinimized: false,
+          isOnscreen: true,
+          isMain: true,
+          isFocused: true,
+        },
+      ]),
+      unminimizeWindow: vi.fn().mockResolvedValue(undefined),
+      activateApp: vi.fn().mockResolvedValue(undefined),
+      raiseWindow: vi.fn().mockResolvedValue(undefined),
+      screenshot: vi.fn().mockResolvedValue({
+        pngBase64: Buffer.from("png").toString("base64"),
+        width: 300,
+        height: 200,
+        scaleFactor: 1,
+      }),
+    };
+    setComputerUseProviderFactoryForTesting(() => provider as Any);
+    const daemon = { logEvent: vi.fn() };
+    const tools = new ComputerUseTools({ id: "w", name: "W", path: "/tmp", createdAt: 0, permissions: {} } as Any, daemon as Any, "task-1");
+
+    await tools.screenshot();
+
+    expect(provider.ensureReadyWithInteractivePermissions).toHaveBeenCalled();
+    expect(provider.screenshot).toHaveBeenCalledWith(100);
+  });
+});

--- a/src/electron/agent/tools/builtin-settings.ts
+++ b/src/electron/agent/tools/builtin-settings.ts
@@ -119,7 +119,7 @@ const DEFAULT_SETTINGS: BuiltinToolsSettings = {
     computer_use: {
       enabled: true,
       priority: "normal",
-      description: "Computer use tools (native mouse, keyboard, screenshot control — macOS only)",
+      description: "Computer use tools (native mouse, keyboard, screenshot control — macOS and Windows)",
     },
   },
   toolOverrides: {},

--- a/src/electron/agent/tools/computer-use-tools.ts
+++ b/src/electron/agent/tools/computer-use-tools.ts
@@ -3,8 +3,8 @@ import { Workspace } from "../../../shared/types";
 import { AgentDaemon } from "../daemon";
 import { LLMTool } from "../llm/types";
 import { ComputerUseSessionManager } from "../../computer-use/session-manager";
+import { getComputerUseProvider, type ComputerUseProvider } from "../../computer-use/provider";
 import {
-  ComputerUseHelperRuntime,
   type ComputerUseHelperApp,
   type ComputerUseHelperKeypressSpec,
   type ComputerUseHelperMouseButton,
@@ -26,6 +26,9 @@ const BLOCKED_KEY_COMBOS = new Set([
   "command+space",
   "cmd+q",
   "command+q",
+  "alt+f4",
+  "l+win",
+  "l+windows",
   "cmd+option+esc",
   "command+option+escape",
   "ctrl+alt+delete",
@@ -228,6 +231,10 @@ const MAC_VIRTUAL_KEY_CODES: Record<string, number> = {
 };
 
 function parseKeypressSpec(pid: number, keys: string[]): ComputerUseHelperKeypressSpec {
+  if (process.platform === "win32") {
+    return parseWindowsKeypressSpec(pid, keys);
+  }
+
   const modifiers: string[] = [];
   let keyText: string | null = null;
   let keyCode: number | null = null;
@@ -325,6 +332,43 @@ function parseKeypressSpec(pid: number, keys: string[]): ComputerUseHelperKeypre
   };
 }
 
+function parseWindowsKeypressSpec(pid: number, keys: string[]): ComputerUseHelperKeypressSpec {
+  const modifiers: string[] = [];
+  let keyText: string | null = null;
+
+  for (const key of keys) {
+    const trimmed = key.trim();
+    const lower = trimmed.toLowerCase();
+    if (lower === "cmd" || lower === "command" || lower === "win" || lower === "windows") {
+      modifiers.push("windows");
+      continue;
+    }
+    if (lower === "ctrl" || lower === "control") {
+      modifiers.push("control");
+      continue;
+    }
+    if (lower === "alt" || lower === "option") {
+      modifiers.push("alt");
+      continue;
+    }
+    if (lower === "shift") {
+      modifiers.push("shift");
+      continue;
+    }
+    keyText = trimmed;
+  }
+
+  if (!keyText) {
+    throw new Error(`Could not resolve key combination: ${keys.join("+")}`);
+  }
+
+  return {
+    pid,
+    keyText,
+    ...(modifiers.length > 0 ? { modifiers } : {}),
+  };
+}
+
 /**
  * Pi-style computer-use tools:
  * - stateful target window chosen by screenshot()
@@ -351,8 +395,8 @@ export class ComputerUseTools {
     this.workspace = workspace;
   }
 
-  private helper(): ComputerUseHelperRuntime {
-    return ComputerUseHelperRuntime.getInstance();
+  private helper(): ComputerUseProvider {
+    return getComputerUseProvider();
   }
 
   private session(): ComputerUseSessionManager {
@@ -367,8 +411,8 @@ export class ComputerUseTools {
   }
 
   private async ensureReady(): Promise<void> {
-    if (process.platform !== "darwin") {
-      throw new Error("Computer use is only supported on macOS.");
+    if (process.platform !== "darwin" && process.platform !== "win32") {
+      throw new Error("Computer use is only supported on macOS and Windows desktop builds.");
     }
     this.session().acquire(this.taskId, this.daemon);
     this.session().checkNotAborted();
@@ -967,7 +1011,7 @@ export class ComputerUseTools {
       if (focused.exists && focused.canSetValue && !focused.isSecure && focused.elementRef) {
         await this.helper().setValue(focused.elementRef, text);
       } else {
-        let focusedTextInput: Awaited<ReturnType<ComputerUseHelperRuntime["axFocusTextInput"]>>;
+        let focusedTextInput: Awaited<ReturnType<ComputerUseProvider["axFocusTextInput"]>>;
         try {
           focusedTextInput = await this.helper().axFocusTextInput({
             pid: target.pid,
@@ -984,7 +1028,7 @@ export class ComputerUseTools {
         ) {
           await this.helper().setValue(focusedTextInput.elementRef, text);
         } else {
-          await this.helper().typeText(text, target.pid);
+          await this.helper().typeText(text, target.pid, target.windowId);
         }
       }
       return await this.captureTarget("type_text");
@@ -1016,7 +1060,7 @@ export class ComputerUseTools {
     });
     await this.bringTargetToFront(target);
     try {
-      await this.helper().pressKeys(parseKeypressSpec(target.pid, keys));
+      await this.helper().pressKeys({ ...parseKeypressSpec(target.pid, keys), windowId: target.windowId });
       return await this.captureTarget("keypress");
     } catch (error) {
       this.daemon.logEvent(this.taskId, "tool_error", {
@@ -1041,7 +1085,7 @@ export class ComputerUseTools {
   }
 
   static getToolDefinitions(options?: { headless?: boolean }): LLMTool[] {
-    if (options?.headless || process.platform !== "darwin") {
+    if (options?.headless || (process.platform !== "darwin" && process.platform !== "win32")) {
       return [];
     }
 
@@ -1049,7 +1093,7 @@ export class ComputerUseTools {
       {
         name: "screenshot",
         description:
-          "Capture the current controlled window in a native macOS app. Call this first. " +
+          "Capture the current controlled window in a native desktop app. Call this first. " +
           "Passing app and/or windowTitle retargets control to that window. Returns a fresh captureId and PNG image.",
         input_schema: {
           type: "object",
@@ -1187,7 +1231,7 @@ export class ComputerUseTools {
       {
         name: "keypress",
         description:
-          "Send a key or key chord to the current controlled window. Modifier keys: cmd/command, ctrl/control, alt/option, shift. Returns a fresh screenshot.",
+          "Send a key or key chord to the current controlled window. Modifier keys: cmd/command on macOS, win/windows on Windows, ctrl/control, alt/option, shift. Returns a fresh screenshot.",
         input_schema: {
           type: "object",
           properties: {

--- a/src/electron/agent/tools/registry.ts
+++ b/src/electron/agent/tools/registry.ts
@@ -1232,7 +1232,7 @@ export class ToolRegistry {
       });
     }
 
-    // Computer use tools (native mouse/keyboard/screenshot — macOS only, not headless)
+    // Computer use tools (native mouse/keyboard/screenshot — desktop platforms only, not headless)
     allTools.push(...ComputerUseTools.getToolDefinitions({ headless }));
 
     // Batch image processing tools — only when image generation is available

--- a/src/electron/agent/tools/tool-prompting.ts
+++ b/src/electron/agent/tools/tool-prompting.ts
@@ -105,15 +105,15 @@ const TOOL_PROMPT_METADATA_BY_NAME: Record<string, LLMToolPromptMetadata> = {
   })),
   run_command: createPromptMetadata(() => ({
     appendDescription:
-      "Use for shell, test, build, packaging, git, and local CLI work. Prefer this over browser or web tools for local execution. Do not use this for native macOS GUI control when screenshot/click/type_text/keypress and related computer-use tools are available. If a test or build fails, inspect the output, fix the cause, then rerun.",
+      "Use for shell, test, build, packaging, git, and local CLI work. Prefer this over browser or web tools for local execution. Do not use this for native desktop GUI control when screenshot/click/type_text/keypress and related computer-use tools are available. If a test or build fails, inspect the output, fix the cause, then rerun.",
     compactDescription:
       "Use for shell, test, build, git, and local CLI execution. Do not use it for native GUI control when computer-use tools fit.",
   })),
   screenshot: createPromptMetadata(() => ({
     appendDescription:
-      "For native macOS computer use, call this first and rely on the latest screenshot only. Each successful computer-use action returns a fresh screenshot state; do not keep acting from stale captures or switch to run_command/run_applescript unless the computer-use lane is explicitly unavailable.",
+      "For native desktop computer use, call this first and rely on the latest screenshot only. Each successful computer-use action returns a fresh screenshot state; do not keep acting from stale captures or switch to run_command/run_applescript unless the computer-use lane is explicitly unavailable.",
     compactDescription:
-      "For native macOS computer use, call this first and always use the newest screenshot state.",
+      "For native desktop computer use, call this first and always use the newest screenshot state.",
   })),
   click: createPromptMetadata(() => ({
     appendDescription:

--- a/src/electron/computer-use/__tests__/helper-runtime-windows.test.ts
+++ b/src/electron/computer-use/__tests__/helper-runtime-windows.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComputerUseHelperRuntime } from "../helper-runtime";
+
+const existsSyncMock = vi.hoisted(() => vi.fn());
+const readFileMock = vi.hoisted(() => vi.fn());
+const writeFileMock = vi.hoisted(() => vi.fn());
+const mkdirMock = vi.hoisted(() => vi.fn());
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    existsSync: existsSyncMock,
+  };
+});
+
+vi.mock("fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("fs/promises")>("fs/promises");
+  return {
+    ...actual,
+    mkdir: mkdirMock,
+    readFile: readFileMock,
+    writeFile: writeFileMock,
+  };
+});
+
+vi.mock("../utils/user-data-dir", () => ({
+  getUserDataDir: () => "/tmp/cowork-user-data",
+}));
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+describe("ComputerUseHelperRuntime Windows helper integrity", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setPlatform("win32");
+    ComputerUseHelperRuntime.resetForTesting();
+    mkdirMock.mockResolvedValue(undefined);
+    writeFileMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    ComputerUseHelperRuntime.resetForTesting();
+  });
+
+  it("rewrites the installed helper when its content hash differs from the bundled source", async () => {
+    const runtime = ComputerUseHelperRuntime.getInstance();
+    const sourcePath = "/repo/resources/computer-use/bridge.ps1";
+    const helperPath = runtime.getHelperPath();
+
+    existsSyncMock.mockImplementation((target: unknown) => {
+      const value = String(target);
+      return value.endsWith("resources/computer-use/bridge.ps1") || value === helperPath || value.endsWith("bridge.sha256");
+    });
+    readFileMock.mockImplementation(async (target: unknown) => {
+      const value = String(target);
+      if (value.endsWith("resources/computer-use/bridge.ps1")) return Buffer.from("bundled-helper");
+      if (value === helperPath) return Buffer.from("tampered-helper");
+      if (value.endsWith("bridge.sha256")) {
+        return "a9625693407f1961dce752a588924d898995be6d58cf164d52516fcc32bfb005\n";
+      }
+      throw new Error(`Unexpected read: ${value}`);
+    });
+
+    await (runtime as { ensureHelperInstalled: () => Promise<void> }).ensureHelperInstalled();
+
+    expect(writeFileMock).toHaveBeenCalledWith(helperPath, Buffer.from("bundled-helper"), "utf8");
+  });
+});

--- a/src/electron/computer-use/helper-runtime.ts
+++ b/src/electron/computer-use/helper-runtime.ts
@@ -5,16 +5,18 @@ import { access, chmod, mkdir, readFile, writeFile } from "fs/promises";
 import { constants as fsConstants } from "fs";
 import * as path from "path";
 import { getUserDataDir } from "../utils/user-data-dir";
+import type { ComputerUseProvider } from "./provider";
 
 type Any = any; // oxlint-disable-line typescript-eslint/no-explicit-any
 
 const HELPER_DIR = path.join(getUserDataDir(), "computer-use-helper");
-const HELPER_PATH = path.join(HELPER_DIR, "bridge");
+const HELPER_PATH = path.join(HELPER_DIR, process.platform === "win32" ? "bridge.ps1" : "bridge");
 const HELPER_STAMP_PATH = path.join(HELPER_DIR, "bridge.sha256");
 const HELPER_SETUP_TIMEOUT_MS = 60_000;
 const HELPER_COMMAND_TIMEOUT_MS = 20_000;
 
 export interface ComputerUseHelperStatus {
+  platform: NodeJS.Platform;
   helperPath: string;
   sourcePath: string | null;
   installed: boolean;
@@ -144,7 +146,10 @@ function normalizeError(error: unknown): Error {
 export function isRecoverableScreenshotError(error: unknown): boolean {
   return (
     error instanceof HelperCommandError &&
-    (error.code === "screenshot_timeout" || error.code === "window_not_found" || error.code === "screenshot_failed")
+    (error.code === "screenshot_timeout" ||
+      error.code === "window_not_found" ||
+      error.code === "window_not_foreground" ||
+      error.code === "screenshot_failed")
   );
 }
 
@@ -159,24 +164,28 @@ function isPackagedElectronApp(): boolean {
 }
 
 function getBundledHelperSourcePath(): string | null {
-  if (process.platform !== "darwin") return null;
+  if (process.platform !== "darwin" && process.platform !== "win32") return null;
+  const fileName = process.platform === "win32" ? "bridge.ps1" : "bridge.swift";
   const candidates: string[] = [];
   if (
     isPackagedElectronApp() &&
     typeof process.resourcesPath === "string" &&
     process.resourcesPath.length > 0
   ) {
-    candidates.push(path.join(process.resourcesPath, "computer-use", "bridge.swift"));
+    candidates.push(path.join(process.resourcesPath, "computer-use", fileName));
   }
   if (typeof process.cwd === "function") {
-    candidates.push(path.join(process.cwd(), "resources", "computer-use", "bridge.swift"));
+    candidates.push(path.join(process.cwd(), "resources", "computer-use", fileName));
   }
-  candidates.push(path.resolve(__dirname, "../../../resources/computer-use/bridge.swift"));
-  candidates.push(path.resolve(__dirname, "../../../../resources/computer-use/bridge.swift"));
+  candidates.push(path.resolve(__dirname, "../../../resources/computer-use", fileName));
+  candidates.push(path.resolve(__dirname, "../../../../resources/computer-use", fileName));
   return candidates.find((candidate) => existsSync(candidate)) ?? null;
 }
 
 async function isExecutable(filePath: string): Promise<boolean> {
+  if (process.platform === "win32") {
+    return existsSync(filePath);
+  }
   try {
     await access(filePath, fsConstants.X_OK);
     return true;
@@ -199,7 +208,14 @@ function sha256(buffer: Buffer): string {
   return createHash("sha256").update(buffer).digest("hex");
 }
 
-export class ComputerUseHelperRuntime {
+function resolvePowerShellCommand(): string {
+  if (process.env.COWORK_POWERSHELL_PATH) {
+    return process.env.COWORK_POWERSHELL_PATH;
+  }
+  return process.env.ComSpec ? "powershell.exe" : "powershell";
+}
+
+export class ComputerUseHelperRuntime implements ComputerUseProvider {
   private static instance: ComputerUseHelperRuntime | null = null;
 
   static getInstance(): ComputerUseHelperRuntime {
@@ -229,9 +245,13 @@ export class ComputerUseHelperRuntime {
 
   async getStatus(): Promise<ComputerUseHelperStatus> {
     const sourcePath = this.getHelperSourcePath();
-    const installed = await isExecutable(HELPER_PATH);
+    const installed =
+      process.platform === "win32"
+        ? Boolean(sourcePath || existsSync(HELPER_PATH))
+        : await isExecutable(HELPER_PATH);
     if (!installed) {
       return {
+        platform: process.platform,
         helperPath: HELPER_PATH,
         sourcePath,
         installed: false,
@@ -241,8 +261,12 @@ export class ComputerUseHelperRuntime {
     }
 
     try {
+      if (process.platform === "win32") {
+        await this.ensureHelperInstalled();
+      }
       const status = await this.checkPermissions();
       return {
+        platform: process.platform,
         helperPath: HELPER_PATH,
         sourcePath,
         installed: true,
@@ -251,6 +275,7 @@ export class ComputerUseHelperRuntime {
       };
     } catch (error) {
       return {
+        platform: process.platform,
         helperPath: HELPER_PATH,
         sourcePath,
         installed: true,
@@ -262,12 +287,14 @@ export class ComputerUseHelperRuntime {
   }
 
   async ensureReadyWithInteractivePermissions(): Promise<void> {
-    if (process.platform !== "darwin") {
-      throw new Error("Computer use is only supported on macOS.");
+    if (process.platform !== "darwin" && process.platform !== "win32") {
+      throw new Error("Computer use is only supported on macOS and Windows desktop builds.");
     }
     await this.ensureHelperInstalled();
     await this.ensureHelperProcess();
-    await this.ensurePermissionsInteractive();
+    if (process.platform === "darwin") {
+      await this.ensurePermissionsInteractive();
+    }
   }
 
   stop(): void {
@@ -500,15 +527,15 @@ export class ComputerUseHelperRuntime {
     await this.bridgeCommand("scrollAtPoint", args);
   }
 
-  async typeText(text: string, pid: number): Promise<void> {
+  async typeText(text: string, pid: number, windowId?: number): Promise<void> {
     await this.bridgeCommand(
       "typeText",
-      { text, pid },
+      { text, pid, ...(typeof windowId === "number" ? { windowId } : {}) },
       Math.min(90_000, Math.max(HELPER_COMMAND_TIMEOUT_MS, text.length * 25 + 4_000)),
     );
   }
 
-  async pressKeys(spec: ComputerUseHelperKeypressSpec): Promise<void> {
+  async pressKeys(spec: ComputerUseHelperKeypressSpec & { windowId?: number }): Promise<void> {
     await this.bridgeCommand("keyPress", { ...spec });
   }
 
@@ -558,6 +585,20 @@ export class ComputerUseHelperRuntime {
     await mkdir(HELPER_DIR, { recursive: true });
     const source = await readFile(sourcePath);
     const nextStamp = sha256(source);
+    if (process.platform === "win32") {
+      const currentStamp = existsSync(HELPER_STAMP_PATH)
+        ? await readFile(HELPER_STAMP_PATH, "utf8").catch(() => "")
+        : "";
+      const currentHelperStamp = existsSync(HELPER_PATH)
+        ? sha256(await readFile(HELPER_PATH))
+        : "";
+      if (currentHelperStamp === nextStamp && currentStamp.trim() === nextStamp) {
+        return;
+      }
+      await writeFile(HELPER_PATH, source, "utf8");
+      await writeFile(HELPER_STAMP_PATH, `${nextStamp}\n`, "utf8");
+      return;
+    }
     const currentStamp = existsSync(HELPER_STAMP_PATH)
       ? await readFile(HELPER_STAMP_PATH, "utf8").catch(() => "")
       : "";
@@ -608,7 +649,20 @@ export class ComputerUseHelperRuntime {
       throw new HelperTransportError(`Computer-use helper is missing at ${HELPER_PATH}.`);
     }
 
-    const child = spawn(HELPER_PATH, [], {
+    const child =
+      process.platform === "win32"
+        ? spawn(resolvePowerShellCommand(), [
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            HELPER_PATH,
+          ], {
+            stdio: ["pipe", "pipe", "pipe"],
+            windowsHide: true,
+          })
+        : spawn(HELPER_PATH, [], {
       stdio: ["pipe", "pipe", "pipe"],
     });
     child.stdout.setEncoding("utf8");

--- a/src/electron/computer-use/provider.ts
+++ b/src/electron/computer-use/provider.ts
@@ -1,0 +1,115 @@
+import type {
+  ComputerUseAxElementResult,
+  ComputerUseAxFocusResult,
+  ComputerUseAxPressResult,
+  ComputerUseFocusedElementResult,
+  ComputerUseFrontmostApp,
+  ComputerUseHelperApp,
+  ComputerUseHelperKeypressSpec,
+  ComputerUseHelperMouseButton,
+  ComputerUseHelperStatus,
+  ComputerUseHelperWindow,
+  ComputerUseScreenshotPayload,
+} from "./helper-runtime";
+import { ComputerUseHelperRuntime } from "./helper-runtime";
+
+export interface ComputerUseProvider {
+  getHelperPath(): string;
+  getHelperSourcePath(): string | null;
+  getStatus(): Promise<ComputerUseHelperStatus>;
+  ensureReadyWithInteractivePermissions(): Promise<void>;
+  stop(): void;
+  listApps(): Promise<ComputerUseHelperApp[]>;
+  listWindows(pid: number): Promise<ComputerUseHelperWindow[]>;
+  getFrontmost(): Promise<ComputerUseFrontmostApp>;
+  screenshot(windowId: number): Promise<ComputerUseScreenshotPayload>;
+  axPressAtPoint(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<ComputerUseAxPressResult>;
+  axFocusAtPoint(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<ComputerUseAxFocusResult>;
+  axDescribeAtPoint(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<Record<string, unknown>>;
+  axFindTextInput(args: { pid: number; windowId?: number }): Promise<ComputerUseAxElementResult>;
+  axFocusTextInput(args: { pid: number; windowId?: number }): Promise<ComputerUseAxElementResult>;
+  axFindFocusableElement(args: {
+    pid: number;
+    windowId?: number;
+    roles?: string[];
+  }): Promise<ComputerUseAxElementResult>;
+  axFindActionableElement(args: {
+    pid: number;
+    windowId?: number;
+    roles?: string[];
+  }): Promise<ComputerUseAxElementResult>;
+  focusedElement(pid: number): Promise<ComputerUseFocusedElementResult>;
+  setValue(elementRef: string, value: string): Promise<void>;
+  mouseClick(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+    button?: ComputerUseHelperMouseButton;
+    clickCount?: number;
+  }): Promise<void>;
+  mouseMove(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<void>;
+  mouseDrag(args: {
+    windowId: number;
+    pid: number;
+    path: Array<{ x: number; y: number }>;
+    captureWidth: number;
+    captureHeight: number;
+  }): Promise<void>;
+  scrollAtPoint(args: {
+    windowId: number;
+    pid: number;
+    x: number;
+    y: number;
+    captureWidth: number;
+    captureHeight: number;
+    scrollX: number;
+    scrollY: number;
+  }): Promise<void>;
+  typeText(text: string, pid: number, windowId?: number): Promise<void>;
+  pressKeys(spec: ComputerUseHelperKeypressSpec & { windowId?: number }): Promise<void>;
+  activateApp(pid: number): Promise<void>;
+  raiseWindow(pid: number, windowId?: number): Promise<void>;
+  unminimizeWindow(pid: number, windowId?: number): Promise<void>;
+  openPermissionPane(kind: "accessibility" | "screenRecording"): Promise<void>;
+}
+
+let providerFactory: (() => ComputerUseProvider) | null = null;
+
+export function getComputerUseProvider(): ComputerUseProvider {
+  return providerFactory?.() ?? ComputerUseHelperRuntime.getInstance();
+}
+
+export function setComputerUseProviderFactoryForTesting(factory: (() => ComputerUseProvider) | null): void {
+  providerFactory = factory;
+}

--- a/src/electron/ipc/handlers.ts
+++ b/src/electron/ipc/handlers.ts
@@ -9734,6 +9734,7 @@ function setupMCPHandlers(): void {
     const helperStatus = await ComputerUseHelperRuntime.getInstance().getStatus();
     return {
       activeTaskId: sm.getActiveTaskId(),
+      platform: helperStatus.platform,
       helperPath: helperStatus.helperPath,
       sourcePath: helperStatus.sourcePath,
       installed: helperStatus.installed,

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -5916,6 +5916,7 @@ export interface ElectronAPI {
   }) => Promise<{ success: boolean; deleted?: number }>;
   getComputerUseStatus: () => Promise<{
     activeTaskId: string | null;
+    platform: string;
     helperPath: string;
     sourcePath: string | null;
     installed: boolean;

--- a/src/renderer/components/ComputerUseSettings.tsx
+++ b/src/renderer/components/ComputerUseSettings.tsx
@@ -5,6 +5,7 @@ type ScreenStatus = "granted" | "denied" | "not-determined" | "unknown";
 
 interface ComputerUseStatus {
   activeTaskId: string | null;
+  platform: string;
   helperPath: string;
   sourcePath: string | null;
   installed: boolean;
@@ -26,7 +27,7 @@ function screenStatusLabel(s: ScreenStatus): string {
     case "not-determined":
       return "Not determined — open System Settings to allow";
     default:
-      return "Unknown (macOS only)";
+      return "Unknown";
   }
 }
 
@@ -38,6 +39,7 @@ export function ComputerUseSettings() {
   const [error, setError] = useState<string | null>(null);
 
   const isMac = platform === "darwin";
+  const isWindows = platform === "win32";
 
   const refresh = useCallback(async () => {
     try {
@@ -109,18 +111,26 @@ export function ComputerUseSettings() {
           Computer use
         </h3>
         <p className="settings-description">
-          Pi-style native desktop control for macOS. The agent targets one controlled window at a time
-          through `screenshot()`, and macOS permissions apply to the bundled helper binary rather than
-          to individual apps.
+          Pi-style native desktop control for macOS and Windows. The agent targets one
+          controlled window at a time through `screenshot()`, then uses screenshot-relative
+          mouse, keyboard, scroll, and typing actions.
         </p>
       </div>
 
       {error ? <div className="settings-error">{error}</div> : null}
 
-      {!isMac ? (
+      {!isMac && !isWindows ? (
         <div className="computer-use-platform-note">
-          Computer use is available on <strong>macOS</strong> only. On this platform the controls
-          below reflect limited or unavailable permission APIs.
+          Computer use is available on <strong>macOS</strong> and <strong>Windows</strong> desktop
+          builds only. On this platform the controls below reflect limited or unavailable
+          permission APIs.
+        </div>
+      ) : null}
+
+      {isWindows ? (
+        <div className="computer-use-platform-note">
+          Windows computer use supports visible, non-minimized native windows in v1. It may fall
+          back to foreground input for apps that block background capture or control.
         </div>
       ) : null}
 
@@ -136,19 +146,21 @@ export function ComputerUseSettings() {
         </div>
 
         <div className="computer-use-status-card">
-          <div className="computer-use-status-title">Accessibility</div>
+          <div className="computer-use-status-title">{isWindows ? "Input control" : "Accessibility"}</div>
           <div
             className={`computer-use-status-value ${status?.accessibilityTrusted ? "ok" : "bad"}`}
           >
             {statusLabel(Boolean(status?.accessibilityTrusted))}
           </div>
-          <button type="button" className="button-secondary" onClick={() => void openAccessibility()}>
-            Open Accessibility settings
-          </button>
+          {isMac ? (
+            <button type="button" className="button-secondary" onClick={() => void openAccessibility()}>
+              Open Accessibility settings
+            </button>
+          ) : null}
         </div>
 
         <div className="computer-use-status-card">
-          <div className="computer-use-status-title">Screen Recording</div>
+          <div className="computer-use-status-title">{isWindows ? "Window capture" : "Screen Recording"}</div>
           <div
             className={`computer-use-status-value ${
               status?.screenCaptureStatus === "granted" ? "ok" : "bad"
@@ -156,9 +168,11 @@ export function ComputerUseSettings() {
           >
             {screenStatusLabel(status?.screenCaptureStatus ?? "unknown")}
           </div>
-          <button type="button" className="button-secondary" onClick={() => void openScreen()}>
-            Open Screen Recording settings
-          </button>
+          {isMac ? (
+            <button type="button" className="button-secondary" onClick={() => void openScreen()}>
+              Open Screen Recording settings
+            </button>
+          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Adds Windows support for the existing `computer_use` tool family while keeping the public tool contract stable: `screenshot`, `click`, `double_click`, `move_mouse`, `drag`, `scroll`, `type_text`, `keypress`, and `wait`.

## Changes

- Adds a platform-aware computer-use provider seam and keeps the macOS Swift helper as the default macOS provider.
- Adds a first-party Windows PowerShell/Win32 helper for visible, non-minimized native windows.
- Exposes computer-use tools on `win32` desktop builds while keeping them hidden in headless/unsupported platforms.
- Adds Windows GUI intent routing for prompts involving Notepad, Calculator, Explorer, Windows Settings, installer dialogs, and native Windows apps.
- Updates Settings and docs from macOS-only behavior to macOS + Windows behavior.
- Adds safety fixes for Windows v1: foreground verification before capture/action, explicit rejection for unsupported back/forward mouse buttons, robust helper error-code extraction, and helper script integrity checking.

## Validation

- `npx vitest run src/electron/computer-use/__tests__/helper-runtime-windows.test.ts src/electron/agent/tools/__tests__/computer-use-platform.test.ts src/electron/agent/__tests__/tool-policy-engine.test.ts`
- `npm run type-check`
- `git diff --check`
- `npm run lint` completed with existing warnings and no errors.

## Manual Windows QA Needed

I do not have a Windows host in this environment, so true Win32 GUI capture/input still needs validation on Windows before this is ready to merge. Requested smoke coverage:

- Notepad: `screenshot`, click editor, type text, `Ctrl+A`, `Backspace`, type replacement text.
- Calculator: click `7 + 5 =` via computer-use tools and verify result.
- Safety cases: minimized target fails clearly; occluded target is brought foreground or fails safely; back/forward mouse buttons reject as unsupported.

Closes #103 if Windows smoke validation passes.