### PR TITLE
Add persistent goal slash command

### DIFF
--- a/docs/message-box-shortcuts.md
+++ b/docs/message-box-shortcuts.md
@@ -32,6 +32,11 @@ The built-in app command catalog is:
 | `/clear` | Clears the current task/chat view without deleting history and without switching the current workspace. |
 | `/plan <task>` | Creates a new task in Plan execution mode using `<task>` as the prompt. |
 | `/cost <task>` | Creates an Analyze-mode estimate request for token usage, model cost, runtime, and risk without executing the requested task. |
+| `/goal <objective>` | Starts a fresh persistent-goal task. The task stores the objective in its agent configuration, enables deep-work continuations, and keeps working until the goal is complete, blocked, paused, or cleared. |
+| `/goal` | Reports the selected task's persistent-goal status. |
+| `/goal pause` | Pauses the selected task's persistent goal. |
+| `/goal resume` | Resumes the selected task's persistent goal and continues work from the current task state. |
+| `/goal clear` | Clears the selected task's persistent goal metadata. |
 | `/compact [context]` | Starts a safe continuation-brief workflow that summarizes context, decisions, open questions, constraints, and next actions. |
 | `/doctor [context]` | Starts a diagnostic workflow for workspace/app state, integrations, permissions, skills, commands, and setup issues. It should not make changes unless explicitly asked. |
 | `/undo [context]` | Starts a safe undo-planning workflow. It does not roll back, delete, or modify anything unless the user explicitly approves a follow-up action. |

