### PR TITLE
[codex] Fix workspace switching for active chats

### DIFF
--- a/src/electron/agent/daemon.ts
+++ b/src/electron/agent/daemon.ts
@@ -6081,8 +6081,39 @@ export class AgentDaemon extends EventEmitter {
   /**
    * Update task workspace ID in database
    */
-  updateTaskWorkspace(taskId: string, workspaceId: string): void {
+  updateTaskWorkspace(taskId: string, workspaceId: string): Task {
+    const task = this.taskRepo.findById(taskId);
+    if (!task) {
+      throw new Error(`Task ${taskId} not found`);
+    }
+
+    const workspace = this.workspaceRepo.findById(workspaceId);
+    if (!workspace) {
+      throw new Error(`Workspace ${workspaceId} not found`);
+    }
+
     this.taskRepo.update(taskId, { workspaceId });
+    const updatedTask = this.taskRepo.findById(taskId);
+    if (!updatedTask) {
+      throw new Error(`Task ${taskId} not found after workspace update`);
+    }
+
+    const effectiveWorkspace = this.applyTaskWorkspaceOverrides(updatedTask, workspace);
+    const cached = this.activeTasks.get(taskId);
+    if (cached) {
+      cached.executor.updateTaskWorkspace(updatedTask, effectiveWorkspace);
+      cached.lastAccessed = Date.now();
+      cached.status = "active";
+    }
+
+    this.logEvent(taskId, "log", {
+      message: `Workspace changed to "${workspace.name}" (${workspace.path}).`,
+      workspaceId: workspace.id,
+      workspaceName: workspace.name,
+      workspacePath: workspace.path,
+    });
+
+    return updatedTask;
   }
 
   /**

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -13724,6 +13724,15 @@ You are continuing a previous conversation. The context from the previous conver
     logger.info(`Workspace updated for task ${this.task.id}, permissions:`, workspace.permissions);
   }
 
+  updateTaskWorkspace(task: Task, workspace: Workspace): void {
+    this.task = {
+      ...this.task,
+      workspaceId: task.workspaceId,
+      updatedAt: task.updatedAt,
+    };
+    this.updateWorkspace(workspace);
+  }
+
   updateTaskAgentConfig(agentConfig: AgentConfig | undefined): void {
     this.task = {
       ...this.task,

--- a/src/electron/ipc/handlers.ts
+++ b/src/electron/ipc/handlers.ts
@@ -163,6 +163,7 @@ import {
   WorkspaceCreateSchema,
   TaskCreateSchema,
   TaskRenameSchema,
+  TaskWorkspaceUpdateSchema,
   TaskMessageSchema,
   FileImportSchema,
   FileImportDataSchema,
@@ -857,6 +858,7 @@ rateLimiter.configure(
   IPC_CHANNELS.TASK_FORK_SESSION,
   RATE_LIMIT_CONFIGS.limited,
 );
+rateLimiter.configure(IPC_CHANNELS.TASK_UPDATE_WORKSPACE, RATE_LIMIT_CONFIGS.limited);
 rateLimiter.configure(IPC_CHANNELS.TASK_PIN, RATE_LIMIT_CONFIGS.limited);
 rateLimiter.configure(
   IPC_CHANNELS.TASK_EXPORT_JSON,
@@ -4248,6 +4250,12 @@ export async function setupIpcHandlers(
   ipcMain.handle(IPC_CHANNELS.TASK_RENAME, async (_, data) => {
     const validated = validateInput(TaskRenameSchema, data, "task rename");
     taskRepo.update(validated.id, { title: validated.title });
+  });
+
+  ipcMain.handle(IPC_CHANNELS.TASK_UPDATE_WORKSPACE, async (_, data) => {
+    checkRateLimit(IPC_CHANNELS.TASK_UPDATE_WORKSPACE);
+    const validated = validateInput(TaskWorkspaceUpdateSchema, data, "task workspace update");
+    return agentDaemon.updateTaskWorkspace(validated.taskId, validated.workspaceId);
   });
 
   ipcMain.handle(IPC_CHANNELS.TASK_PIN, async (_, id: string) => {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -2192,6 +2192,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke(IPC_CHANNELS.TASK_KILL_COMMAND, { taskId, force }),
   renameTask: (id: string, title: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.TASK_RENAME, { id, title }),
+  updateTaskWorkspace: (taskId: string, workspaceId: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.TASK_UPDATE_WORKSPACE, { taskId, workspaceId }),
   deleteTask: (id: string) => ipcRenderer.invoke(IPC_CHANNELS.TASK_DELETE, id),
 
   // Task event streaming
@@ -4739,6 +4741,7 @@ export interface ElectronAPI {
   sendStdin: (taskId: string, input: string) => Promise<boolean>;
   killCommand: (taskId: string, force?: boolean) => Promise<boolean>;
   renameTask: (id: string, title: string) => Promise<void>;
+  updateTaskWorkspace: (taskId: string, workspaceId: string) => Promise<Any>;
   deleteTask: (id: string) => Promise<void>;
   onTaskEvent: (callback: (event: Any) => void) => () => void;
   onTaskLearningEvent: (callback: (event: TaskLearningProgress) => void) => () => void;

--- a/src/electron/utils/__tests__/validation.test.ts
+++ b/src/electron/utils/__tests__/validation.test.ts
@@ -3,6 +3,7 @@ import {
   validateInput,
   WorkspaceCreateSchema,
   TaskCreateSchema,
+  TaskWorkspaceUpdateSchema,
   TaskMessageSchema,
   ApprovalResponseSchema,
   GuardrailSettingsSchema,
@@ -213,6 +214,35 @@ describe("TaskCreateSchema", () => {
       budgetTokens: 50000,
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("TaskWorkspaceUpdateSchema", () => {
+  it("validates a task workspace update with a persistent workspace", () => {
+    const result = TaskWorkspaceUpdateSchema.safeParse({
+      taskId: "550e8400-e29b-41d4-a716-446655440000",
+      workspaceId: "550e8400-e29b-41d4-a716-446655440001",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("validates a task workspace update with a temp workspace", () => {
+    const result = TaskWorkspaceUpdateSchema.safeParse({
+      taskId: "550e8400-e29b-41d4-a716-446655440000",
+      workspaceId: "__temp_workspace__:session-123",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid task ID", () => {
+    const result = TaskWorkspaceUpdateSchema.safeParse({
+      taskId: "not-a-task-id",
+      workspaceId: "550e8400-e29b-41d4-a716-446655440001",
+    });
+
+    expect(result.success).toBe(false);
   });
 });
 

--- a/src/electron/utils/validation.ts
+++ b/src/electron/utils/validation.ts
@@ -381,6 +381,11 @@ export const TaskRenameSchema = z.object({
   title: z.string().min(1).max(MAX_TITLE_LENGTH),
 });
 
+export const TaskWorkspaceUpdateSchema = z.object({
+  taskId: z.string().uuid(),
+  workspaceId: WorkspaceIdSchema,
+});
+
 export const TaskMessageSchema = z
   .object({
     taskId: z.string().uuid(),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -578,6 +578,7 @@ function getAppTaskSignature(task: Task | undefined): string {
     task.title,
     task.status,
     task.terminalStatus ?? "",
+    task.workspaceId,
     task.updatedAt,
     task.completedAt ?? "",
     task.pinned ? "pinned" : "unpinned",
@@ -3231,6 +3232,35 @@ export function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const handleSelectWorkspace = useCallback(
+    async (workspace: Workspace) => {
+      if (selectedTaskId && !remoteTaskView && window.electronAPI?.updateTaskWorkspace) {
+        try {
+          const updatedTask = (await window.electronAPI.updateTaskWorkspace(
+            selectedTaskId,
+            workspace.id,
+          )) as Task | undefined;
+          setTasks((prev) =>
+            updateTaskPreservingIdentity(prev, selectedTaskId, (task) =>
+              mergeTaskPreservingIdentity(task, updatedTask ?? { workspaceId: workspace.id }),
+            ),
+          );
+        } catch (error) {
+          console.error("Failed to update task workspace:", error);
+          addToast({
+            type: "error",
+            title: "Workspace Error",
+            message: error instanceof Error ? error.message : "Could not apply the workspace to this chat.",
+          });
+          return;
+        }
+      }
+
+      setCurrentWorkspace(workspace);
+    },
+    [addToast, remoteTaskView, selectedTaskId],
+  );
+
   // Handle workspace change - opens folder selection dialog directly
   const handleChangeWorkspace = async () => {
     try {
@@ -3249,12 +3279,12 @@ export function App() {
       // Check if this folder is already a workspace
       const existingWorkspace = existingWorkspaces.find((w: Workspace) => w.path === folderPath);
       if (existingWorkspace) {
-        setCurrentWorkspace(existingWorkspace);
+        await handleSelectWorkspace(existingWorkspace);
         return;
       }
 
       // Create a new workspace for this folder
-      const folderName = folderPath.split("/").pop() || "Workspace";
+      const folderName = folderPath.split(/[\\/]/).filter(Boolean).pop() || "Workspace";
       const permissionSettings = await window.electronAPI.getPermissionSettings().catch(() => null);
       const workspace = await window.electronAPI.createWorkspace({
         name: folderName,
@@ -3268,7 +3298,7 @@ export function App() {
         },
       });
 
-      setCurrentWorkspace(workspace);
+      await handleSelectWorkspace(workspace);
     } catch (error) {
       console.error("Failed to change workspace:", error);
     }
@@ -4657,7 +4687,7 @@ export function App() {
                 onCreateTask={handleCreateTask}
                 onAskInbox={handleAskInboxFromComposer}
                 onChangeWorkspace={handleChangeWorkspace}
-                onSelectWorkspace={setCurrentWorkspace}
+                onSelectWorkspace={handleSelectWorkspace}
                 onOpenSettings={(tab) => {
                   setSettingsTab((tab as typeof settingsTab | undefined) || "appearance");
                   setCurrentView("settings");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6748,6 +6748,7 @@ export const IPC_CHANNELS = {
   TASK_STEP_FEEDBACK: "task:stepFeedback", // Send feedback on an in-progress step
   TASK_SEND_STDIN: "task:sendStdin", // Send stdin input to running command
   TASK_KILL_COMMAND: "task:killCommand", // Kill running command (Ctrl+C)
+  TASK_UPDATE_WORKSPACE: "task:updateWorkspace",
   SHELL_SESSION_EVENT: "shell:sessionEvent",
   SHELL_SESSION_GET: "shell:sessionGet",
   SHELL_SESSION_LIST: "shell:sessionList",


### PR DESCRIPTION
## Summary

Fixes issue #109, where selecting a different work folder after sending the initial chat message would briefly refresh but then snap back to the old workspace.

## Root Cause

The renderer updated `currentWorkspace`, but the selected task still carried the old `workspaceId`. The task/workspace sync effect then restored the old workspace for the active chat.

## Changes

- Add a task workspace update IPC path and validation.
- Persist the selected task's new workspace before updating the visible workspace.
- Refresh cached executors when an active task moves to another workspace.
- Add validation coverage for task workspace updates.

## Validation

- `npx vitest run src/electron/utils/__tests__/validation.test.ts`
- `npm run type-check`

## Notes

The original mixed commit was reverted from `main`; this PR contains only the issue #109 fix files.