--- a/src/electron/agent/daemon.ts
+++ b/src/electron/agent/daemon.ts
@@ -6293,6 +6293,9 @@ export class AgentDaemon extends EventEmitter {
         | "noProgressStreak"
         | "lastLoopFingerprint"
         | "bestKnownOutcome"
+        | "agentConfig"
+        | "rawPrompt"
+        | "userPrompt"
       >
     >,
   ): void {
@@ -7045,6 +7048,7 @@ export class AgentDaemon extends EventEmitter {
       semanticSummary?: string;
       verificationVerdict?: VerificationVerdict;
       verificationReport?: string;
+      agentConfig?: AgentConfig;
     },
   ): void {
     const existingTask = this.taskRepo.findById(taskId);
@@ -7672,6 +7676,7 @@ export class AgentDaemon extends EventEmitter {
       ...(typeof metadata?.verificationReport === "string" && metadata.verificationReport.trim().length > 0
         ? { verificationReport: metadata.verificationReport.trim() }
         : {}),
+      ...(metadata?.agentConfig ? { agentConfig: metadata.agentConfig } : {}),
     };
     this.taskRepo.update(taskId, updates);
     this.clearRetryState(taskId);

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -55,6 +55,11 @@ import {
   type ParsedSkillSlashCommand,
   type SkillSlashExternalMode,
 } from "../../shared/skill-slash-commands";
+import {
+  buildPersistentGoalAgentConfig,
+  buildPersistentGoalPrompt,
+  parseLeadingGoalSlashCommand,
+} from "../../shared/goal-slash-command";
 import { parseNaturalLlmWikiPrompt } from "../../shared/llm-wiki-prompt-routing";
 import { parseOnboardingSlashCommand } from "../../shared/onboarding";
 import * as fs from "fs";
@@ -1296,6 +1301,7 @@ export class TaskExecutor {
     if (trimmedSummary) {
       this.task.resultSummary = trimmedSummary;
     }
+    const goalAgentConfig = this.applyGoalTerminalState(trimmedSummary, "ok");
 
     this.daemon.updateTask(this.task.id, {
       status: "completed",
@@ -1304,6 +1310,7 @@ export class TaskExecutor {
       ...(clearTerminalFailure ? { terminalStatus: undefined, failureClass: undefined } : {}),
       ...(trimmedSummary ? { resultSummary: trimmedSummary } : {}),
       ...(this.bestKnownOutcome ? { bestKnownOutcome: this.bestKnownOutcome } : {}),
+      ...(goalAgentConfig ? { agentConfig: goalAgentConfig } : {}),
       ...runtimeProjection,
       ...this.getCompletionProjectionFields(),
     });
@@ -11201,6 +11208,7 @@ ${transcript}
     this.task.resultSummary = summary;
     const outputSummary = this.buildTaskOutputSummary();
     this.persistBestKnownOutcome(summary, terminalStatus, failureClass);
+    const goalAgentConfig = this.applyGoalTerminalState(summary, terminalStatus);
     const verificationMetadata =
       this.verificationOutcomeV2Enabled && this.completionVerificationMetadata
         ? {
@@ -11219,6 +11227,7 @@ ${transcript}
     this.daemon.completeTask(this.task.id, summary, {
       terminalStatus,
       failureClass: this.task.failureClass,
+      ...(goalAgentConfig ? { agentConfig: goalAgentConfig } : {}),
       ...runtimeProjection,
       outputSummary,
       bestKnownOutcome: this.bestKnownOutcome,
@@ -11319,6 +11328,7 @@ ${transcript}
     this.task.resultSummary = summary;
     const outputSummary = this.buildTaskOutputSummary();
     this.persistBestKnownOutcome(summary, this.task.terminalStatus, this.task.failureClass, reason);
+    const goalAgentConfig = this.applyGoalTerminalState(summary, this.task.terminalStatus);
     const verificationMetadata =
       this.verificationOutcomeV2Enabled && this.completionVerificationMetadata
         ? {
@@ -11335,6 +11345,7 @@ ${transcript}
     this.daemon.completeTask(this.task.id, summary, {
       terminalStatus: this.task.terminalStatus,
       failureClass: this.task.failureClass,
+      ...(goalAgentConfig ? { agentConfig: goalAgentConfig } : {}),
       ...runtimeProjection,
       outputSummary,
       bestKnownOutcome: this.bestKnownOutcome,
@@ -18987,6 +18998,224 @@ You are continuing a previous conversation. The context from the previous conver
     return true;
   }
 
+  private emitGoalAssistantMessage(raw: string, message: string): void {
+    this.emitEvent("assistant_message", { message });
+    this.updateConversationHistory([
+      { role: "user", content: [{ type: "text", text: raw }] },
+      { role: "assistant", content: [{ type: "text", text: message }] },
+    ]);
+    this.lastAssistantOutput = message;
+    this.lastNonVerificationOutput = message;
+  }
+
+  private updateGoalAgentConfig(agentConfig: AgentConfig): void {
+    this.task.agentConfig = agentConfig;
+    this.daemon.updateTask(this.task.id, { agentConfig });
+  }
+
+  private withGoalRuntimeDefaults(agentConfig: AgentConfig): AgentConfig {
+    return {
+      ...agentConfig,
+      executionMode: "execute",
+      deepWorkMode: true,
+      autoReportEnabled: agentConfig.autoReportEnabled ?? true,
+      progressJournalEnabled: agentConfig.progressJournalEnabled ?? true,
+      autoContinueOnTurnLimit: true,
+      maxAutoContinuations: agentConfig.maxAutoContinuations ?? 12,
+      lifetimeMaxTurns: agentConfig.lifetimeMaxTurns ?? 1200,
+      minProgressScoreForAutoContinue: agentConfig.minProgressScoreForAutoContinue ?? -0.05,
+      continuationStrategy: "adaptive_progress",
+      compactOnContinuation: true,
+      globalNoProgressCircuitBreaker: agentConfig.globalNoProgressCircuitBreaker ?? 4,
+      loopWarningThreshold: agentConfig.loopWarningThreshold ?? 3,
+      loopCriticalThreshold: agentConfig.loopCriticalThreshold ?? 5,
+    };
+  }
+
+  private formatGoalStatusMessage(): string {
+    const goalMode = this.task.agentConfig?.goalMode;
+    if (!goalMode || goalMode.status === "cleared") {
+      return "No persistent goal is attached to this task.";
+    }
+
+    const statusLabel =
+      goalMode.status === "active"
+        ? "active"
+        : goalMode.status === "paused"
+          ? "paused"
+          : "completed";
+    return [
+      `Goal status: ${statusLabel}.`,
+      "",
+      `Objective: ${goalMode.objective}`,
+      "",
+      "Use `/goal pause`, `/goal resume`, or `/goal clear` to manage it.",
+    ].join("\n");
+  }
+
+  private async maybePrepareInitialGoalSlashCommand(): Promise<boolean> {
+    const raw = String(this.getContractPrompt() || this.task.title || "").trim();
+    const parsed = parseLeadingGoalSlashCommand(raw);
+    if (!parsed.matched) return false;
+
+    if (parsed.action === "start" && parsed.objective) {
+      const now = Date.now();
+      const agentConfig = buildPersistentGoalAgentConfig(parsed, now, this.task.agentConfig);
+      const prompt = buildPersistentGoalPrompt(parsed.objective);
+      this.task.agentConfig = agentConfig;
+      this.task.rawPrompt = prompt;
+      this.task.userPrompt = raw;
+      this.daemon.updateTask(this.task.id, {
+        agentConfig,
+        rawPrompt: prompt,
+        userPrompt: raw,
+      });
+      this.emitEvent("log", { message: `Persistent goal started: ${parsed.objective}` });
+      return false;
+    }
+
+    const message = this.formatGoalStatusMessage();
+    this.emitGoalAssistantMessage(raw, message);
+    this.finalizeTask(message);
+    return true;
+  }
+
+  private applyGoalTerminalState(
+    summary: string,
+    terminalStatus?: Task["terminalStatus"],
+  ): AgentConfig | undefined {
+    const goalMode = this.task.agentConfig?.goalMode;
+    if (!goalMode || goalMode.status !== "active") return undefined;
+
+    const now = Date.now();
+    const normalizedSummary = String(summary || "").trim();
+    const isBlocked =
+      /^GOAL BLOCKED:/i.test(normalizedSummary) || terminalStatus === "needs_user_action";
+    const isCompleted =
+      /^GOAL COMPLETE:/i.test(normalizedSummary) ||
+      (!isBlocked && (terminalStatus === "ok" || terminalStatus === undefined));
+
+    if (!isBlocked && !isCompleted) return undefined;
+
+    const nextGoalMode =
+      isBlocked
+        ? {
+            ...goalMode,
+            status: "paused" as const,
+            pausedAt: now,
+            updatedAt: now,
+          }
+        : {
+            ...goalMode,
+            status: "completed" as const,
+            completedAt: now,
+            updatedAt: now,
+          };
+    const nextAgentConfig = {
+      ...this.task.agentConfig,
+      goalMode: nextGoalMode,
+    };
+    this.task.agentConfig = nextAgentConfig;
+    return nextAgentConfig;
+  }
+
+  private handleGoalSlashFollowUp(message: string): { handled: boolean; executionMessage?: string } {
+    const parsed = parseLeadingGoalSlashCommand(message);
+    if (!parsed.matched) return { handled: false };
+
+    const now = Date.now();
+    const currentGoal = this.task.agentConfig?.goalMode;
+
+    if (parsed.action === "status") {
+      const statusMessage = this.formatGoalStatusMessage();
+      this.emitGoalAssistantMessage(message, statusMessage);
+      this.finalizeFollowUpCompletion("Goal status reported");
+      return { handled: true };
+    }
+
+    if (parsed.action === "pause") {
+      if (!currentGoal || currentGoal.status === "cleared") {
+        const statusMessage = "No persistent goal is attached to this task.";
+        this.emitGoalAssistantMessage(message, statusMessage);
+        this.finalizeFollowUpCompletion("No goal to pause");
+        return { handled: true };
+      }
+      const goalMode = {
+        ...currentGoal,
+        status: "paused" as const,
+        pausedAt: now,
+        updatedAt: now,
+      };
+      this.updateGoalAgentConfig({
+        ...this.task.agentConfig,
+        goalMode,
+      });
+      const statusMessage = `Goal paused.\n\nObjective: ${goalMode.objective}`;
+      this.emitGoalAssistantMessage(message, statusMessage);
+      this.finalizeFollowUpCompletion("Goal paused");
+      return { handled: true };
+    }
+
+    if (parsed.action === "clear") {
+      if (!currentGoal || currentGoal.status === "cleared") {
+        const statusMessage = "No persistent goal is attached to this task.";
+        this.emitGoalAssistantMessage(message, statusMessage);
+        this.finalizeFollowUpCompletion("No goal to clear");
+        return { handled: true };
+      }
+      const goalMode = {
+        ...currentGoal,
+        status: "cleared" as const,
+        clearedAt: now,
+        updatedAt: now,
+      };
+      this.updateGoalAgentConfig({
+        ...this.task.agentConfig,
+        goalMode,
+      });
+      const statusMessage = "Goal cleared for this task.";
+      this.emitGoalAssistantMessage(message, statusMessage);
+      this.finalizeFollowUpCompletion("Goal cleared");
+      return { handled: true };
+    }
+
+    if (parsed.action === "resume") {
+      if (!currentGoal || currentGoal.status === "cleared") {
+        const statusMessage = "No persistent goal is attached to this task.";
+        this.emitGoalAssistantMessage(message, statusMessage);
+        this.finalizeFollowUpCompletion("No goal to resume");
+        return { handled: true };
+      }
+      const goalMode = {
+        ...currentGoal,
+        status: "active" as const,
+        updatedAt: now,
+      };
+      delete goalMode.pausedAt;
+      this.updateGoalAgentConfig(
+        this.withGoalRuntimeDefaults({
+          ...this.task.agentConfig,
+          goalMode,
+        }),
+      );
+      return {
+        handled: false,
+        executionMessage: `${buildPersistentGoalPrompt(goalMode.objective)}\n\nResume from the current task state and continue useful work toward the goal.`,
+      };
+    }
+
+    if (parsed.action === "start" && parsed.objective) {
+      const agentConfig = buildPersistentGoalAgentConfig(parsed, now, this.task.agentConfig);
+      this.updateGoalAgentConfig(agentConfig);
+      return {
+        handled: false,
+        executionMessage: buildPersistentGoalPrompt(parsed.objective),
+      };
+    }
+
+    return { handled: false };
+  }
+
   /**
    * Handle `/schedule ...` commands locally to ensure the cron job is actually created.
    *
@@ -21341,6 +21570,10 @@ You are continuing a previous conversation. The context from the previous conver
       // Handle local slash-commands (e.g. /schedule ...) deterministically without relying on the LLM.
       // This prevents "plan-only" runs that never create the underlying cron job.
       if (await this.maybeHandleOnboardingSlashCommand()) {
+        return;
+      }
+
+      if (await this.maybePrepareInitialGoalSlashCommand()) {
         return;
       }
 
@@ -30424,8 +30657,15 @@ Return ONLY a JSON object:
     this.waitingForUserInput = false;
     this.paused = false;
     this.lastUserMessage = message;
+    const goalFollowUp = this.handleGoalSlashFollowUp(message);
+    if (goalFollowUp.handled) {
+      return;
+    }
+    if (goalFollowUp.executionMessage) {
+      executionMessage = goalFollowUp.executionMessage;
+    }
     const followUpConversationMessage = this.buildQuotedAssistantContextMessage(
-      message,
+      executionMessage,
       quotedAssistantMessage,
     );
     this.getSessionRuntime().setRecoveryRequestActive(this.isRecoveryIntent(message));

--- a/src/electron/utils/validation.ts
+++ b/src/electron/utils/validation.ts
@@ -265,6 +265,23 @@ export const AgentConfigSchema = z
     entropySweepPolicy: z.enum(["off", "balanced", "strict"]).optional(),
     stepIntentAlignmentPolicy: z.enum(["off", "balanced", "strict"]).optional(),
     stepDecompositionPolicy: z.enum(["off", "balanced", "strict"]).optional(),
+    deepWorkMode: z.boolean().optional(),
+    goalMode: z
+      .object({
+        objective: z.string().min(1).max(MAX_PROMPT_LENGTH),
+        status: z.enum(["active", "paused", "completed", "cleared"]),
+        createdAt: z.number().int().nonnegative(),
+        updatedAt: z.number().int().nonnegative(),
+        completedAt: z.number().int().nonnegative().optional(),
+        pausedAt: z.number().int().nonnegative().optional(),
+        clearedAt: z.number().int().nonnegative().optional(),
+        maxAutoContinuations: z.number().int().min(0).max(20).optional(),
+        lifetimeMaxTurns: z.number().int().min(1).max(5000).optional(),
+      })
+      .strict()
+      .optional(),
+    autoReportEnabled: z.boolean().optional(),
+    progressJournalEnabled: z.boolean().optional(),
     autoContinueOnTurnLimit: z.boolean().optional(),
     maxAutoContinuations: z.number().int().min(0).max(20).optional(),
     minProgressScoreForAutoContinue: z.number().min(-1).max(1).optional(),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -63,6 +63,7 @@ import {
   QuotedAssistantMessage,
   ExecutionMode,
   TaskDomain,
+  AgentConfig,
   LlmProfile,
   PermissionMode,
   LLMProviderType,
@@ -3321,6 +3322,7 @@ export function App() {
       videoGenerationMode?: boolean;
       llmProfile?: LlmProfile;
       llmProfileForced?: boolean;
+      agentConfig?: AgentConfig;
       integrationMentions?: IntegrationMentionSelection[];
     },
     images?: ImageAttachment[],
@@ -3371,6 +3373,7 @@ export function App() {
     const shellAccess = options?.shellAccess === true;
     const llmProfile = options?.llmProfile;
     const llmProfileForced = options?.llmProfileForced;
+    const explicitAgentConfig = options?.agentConfig;
     const integrationMentions =
       options?.integrationMentions && options.integrationMentions.length > 0
         ? options.integrationMentions
@@ -3394,8 +3397,10 @@ export function App() {
       permissionMode ||
       shellAccess ||
       integrationMentions ||
-      effectiveLlmProfile
+      effectiveLlmProfile ||
+      explicitAgentConfig
         ? {
+            ...explicitAgentConfig,
             ...(effectiveSessionModelOverride ? { modelKey: effectiveSessionModelOverride } : {}),
             ...(autonomousMode ? { allowUserInput: false, autonomousMode: true } : {}),
             ...(collaborativeMode ? { collaborativeMode: true } : {}),

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -42,6 +42,7 @@ import {
   CanvasSession,
   isTempWorkspaceId,
   ImageAttachment,
+  AgentConfig,
   AgentTeamRun,
   MultiLlmConfig,
   StepFeedbackAction,
@@ -65,6 +66,11 @@ import {
   parseOnboardingSlashCommand,
 } from "../../shared/onboarding";
 import { parseLeadingMessageAppShortcut } from "../../shared/message-shortcuts";
+import {
+  buildPersistentGoalAgentConfig,
+  buildPersistentGoalPrompt,
+  parseLeadingGoalSlashCommand,
+} from "../../shared/goal-slash-command";
 import {
   MESSAGE_SHORTCUTS_UPDATED_EVENT,
   buildMessageSlashOptions,
@@ -3626,6 +3632,7 @@ interface CreateTaskOptions {
   taskDomain?: TaskDomain;
   chronicleMode?: import("../../shared/types").ChronicleTaskMode;
   videoGenerationMode?: boolean;
+  agentConfig?: AgentConfig;
   integrationMentions?: IntegrationMentionSelection[];
 }
 
@@ -10506,6 +10513,7 @@ function MainContentComponent({
     const hasAttachments = pendingAttachments.length > 0;
     const onboardingSlashCommand = parseOnboardingSlashCommand(trimmedInput);
     const appSlashCommand = parseLeadingMessageAppShortcut(trimmedInput);
+    const goalSlashCommand = parseLeadingGoalSlashCommand(trimmedInput);
 
     if (!trimmedInput && !hasAttachments) return;
     if (
@@ -10636,6 +10644,58 @@ function MainContentComponent({
           ? { integrationMentions: selectedIntegrationMentions }
           : {};
 
+      if (goalSlashCommand.matched && goalSlashCommand.action === "start" && onCreateTask) {
+        const objective = String(goalSlashCommand.objective || "").trim();
+        if (!objective) {
+          setAttachmentError("Add the goal after /goal.");
+          sendFailed = true;
+          return;
+        }
+        const goalBaseAgentConfig: AgentConfig =
+          selectedIntegrationMentions.length > 0
+            ? { integrationMentions: selectedIntegrationMentions }
+            : {};
+        const goalAgentConfig = buildPersistentGoalAgentConfig(
+          goalSlashCommand,
+          Date.now(),
+          goalBaseAgentConfig,
+        );
+        const prompt = buildPersistentGoalPrompt(objective, hasAttachments ? message : undefined);
+        const title = buildTaskTitle(`/goal ${objective}`);
+        onCreateTask(
+          title,
+          prompt,
+          {
+            executionMode: "execute",
+            taskDomain,
+            agentConfig: goalAgentConfig,
+            ...createIntegrationMentionOptions,
+          },
+          imagePayload,
+        );
+
+        pendingProgrammaticResizeRef.current = true;
+        setInputValue("");
+        setActiveWelcomeSuggestionDraft(null);
+        setQuotedAssistantMessage(null);
+        setPendingAttachments([]);
+        setMentionOpen(false);
+        setMentionQuery("");
+        setMentionTarget(null);
+        setSlashOpen(false);
+        setSlashQuery("");
+        setSlashTarget(null);
+        setModeSuggestions([]);
+        setAutonomousModeEnabled(false);
+        setCollaborativeModeEnabled(false);
+        setMultiLlmModeEnabled(false);
+        setChronicleEnabledForTask(true);
+        setPermissionAccessMode(defaultPermissionAccessMode);
+        setMultiLlmConfig(null);
+        setVerificationAgentEnabled(false);
+        return;
+      }
+
       if (
         appSlashCommand.matched &&
         appSlashCommand.shortcut &&
@@ -10694,7 +10754,9 @@ function MainContentComponent({
           executionMode,
           selectedTaskId,
           selectedTaskExecutionMode: task?.agentConfig?.executionMode,
-          forceFreshTask: appSlashCommand.shortcut?.name === "schedule",
+          forceFreshTask:
+            appSlashCommand.shortcut?.name === "schedule" ||
+            goalSlashCommand.action === "start",
         });
 
       if (shouldCreateFreshTask && onCreateTask) {

--- a/src/shared/__tests__/goal-slash-command.test.ts
+++ b/src/shared/__tests__/goal-slash-command.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPersistentGoalAgentConfig,
+  buildPersistentGoalPrompt,
+  parseLeadingGoalSlashCommand,
+} from "../goal-slash-command";
+
+describe("goal slash command", () => {
+  it("parses a goal objective", () => {
+    const parsed = parseLeadingGoalSlashCommand(
+      "/goal ship the release --max-continuations=5 --max-turns 300",
+    );
+
+    expect(parsed.matched).toBe(true);
+    expect(parsed.action).toBe("start");
+    expect(parsed.objective).toBe("ship the release");
+    expect(parsed.maxAutoContinuations).toBe(5);
+    expect(parsed.lifetimeMaxTurns).toBe(300);
+  });
+
+  it("parses lifecycle commands", () => {
+    expect(parseLeadingGoalSlashCommand("/goal").action).toBe("status");
+    expect(parseLeadingGoalSlashCommand("/goal pause").action).toBe("pause");
+    expect(parseLeadingGoalSlashCommand("/goal resume").action).toBe("resume");
+    expect(parseLeadingGoalSlashCommand("/goal clear").action).toBe("clear");
+  });
+
+  it("does not match other slash commands", () => {
+    expect(parseLeadingGoalSlashCommand("/goals ship").matched).toBe(false);
+    expect(parseLeadingGoalSlashCommand("/schedule daily 9am check").matched).toBe(false);
+  });
+
+  it("builds persistent goal runtime defaults", () => {
+    const parsed = parseLeadingGoalSlashCommand("/goal publish docs");
+    const config = buildPersistentGoalAgentConfig(parsed, 123);
+
+    expect(config.goalMode).toEqual({
+      objective: "publish docs",
+      status: "active",
+      createdAt: 123,
+      updatedAt: 123,
+    });
+    expect(config.deepWorkMode).toBe(true);
+    expect(config.autoContinueOnTurnLimit).toBe(true);
+    expect(config.maxAutoContinuations).toBe(12);
+    expect(config.lifetimeMaxTurns).toBe(1200);
+  });
+
+  it("builds an execution prompt with completion markers", () => {
+    const prompt = buildPersistentGoalPrompt("finish migration");
+
+    expect(prompt).toContain("Goal: finish migration");
+    expect(prompt).toContain("GOAL COMPLETE:");
+    expect(prompt).toContain("GOAL BLOCKED:");
+  });
+});

--- a/src/shared/__tests__/message-shortcuts.test.ts
+++ b/src/shared/__tests__/message-shortcuts.test.ts
@@ -11,6 +11,7 @@ describe("message shortcuts", () => {
     expect(result.matched).toBe(true);
     expect(result.shortcut?.name).toBe("plan");
     expect(result.args).toBe("migrate the docs");
+    expect(parseLeadingMessageAppShortcut("/goal ship the release").shortcut?.name).toBe("goal");
   });
 
   it("does not match unknown slash commands", () => {

--- a/src/shared/goal-slash-command.ts
+++ b/src/shared/goal-slash-command.ts
@@ -1,0 +1,142 @@
+import type { AgentConfig, PersistentTaskGoalConfig } from "./types";
+
+export type GoalSlashCommandAction = "start" | "status" | "pause" | "resume" | "clear";
+
+export interface ParsedGoalSlashCommand {
+  matched: boolean;
+  action?: GoalSlashCommandAction;
+  objective?: string;
+  raw?: string;
+  maxAutoContinuations?: number;
+  lifetimeMaxTurns?: number;
+}
+
+const GOAL_ACTIONS = new Set(["pause", "resume", "clear", "status"]);
+
+function clampInteger(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+function readNumberFlag(tokens: string[], index: number): { value?: number; nextIndex: number } {
+  const token = tokens[index] || "";
+  const equalsIndex = token.indexOf("=");
+  if (equalsIndex >= 0) {
+    const value = Number(token.slice(equalsIndex + 1));
+    return { value: Number.isFinite(value) ? value : undefined, nextIndex: index + 1 };
+  }
+
+  const value = Number(tokens[index + 1]);
+  return { value: Number.isFinite(value) ? value : undefined, nextIndex: index + 2 };
+}
+
+export function parseLeadingGoalSlashCommand(input: string): ParsedGoalSlashCommand {
+  const raw = String(input || "").trim();
+  const match = raw.match(/^\/goal(?=\s|$)([\s\S]*)$/i);
+  if (!match) return { matched: false };
+
+  const args = String(match[1] || "").trim();
+  if (!args) {
+    return { matched: true, action: "status", raw };
+  }
+
+  const tokens = args.split(/\s+/);
+  const first = String(tokens[0] || "").toLowerCase();
+  if (GOAL_ACTIONS.has(first)) {
+    return { matched: true, action: first as GoalSlashCommandAction, raw };
+  }
+
+  const objectiveTokens: string[] = [];
+  let maxAutoContinuations: number | undefined;
+  let lifetimeMaxTurns: number | undefined;
+  for (let i = 0; i < tokens.length; ) {
+    const token = tokens[i] || "";
+    const lower = token.toLowerCase();
+    if (lower === "--max-continuations" || lower.startsWith("--max-continuations=")) {
+      const parsed = readNumberFlag(tokens, i);
+      if (typeof parsed.value === "number") {
+        maxAutoContinuations = clampInteger(parsed.value, 0, 20);
+      }
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (lower === "--max-turns" || lower.startsWith("--max-turns=")) {
+      const parsed = readNumberFlag(tokens, i);
+      if (typeof parsed.value === "number") {
+        lifetimeMaxTurns = clampInteger(parsed.value, 1, 5000);
+      }
+      i = parsed.nextIndex;
+      continue;
+    }
+    objectiveTokens.push(token);
+    i += 1;
+  }
+
+  const objective = objectiveTokens.join(" ").trim();
+  return {
+    matched: true,
+    action: objective ? "start" : "status",
+    objective,
+    raw,
+    maxAutoContinuations,
+    lifetimeMaxTurns,
+  };
+}
+
+export function buildPersistentGoalPrompt(objective: string, context?: string): string {
+  const trimmedObjective = String(objective || "").trim();
+  const trimmedContext = String(context || "").trim();
+  const contextBlock =
+    trimmedContext && trimmedContext !== `/goal ${trimmedObjective}`.trim()
+      ? `\n\nInitial context:\n${trimmedContext}`
+      : "";
+
+  return [
+    "Persistent goal mode is active.",
+    "",
+    `Goal: ${trimmedObjective}`,
+    contextBlock,
+    "",
+    "Work toward this goal until it is verified complete, explicitly blocked, or paused by the user.",
+    "Use the goal as the source of truth across continuations. Keep progress visible, continue after turn-window exhaustion when there is still useful progress to make, and avoid stopping after partial progress.",
+    "Before finishing, verify the concrete outcome against the goal. Start the final response with `GOAL COMPLETE:` when the goal is done, or `GOAL BLOCKED:` when external input or access is required.",
+  ].join("\n");
+}
+
+export function buildPersistentGoalAgentConfig(
+  parsed: ParsedGoalSlashCommand,
+  now: number,
+  base?: AgentConfig,
+): AgentConfig {
+  const objective = String(parsed.objective || "").trim();
+  const goalMode: PersistentTaskGoalConfig = {
+    objective,
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  };
+  if (typeof parsed.maxAutoContinuations === "number") {
+    goalMode.maxAutoContinuations = parsed.maxAutoContinuations;
+  }
+  if (typeof parsed.lifetimeMaxTurns === "number") {
+    goalMode.lifetimeMaxTurns = parsed.lifetimeMaxTurns;
+  }
+
+  return {
+    ...base,
+    goalMode,
+    executionMode: "execute",
+    deepWorkMode: true,
+    autoReportEnabled: true,
+    progressJournalEnabled: true,
+    autoContinueOnTurnLimit: true,
+    maxAutoContinuations: parsed.maxAutoContinuations ?? base?.maxAutoContinuations ?? 12,
+    lifetimeMaxTurns: parsed.lifetimeMaxTurns ?? base?.lifetimeMaxTurns ?? 1200,
+    minProgressScoreForAutoContinue: base?.minProgressScoreForAutoContinue ?? -0.05,
+    continuationStrategy: "adaptive_progress",
+    compactOnContinuation: true,
+    globalNoProgressCircuitBreaker: base?.globalNoProgressCircuitBreaker ?? 4,
+    loopWarningThreshold: base?.loopWarningThreshold ?? 3,
+    loopCriticalThreshold: base?.loopCriticalThreshold ?? 5,
+  };
+}

--- a/src/shared/message-shortcuts.ts
+++ b/src/shared/message-shortcuts.ts
@@ -3,6 +3,7 @@ export type MessageAppShortcutName =
   | "clear"
   | "plan"
   | "cost"
+  | "goal"
   | "compact"
   | "doctor"
   | "undo";
@@ -46,6 +47,12 @@ export const MESSAGE_APP_SHORTCUTS: MessageAppShortcut[] = [
     description: "Estimate effort and model cost before running a task.",
     icon: "💳",
     action: "cost",
+  },
+  {
+    name: "goal",
+    description: "Start or manage a persistent objective.",
+    icon: "🎯",
+    action: "insert",
   },
   {
     name: "compact",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1895,6 +1895,19 @@ export type ReviewPolicy = "off" | "balanced" | "strict";
  */
 export type EntropySweepPolicy = "off" | "balanced" | "strict";
 export type TaskRiskLevel = "low" | "medium" | "high";
+export type PersistentTaskGoalStatus = "active" | "paused" | "completed" | "cleared";
+
+export interface PersistentTaskGoalConfig {
+  objective: string;
+  status: PersistentTaskGoalStatus;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  pausedAt?: number;
+  clearedAt?: number;
+  maxAutoContinuations?: number;
+  lifetimeMaxTurns?: number;
+}
 
 export type IntegrationMentionSource = "builtin" | "gateway" | "mcp";
 export type IntegrationMentionStatus = "configured" | "connected";
@@ -2087,6 +2100,8 @@ export interface AgentConfig {
   preflightRequired?: boolean;
   /** Enable deep work mode: long-running autonomous execution with research-retry, journaling, auto-report */
   deepWorkMode?: boolean;
+  /** Persistent `/goal` lifecycle metadata for long-running task objectives. */
+  goalMode?: PersistentTaskGoalConfig;
   /** Enable auto-report generation on completion (markdown summary of what was done) */
   autoReportEnabled?: boolean;
   /** Enable periodic progress journaling for fire-and-forget visibility */


### PR DESCRIPTION
## Summary
- add /goal parsing, shortcuts, validation, and persistent goal-mode task config
- keep goal runtime state on task metadata through pause/resume/clear transitions
- wire /goal task creation through the renderer and document the shortcut

## Tests
- npm run type-check
- npx vitest run src/shared/__tests__/goal-slash-command.test.ts src/shared/__tests__/message-shortcuts.test.ts