### PR TITLE
Add DeepSeek as a built-in LLM provider

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -12,6 +12,7 @@ CoWork OS is **free and open source**. To run tasks, configure your own model cr
 | Azure Anthropic | API key + endpoint + deployment in Settings | Pay-per-token via Azure |
 | Google Gemini | API key in Settings | Pay-per-token (free tier available) |
 | OpenRouter | API key in Settings (default provider) | Free tier available, pay-per-token for premium models |
+| DeepSeek | API key in Settings | Provider billing |
 | OpenAI (API Key) | API key in Settings | Pay-per-token |
 | OpenAI (ChatGPT OAuth) | Sign in with ChatGPT account | Uses your ChatGPT subscription |
 | AWS Bedrock | AWS credentials in Settings (auto-resolves inference profiles) | Pay-per-token via AWS |

--- a/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
+++ b/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
@@ -25,6 +25,7 @@ function getModelIdWithCustomProviders(
     undefined,
     undefined,
     undefined,
+    undefined,
     customProviders,
     undefined,
   );
@@ -79,6 +80,7 @@ describe("LLMProviderFactory custom provider config resolution", () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       "my-deployment",
       undefined,
       undefined,
@@ -98,6 +100,7 @@ describe("LLMProviderFactory custom provider config resolution", () => {
       undefined, // ollamaModel
       undefined, // geminiModel
       undefined, // openrouterModel
+      undefined, // deepseekModel
       undefined, // openaiModel
       undefined, // azureDeployment
       undefined, // azureAnthropicDeployment
@@ -281,6 +284,61 @@ describe("LLMProviderFactory custom provider config resolution", () => {
         }),
       }),
     );
+  });
+
+  it("uses DeepSeek's documented OpenAI-compatible endpoint", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "ok" } }],
+      }),
+    } as Response);
+
+    const provider = LLMProviderFactory.createProviderFromConfig({
+      type: "deepseek",
+      model: "deepseek-reasoner",
+      deepseekApiKey: "deepseek-key",
+    } as Any);
+
+    await expect(provider.testConnection()).resolves.toEqual({
+      success: true,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.deepseek.com/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer deepseek-key",
+        }),
+      }),
+    );
+  });
+
+  it("blocks DeepSeek Reasoner for tool-using agent turns until reasoning replay is supported", async () => {
+    const provider = LLMProviderFactory.createProviderFromConfig({
+      type: "deepseek",
+      model: "deepseek-reasoner",
+      deepseekApiKey: "deepseek-key",
+    } as Any);
+
+    await expect(
+      provider.createMessage({
+        model: "deepseek-reasoner",
+        messages: [{ role: "user", content: "Use a tool" }],
+        maxTokens: 100,
+        tools: [
+          {
+            name: "example",
+            description: "Example tool",
+            input_schema: {
+              type: "object",
+              properties: {},
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/DeepSeek Reasoner is not supported/);
   });
 
   it("adds documented Z.AI coding-plan models to partial refresh results", async () => {

--- a/src/electron/agent/llm/deepseek-provider.ts
+++ b/src/electron/agent/llm/deepseek-provider.ts
@@ -1,0 +1,34 @@
+import { OpenAICompatibleProvider } from "./openai-compatible-provider";
+import { LLMProviderConfig, LLMRequest, LLMResponse } from "./types";
+
+const DEEPSEEK_BASE_URL = "https://api.deepseek.com";
+const DEFAULT_DEEPSEEK_MODEL = "deepseek-chat";
+
+export class DeepSeekProvider extends OpenAICompatibleProvider {
+  constructor(config: LLMProviderConfig) {
+    if (!config.deepseekApiKey) {
+      throw new Error(
+        "DeepSeek API key is required. Get one at https://platform.deepseek.com/api_keys then add it in Settings > LLM.",
+      );
+    }
+
+    super({
+      type: "deepseek",
+      providerName: "DeepSeek",
+      apiKey: config.deepseekApiKey,
+      baseUrl: config.deepseekBaseUrl || DEEPSEEK_BASE_URL,
+      defaultModel: config.model || DEFAULT_DEEPSEEK_MODEL,
+    });
+  }
+
+  async createMessage(request: LLMRequest): Promise<LLMResponse> {
+    const model = request.model || DEFAULT_DEEPSEEK_MODEL;
+    if (model === "deepseek-reasoner" && request.tools?.length) {
+      throw new Error(
+        "DeepSeek Reasoner is not supported for tool-using agent runs yet. Use deepseek-chat, or disable tools for this route.",
+      );
+    }
+
+    return super.createMessage(request);
+  }
+}

--- a/src/electron/agent/llm/index.ts
+++ b/src/electron/agent/llm/index.ts
@@ -9,6 +9,7 @@ export { AzureOpenAIProvider } from "./azure-openai-provider";
 export { GroqProvider } from "./groq-provider";
 export { XAIProvider } from "./xai-provider";
 export { KimiProvider } from "./kimi-provider";
+export { DeepSeekProvider } from "./deepseek-provider";
 export { AnthropicCompatibleProvider } from "./anthropic-compatible-provider";
 export { GitHubCopilotProvider } from "./github-copilot-provider";
 export { OpenAIOAuth, OpenAIOAuthTokens } from "./openai-oauth";

--- a/src/electron/agent/llm/provider-factory.ts
+++ b/src/electron/agent/llm/provider-factory.ts
@@ -14,6 +14,7 @@ import {
   GROQ_MODELS,
   XAI_MODELS,
   KIMI_MODELS,
+  DEEPSEEK_MODELS,
   ModelKey,
   DEFAULT_MODEL,
   DEFAULT_PI_MODEL,
@@ -33,6 +34,7 @@ import { AzureAnthropicProvider } from "./azure-anthropic-provider";
 import { GroqProvider } from "./groq-provider";
 import { XAIProvider } from "./xai-provider";
 import { KimiProvider } from "./kimi-provider";
+import { DeepSeekProvider } from "./deepseek-provider";
 import { PiProvider } from "./pi-provider";
 import { AnthropicCompatibleProvider } from "./anthropic-compatible-provider";
 import { OpenAICompatibleProvider } from "./openai-compatible-provider";
@@ -638,6 +640,8 @@ function normalizeProviderConfig(config: LLMProviderConfig): LLMProviderConfig {
     geminiApiKey: normalizeSecret(config.geminiApiKey),
     openrouterApiKey: normalizeSecret(config.openrouterApiKey),
     openrouterBaseUrl: normalizeOptionalString(config.openrouterBaseUrl),
+    deepseekApiKey: normalizeSecret(config.deepseekApiKey),
+    deepseekBaseUrl: normalizeOptionalString(config.deepseekBaseUrl),
     openaiApiKey: normalizeSecret(config.openaiApiKey),
     openaiAccessToken: normalizeSecret(config.openaiAccessToken),
     openaiRefreshToken: normalizeSecret(config.openaiRefreshToken),
@@ -733,6 +737,13 @@ function sanitizeSettings(settings: LLMSettings): LLMSettings {
     sanitized.openrouter = {
       ...sanitized.openrouter,
       apiKey: decryptSecret(sanitized.openrouter.apiKey),
+    };
+  }
+
+  if (sanitized.deepseek) {
+    sanitized.deepseek = {
+      ...sanitized.deepseek,
+      apiKey: decryptSecret(sanitized.deepseek.apiKey),
     };
   }
 
@@ -887,6 +898,11 @@ export interface LLMSettings {
     model?: string;
     baseUrl?: string;
   } & ProviderRoutingSettings;
+  deepseek?: {
+    apiKey?: string;
+    model?: string;
+    baseUrl?: string;
+  } & ProviderRoutingSettings;
   openai?: {
     apiKey?: string;
     model?: string;
@@ -1030,6 +1046,7 @@ export interface LLMSettings {
   cachedGroqModels?: CachedModelInfo[];
   cachedXaiModels?: CachedModelInfo[];
   cachedKimiModels?: CachedModelInfo[];
+  cachedDeepSeekModels?: CachedModelInfo[];
   cachedPiModels?: CachedModelInfo[];
   cachedOpenAICompatibleModels?: CachedModelInfo[];
 }
@@ -1076,6 +1093,17 @@ export class LLMProviderFactory {
           model: legacyOpenAICompat.model,
         };
         delete settings.customProviders["openai-compatible"];
+      }
+
+      // Migrate DeepSeek from earlier custom-provider settings to built-in.
+      const legacyDeepSeek = settings.customProviders["deepseek"];
+      if (legacyDeepSeek && !settings.deepseek) {
+        settings.deepseek = {
+          apiKey: legacyDeepSeek.apiKey,
+          baseUrl: legacyDeepSeek.baseUrl,
+          model: legacyDeepSeek.model,
+        };
+        delete settings.customProviders["deepseek"];
       }
     }
 
@@ -1134,6 +1162,7 @@ export class LLMProviderFactory {
     normalizeNode(settings.ollama);
     normalizeNode(settings.gemini);
     normalizeNode(settings.openrouter);
+    normalizeNode(settings.deepseek);
     normalizeNode(settings.openai);
     normalizeNode(settings.azure);
     normalizeNode(settings.azureAnthropic);
@@ -1179,6 +1208,8 @@ export class LLMProviderFactory {
         return Boolean(settings.gemini?.apiKey);
       case "openrouter":
         return Boolean(settings.openrouter?.apiKey);
+      case "deepseek":
+        return Boolean(settings.deepseek?.apiKey);
       case "openai":
         return Boolean(settings.openai?.apiKey || settings.openai?.accessToken);
       case "azure":
@@ -1259,6 +1290,9 @@ export class LLMProviderFactory {
       case "openrouter":
         if (!settings.openrouter && createIfMissing) settings.openrouter = {};
         return settings.openrouter;
+      case "deepseek":
+        if (!settings.deepseek && createIfMissing) settings.deepseek = {};
+        return settings.deepseek;
       case "openai":
         if (!settings.openai && createIfMissing) settings.openai = {};
         return settings.openai;
@@ -1341,6 +1375,7 @@ export class LLMProviderFactory {
     if (next.ollama) applyDefaults("ollama");
     if (next.gemini) applyDefaults("gemini");
     if (next.openrouter) applyDefaults("openrouter");
+    if (next.deepseek) applyDefaults("deepseek");
     if (next.openai) applyDefaults("openai");
     if (next.azure) applyDefaults("azure");
     if (next.azureAnthropic) applyDefaults("azure-anthropic");
@@ -1442,6 +1477,7 @@ export class LLMProviderFactory {
         settings.ollama?.model,
         settings.gemini?.model,
         settings.openrouter?.model,
+        settings.deepseek?.model,
         normalizeOpenAIModelForAuth(
           settings.openai?.model,
           settings.openai?.authMethod,
@@ -1467,6 +1503,7 @@ export class LLMProviderFactory {
         settings.ollama?.model,
         settings.gemini?.model,
         settings.openrouter?.model,
+        settings.deepseek?.model,
         normalizeOpenAIModelForAuth(
           settings.openai?.model,
           settings.openai?.authMethod,
@@ -1852,6 +1889,9 @@ export class LLMProviderFactory {
     if (settings.openrouter?.apiKey) {
       return "openrouter";
     }
+    if (settings.deepseek?.apiKey) {
+      return "deepseek";
+    }
     if (settings.openai?.apiKey || settings.openai?.accessToken) {
       return "openai";
     }
@@ -1972,6 +2012,7 @@ export class LLMProviderFactory {
           settings.ollama?.model,
           settings.gemini?.model,
           settings.openrouter?.model,
+          settings.deepseek?.model,
           normalizeOpenAIModelForAuth(
             settings.openai?.model,
             settings.openai?.authMethod,
@@ -2017,6 +2058,12 @@ export class LLMProviderFactory {
         settings.openrouter?.apiKey,
       openrouterBaseUrl:
         overrideConfig?.openrouterBaseUrl || settings.openrouter?.baseUrl,
+      // DeepSeek config - from settings only
+      deepseekApiKey:
+        normalizeSecret(overrideConfig?.deepseekApiKey) ||
+        settings.deepseek?.apiKey,
+      deepseekBaseUrl:
+        overrideConfig?.deepseekBaseUrl || settings.deepseek?.baseUrl,
       // OpenAI config - from settings only
       openaiApiKey:
         normalizeSecret(overrideConfig?.openaiApiKey) ||
@@ -2130,6 +2177,9 @@ export class LLMProviderFactory {
       case "openrouter":
         provider = new OpenRouterProvider(config);
         break;
+      case "deepseek":
+        provider = new DeepSeekProvider(config);
+        break;
       case "openai":
         provider = new OpenAIProvider(config);
         break;
@@ -2176,6 +2226,7 @@ export class LLMProviderFactory {
     ollamaModel?: string,
     geminiModel?: string,
     openrouterModel?: string,
+    deepseekModel?: string,
     openaiModel?: string,
     azureDeployment?: string,
     azureAnthropicDeployment?: string,
@@ -2207,6 +2258,11 @@ export class LLMProviderFactory {
     // For OpenRouter, use the specific model if provided or default
     if (providerType === "openrouter") {
       return openrouterModel || OPENROUTER_DEFAULT_MODEL;
+    }
+
+    // For DeepSeek, use the specific model if provided or default
+    if (providerType === "deepseek") {
+      return deepseekModel || "deepseek-chat";
     }
 
     // For OpenAI, use the specific model if provided or default
@@ -2329,6 +2385,11 @@ export class LLMProviderFactory {
         type: "openrouter" as LLMProviderType,
         name: "OpenRouter",
         configured: !!settings.openrouter?.apiKey,
+      },
+      {
+        type: "deepseek" as LLMProviderType,
+        name: "DeepSeek",
+        configured: !!settings.deepseek?.apiKey,
       },
       {
         type: "anthropic" as LLMProviderType,
@@ -2570,6 +2631,7 @@ export class LLMProviderFactory {
           settings.openai?.model === storedModel ||
           settings.gemini?.model === storedModel ||
           settings.openrouter?.model === storedModel ||
+          settings.deepseek?.model === storedModel ||
           settings.ollama?.model === storedModel ||
           settings.groq?.model === storedModel ||
           settings.xai?.model === storedModel ||
@@ -2657,6 +2719,22 @@ export class LLMProviderFactory {
           settings.cachedOpenRouterModels.length > 0
             ? settings.cachedOpenRouterModels
             : Object.values(OPENROUTER_MODELS).map((value) => ({
+                key: value.id,
+                displayName: value.displayName,
+                description: value.description,
+              }));
+        return {
+          currentModel,
+          models: attachMetadata(ensureCurrentModel(modelList, currentModel)),
+        };
+      }
+
+      case "deepseek": {
+        const currentModel = settings.deepseek?.model || "deepseek-chat";
+        const modelList =
+          settings.cachedDeepSeekModels && settings.cachedDeepSeekModels.length > 0
+            ? settings.cachedDeepSeekModels
+            : Object.values(DEEPSEEK_MODELS).map((value) => ({
                 key: value.id,
                 displayName: value.displayName,
                 description: value.description,
@@ -3003,6 +3081,9 @@ export class LLMProviderFactory {
       case "openrouter":
         updated.openrouter = { ...settings.openrouter, model: modelKey };
         break;
+      case "deepseek":
+        updated.deepseek = { ...settings.deepseek, model: modelKey };
+        break;
       case "ollama":
         updated.ollama = { ...settings.ollama, model: modelKey };
         break;
@@ -3141,6 +3222,8 @@ export class LLMProviderFactory {
         return patchProviderRouting("gemini");
       case "openrouter":
         return patchProviderRouting("openrouter");
+      case "deepseek":
+        return patchProviderRouting("deepseek");
       case "openai":
         return patchProviderRouting("openai");
       case "azure-anthropic":
@@ -3977,6 +4060,45 @@ export class LLMProviderFactory {
   }
 
   /**
+   * Fetch available DeepSeek models from the API.
+   *
+   * Only deepseek-chat is exposed for agentic routes until the adapter supports
+   * DeepSeek thinking-mode reasoning_content replay across tool continuations.
+   */
+  static async getDeepSeekModels(
+    apiKey?: string,
+    baseUrl?: string,
+  ): Promise<Array<{ id: string; name: string }>> {
+    const settings = this.loadSettings();
+    const normalizedApiKey = apiKey?.trim() || undefined;
+    const key = normalizedApiKey || settings.deepseek?.apiKey;
+    const normalizedBaseUrl = baseUrl?.trim() || undefined;
+    const resolvedBaseUrl = normalizedBaseUrl || settings.deepseek?.baseUrl;
+
+    const defaultModels = [{ id: "deepseek-chat", name: "DeepSeek Chat" }];
+
+    if (!key) {
+      return defaultModels;
+    }
+
+    try {
+      const provider = new DeepSeekProvider({
+        type: "deepseek",
+        model: "deepseek-chat",
+        deepseekApiKey: key,
+        deepseekBaseUrl: resolvedBaseUrl,
+      });
+      const models = await provider.getAvailableModels();
+      const supported = new Set(defaultModels.map((model) => model.id));
+      const filtered = models.filter((model) => supported.has(model.id));
+      return filtered.length > 0 ? filtered : defaultModels;
+    } catch (error: Any) {
+      console.error("Failed to fetch DeepSeek models:", error);
+      return defaultModels;
+    }
+  }
+
+  /**
    * Fetch available Pi models for a given Pi backend provider
    */
   static async getPiModels(
@@ -4060,6 +4182,7 @@ export class LLMProviderFactory {
       | "groq"
       | "xai"
       | "kimi"
+      | "deepseek"
       | "pi"
       | "openai-compatible",
     models: CachedModelInfo[],
@@ -4094,6 +4217,9 @@ export class LLMProviderFactory {
       case "kimi":
         settings.cachedKimiModels = models;
         break;
+      case "deepseek":
+        settings.cachedDeepSeekModels = models;
+        break;
       case "pi":
         settings.cachedPiModels = models;
         break;
@@ -4119,6 +4245,7 @@ export class LLMProviderFactory {
       | "groq"
       | "xai"
       | "kimi"
+      | "deepseek"
       | "pi"
       | "openai-compatible",
   ): CachedModelInfo[] | undefined {
@@ -4143,6 +4270,8 @@ export class LLMProviderFactory {
         return settings.cachedXaiModels;
       case "kimi":
         return settings.cachedKimiModels;
+      case "deepseek":
+        return settings.cachedDeepSeekModels;
       case "pi":
         return settings.cachedPiModels;
       case "openai-compatible":

--- a/src/electron/agent/llm/types.ts
+++ b/src/electron/agent/llm/types.ts
@@ -37,6 +37,9 @@ export interface LLMProviderConfig {
   // OpenRouter-specific
   openrouterApiKey?: string;
   openrouterBaseUrl?: string;
+  // DeepSeek-specific
+  deepseekApiKey?: string;
+  deepseekBaseUrl?: string;
   // OpenAI-specific
   openaiApiKey?: string;
   openaiReasoningEffort?: OpenAIReasoningEffort;
@@ -191,6 +194,7 @@ export const PROVIDER_IMAGE_CAPS: Record<string, LLMProviderImageCaps> = {
     maxImageBytes: 20 * 1024 * 1024,
     supportedMimeTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
   },
+  deepseek: { supportsImages: false, maxImageBytes: 0, supportedMimeTypes: [] },
   xai: {
     supportsImages: true,
     maxImageBytes: 20 * 1024 * 1024,
@@ -594,6 +598,16 @@ export const KIMI_MODELS = {
 } as const;
 
 export type KimiModelKey = keyof typeof KIMI_MODELS;
+
+export const DEEPSEEK_MODELS = {
+  "deepseek-chat": {
+    id: "deepseek-chat",
+    displayName: "DeepSeek Chat",
+    description: "DeepSeek's OpenAI-compatible non-thinking chat model",
+  },
+} as const;
+
+export type DeepSeekModelKey = keyof typeof DEEPSEEK_MODELS;
 
 /**
  * Pi provider backends

--- a/src/electron/control-plane/llm-configure.ts
+++ b/src/electron/control-plane/llm-configure.ts
@@ -4,7 +4,14 @@ import type { LLMProviderType } from "../../shared/types";
 import { LLM_PROVIDER_TYPES } from "../../shared/types";
 
 const VALID_LLM_PROVIDER_TYPES = new Set<string>(LLM_PROVIDER_TYPES as readonly string[]);
-const BASE_URL_PROVIDER_KEYS = new Set<string>(["openrouter", "groq", "xai", "kimi", "ollama"]);
+const BASE_URL_PROVIDER_KEYS = new Set<string>([
+  "openrouter",
+  "deepseek",
+  "groq",
+  "xai",
+  "kimi",
+  "ollama",
+]);
 
 type LlmValidationError = Error & { code: ErrorCode };
 

--- a/src/electron/ipc/handlers.ts
+++ b/src/electron/ipc/handlers.ts
@@ -5328,6 +5328,10 @@ export async function setupIpcHandlers(
           updatedSettings.xai = undefined;
           updatedSettings.cachedXaiModels = undefined;
           break;
+        case "deepseek":
+          updatedSettings.deepseek = undefined;
+          updatedSettings.cachedDeepSeekModels = undefined;
+          break;
         case "kimi":
           updatedSettings.kimi = undefined;
           updatedSettings.cachedKimiModels = undefined;
@@ -5718,6 +5722,27 @@ export async function setupIpcHandlers(
         description: "xAI model",
       }));
       LLMProviderFactory.saveCachedModels("xai", cachedModels);
+      return models;
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.LLM_GET_DEEPSEEK_MODELS,
+    async (_, apiKey?: string, baseUrl?: string) => {
+      checkRateLimit(IPC_CHANNELS.LLM_GET_DEEPSEEK_MODELS);
+      const validatedBaseUrl = await validateOptionalProviderBaseUrl(baseUrl, {
+        providerLabel: "DeepSeek",
+      });
+      const models = await LLMProviderFactory.getDeepSeekModels(
+        validateOptionalProviderApiKey(apiKey, "DeepSeek"),
+        validatedBaseUrl,
+      );
+      const cachedModels = models.map((m) => ({
+        key: m.id,
+        displayName: m.name,
+        description: "DeepSeek model",
+      }));
+      LLMProviderFactory.saveCachedModels("deepseek", cachedModels);
       return models;
     },
   );

--- a/src/electron/ipc/llm-settings-save.ts
+++ b/src/electron/ipc/llm-settings-save.ts
@@ -175,6 +175,9 @@ export function buildSavedLLMSettings(
     openrouter: cleanProviderSettings(
       mergeProviderSettings(validated.openrouter, existingSettings.openrouter),
     ),
+    deepseek: cleanProviderSettings(
+      mergeProviderSettings(validated.deepseek, existingSettings.deepseek),
+    ),
     openai: cleanProviderSettings(openaiSettings),
     azure: normalizeAzureSettings(validated.azure, existingSettings.azure),
     azureAnthropic: normalizeAzureAnthropicSettings(
@@ -210,6 +213,7 @@ export function buildSavedLLMSettings(
     cachedGroqModels: existingSettings.cachedGroqModels,
     cachedXaiModels: existingSettings.cachedXaiModels,
     cachedKimiModels: existingSettings.cachedKimiModels,
+    cachedDeepSeekModels: existingSettings.cachedDeepSeekModels,
     cachedOpenAICompatibleModels: existingSettings.cachedOpenAICompatibleModels,
   };
 }

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -2545,6 +2545,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke(IPC_CHANNELS.LLM_GET_GROQ_MODELS, apiKey, baseUrl),
   getXAIModels: (apiKey?: string, baseUrl?: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.LLM_GET_XAI_MODELS, apiKey, baseUrl),
+  getDeepSeekModels: (apiKey?: string, baseUrl?: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.LLM_GET_DEEPSEEK_MODELS, apiKey, baseUrl),
   getKimiModels: (apiKey?: string, baseUrl?: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.LLM_GET_KIMI_MODELS, apiKey, baseUrl),
   getPiModels: (piProvider?: string) =>
@@ -4998,6 +5000,10 @@ export interface ElectronAPI {
     baseUrl?: string,
   ) => Promise<Array<{ id: string; name: string }>>;
   getXAIModels: (apiKey?: string, baseUrl?: string) => Promise<Array<{ id: string; name: string }>>;
+  getDeepSeekModels: (
+    apiKey?: string,
+    baseUrl?: string,
+  ) => Promise<Array<{ id: string; name: string }>>;
   getKimiModels: (
     apiKey?: string,
     baseUrl?: string,

--- a/src/electron/utils/__tests__/env-migration.test.ts
+++ b/src/electron/utils/__tests__/env-migration.test.ts
@@ -104,6 +104,21 @@ describe("importProcessEnvToSettings", () => {
     expect(saved.openai.apiKey).toBe("sk-new");
   });
 
+  it("imports DeepSeek key and base URL into built-in settings", async () => {
+    process.env.DEEPSEEK_API_KEY = "sk-deepseek";
+    process.env.DEEPSEEK_BASE_URL = "https://deepseek.example/v1";
+
+    mocks.llmLoad.mockReturnValue({ providerType: "anthropic", modelKey: "opus-4-5" });
+    mocks.searchLoad.mockReturnValue({ primaryProvider: null, fallbackProvider: null });
+
+    await importProcessEnvToSettings({ mode: "merge" });
+
+    const saved = mocks.llmSave.mock.calls[0][0];
+    expect(saved.deepseek.apiKey).toBe("sk-deepseek");
+    expect(saved.deepseek.baseUrl).toBe("https://deepseek.example/v1");
+    expect(saved.providerType).toBe("deepseek");
+  });
+
   it("imports Tavily key into search settings", async () => {
     process.env.TAVILY_API_KEY = "tav-test";
 

--- a/src/electron/utils/env-migration.ts
+++ b/src/electron/utils/env-migration.ts
@@ -79,6 +79,8 @@ function isProviderConfigured(
       return !!normalizeEnvValue(settings?.gemini?.apiKey);
     case "openrouter":
       return !!normalizeEnvValue(settings?.openrouter?.apiKey);
+    case "deepseek":
+      return !!normalizeEnvValue(settings?.deepseek?.apiKey);
     case "azure": {
       const hasKey = !!normalizeEnvValue(settings?.azure?.apiKey);
       const hasEndpoint = !!normalizeEnvValue(settings?.azure?.endpoint);
@@ -127,6 +129,7 @@ function pickProviderFromSettings(settings: Any): LLMProviderType | null {
     return "anthropic";
   if (normalizeEnvValue(settings?.gemini?.apiKey)) return "gemini";
   if (normalizeEnvValue(settings?.openrouter?.apiKey)) return "openrouter";
+  if (normalizeEnvValue(settings?.deepseek?.apiKey)) return "deepseek";
   if (
     normalizeEnvValue(settings?.azure?.apiKey) &&
     normalizeEnvValue(settings?.azure?.endpoint) &&
@@ -166,6 +169,7 @@ function validateProviderType(raw: string | undefined): LLMProviderType | null {
     "ollama",
     "gemini",
     "openrouter",
+    "deepseek",
     "openai",
     "azure",
     "groq",
@@ -302,6 +306,17 @@ export async function migrateEnvToSettings(): Promise<MigrationResult> {
         apiKey: env.OPENROUTER_API_KEY,
       };
       migratedKeys.push("OpenRouter API Key");
+      llmChanged = true;
+    }
+
+    // Migrate DeepSeek API key
+    if (env.DEEPSEEK_API_KEY && !llmSettings.deepseek?.apiKey) {
+      llmSettings.deepseek = {
+        ...llmSettings.deepseek,
+        apiKey: env.DEEPSEEK_API_KEY,
+        baseUrl: env.DEEPSEEK_BASE_URL || llmSettings.deepseek?.baseUrl,
+      };
+      migratedKeys.push("DeepSeek API Key");
       llmChanged = true;
     }
 
@@ -516,6 +531,28 @@ export async function importProcessEnvToSettings(
         apiKey: openrouterApiKey,
       };
       migratedKeys.push("OpenRouter API Key");
+      llmChanged = true;
+    }
+
+    const deepseekApiKey = normalizeEnvValue(process.env.DEEPSEEK_API_KEY);
+    const deepseekBaseUrl = normalizeEnvValue(process.env.DEEPSEEK_BASE_URL);
+    if (shouldWriteValue(llmSettings?.deepseek?.apiKey, deepseekApiKey, mode)) {
+      llmSettings.deepseek = {
+        ...llmSettings.deepseek,
+        apiKey: deepseekApiKey,
+        ...(deepseekBaseUrl ? { baseUrl: deepseekBaseUrl } : {}),
+      };
+      migratedKeys.push("DeepSeek API Key");
+      llmChanged = true;
+    } else if (
+      deepseekBaseUrl &&
+      shouldWriteValue(llmSettings?.deepseek?.baseUrl, deepseekBaseUrl, mode)
+    ) {
+      llmSettings.deepseek = {
+        ...llmSettings.deepseek,
+        baseUrl: deepseekBaseUrl,
+      };
+      migratedKeys.push("DeepSeek Base URL");
       llmChanged = true;
     }
 

--- a/src/electron/utils/validation.ts
+++ b/src/electron/utils/validation.ts
@@ -648,6 +648,15 @@ export const OpenRouterSettingsSchema = z
   })
   .optional();
 
+export const DeepSeekSettingsSchema = z
+  .object({
+    apiKey: z.string().max(500).optional(),
+    model: z.string().max(200).optional(),
+    baseUrl: z.string().max(500).optional(),
+    ...ProviderRoutingSettingsSchema,
+  })
+  .optional();
+
 export const OpenAISettingsSchema = z
   .object({
     apiKey: z.string().max(500).optional(),
@@ -846,6 +855,7 @@ export const LLMSettingsSchema = z.object({
   ollama: OllamaSettingsSchema,
   gemini: GeminiSettingsSchema,
   openrouter: OpenRouterSettingsSchema,
+  deepseek: DeepSeekSettingsSchema,
   openai: OpenAISettingsSchema,
   azure: AzureSettingsSchema,
   azureAnthropic: AzureAnthropicSettingsSchema,

--- a/src/renderer/components/Onboarding/Onboarding.tsx
+++ b/src/renderer/components/Onboarding/Onboarding.tsx
@@ -66,6 +66,7 @@ const PROVIDERS: {
   { id: "ollama", name: "Ollama", requiresKey: false },
   { id: "groq", name: "Groq", requiresKey: true },
   { id: "xai", name: "Grok", requiresKey: true },
+  { id: "deepseek", name: "DeepSeek", requiresKey: true },
   { id: "kimi", name: "Kimi", requiresKey: true },
   { id: "bedrock", name: "AWS Bedrock", requiresKey: false },
 ];
@@ -78,6 +79,7 @@ const PROVIDER_URLS: Record<string, string> = {
   openrouter: "https://openrouter.ai/keys",
   groq: "https://console.groq.com/keys",
   xai: "https://console.x.ai/",
+  deepseek: "https://platform.deepseek.com/api_keys",
   kimi: "https://platform.moonshot.ai/",
 };
 
@@ -1690,7 +1692,9 @@ export function Onboarding({ onComplete, workspaceId }: OnboardingProps) {
                         ? "Groq Console"
                         : provider === "xai"
                           ? "xAI Console"
-                          : "Moonshot Platform"}
+                          : provider === "deepseek"
+                            ? "DeepSeek Platform"
+                            : "Moonshot Platform"}
             </a>
           </p>
         )}

--- a/src/renderer/components/OnboardingModal.tsx
+++ b/src/renderer/components/OnboardingModal.tsx
@@ -21,6 +21,7 @@ type LLMProviderType =
   | "bedrock"
   | "groq"
   | "xai"
+  | "deepseek"
   | "kimi";
 
 interface ProviderOption {
@@ -191,6 +192,27 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
     requiresApiKey: true,
     apiKeyPlaceholder: "xai-...",
     apiKeyLink: "https://console.x.ai/",
+  },
+  {
+    type: "deepseek",
+    name: "DeepSeek",
+    description: "DeepSeek Chat for agentic runs",
+    icon: (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M12 3l8 9-8 9-8-9 8-9z" />
+        <path d="M8 12h8" />
+      </svg>
+    ),
+    requiresApiKey: true,
+    apiKeyPlaceholder: "sk-...",
+    apiKeyLink: "https://platform.deepseek.com/api_keys",
   },
   {
     type: "kimi",
@@ -423,6 +445,8 @@ export function OnboardingModal({
         testConfig.groq = { apiKey };
       } else if (selectedProvider === "xai") {
         testConfig.xai = { apiKey };
+      } else if (selectedProvider === "deepseek") {
+        testConfig.deepseek = { apiKey, model: "deepseek-chat" };
       } else if (selectedProvider === "kimi") {
         testConfig.kimi = { apiKey };
       }
@@ -461,6 +485,8 @@ export function OnboardingModal({
           settings.groq = { apiKey, model: "llama-3.1-8b-instant" };
         } else if (selectedProvider === "xai") {
           settings.xai = { apiKey, model: "grok-4-fast-non-reasoning" };
+        } else if (selectedProvider === "deepseek") {
+          settings.deepseek = { apiKey, model: "deepseek-chat" };
         } else if (selectedProvider === "kimi") {
           settings.kimi = { apiKey, model: "kimi-k2.5" };
         }
@@ -511,6 +537,8 @@ export function OnboardingModal({
         return "llama-3.1-8b-instant";
       case "xai":
         return "grok-4-fast-non-reasoning";
+      case "deepseek":
+        return "deepseek-chat";
       case "kimi":
         return "kimi-k2.5";
       default:

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1003,6 +1003,7 @@ const LLM_PROVIDER_ICONS: Record<string, ReactNode> = {
   "azure-anthropic": <Cloud {...S} />,
   gemini: <Star {...S} />,
   openrouter: <Globe {...S} />,
+  deepseek: <Hexagon {...S} />,
   ollama: <Box {...S} />,
   groq: <Crosshair {...S} />,
   xai: <AtSign {...S} />,
@@ -1011,6 +1012,8 @@ const LLM_PROVIDER_ICONS: Record<string, ReactNode> = {
   pi: <Pi {...S} />,
   "hf-agents": <Zap {...S} />,
 };
+
+const DEFAULT_DEEPSEEK_MODELS = [{ id: "deepseek-chat", name: "DeepSeek Chat" }];
 
 const getLLMProviderIcon = (
   providerType: string,
@@ -1443,6 +1446,15 @@ export function Settings({
   >([]);
   const [loadingXaiModels, setLoadingXaiModels] = useState(false);
 
+  // DeepSeek state
+  const [deepseekApiKey, setDeepseekApiKey] = useState("");
+  const [deepseekBaseUrl, setDeepseekBaseUrl] = useState("");
+  const [deepseekModel, setDeepseekModel] = useState("deepseek-chat");
+  const [deepseekModels, setDeepseekModels] = useState<
+    Array<{ id: string; name: string }>
+  >(DEFAULT_DEEPSEEK_MODELS);
+  const [loadingDeepseekModels, setLoadingDeepseekModels] = useState(false);
+
   // Kimi state
   const [kimiApiKey, setKimiApiKey] = useState("");
   const [kimiBaseUrl, setKimiBaseUrl] = useState("");
@@ -1755,6 +1767,8 @@ export function Settings({
         return settings.groq || {};
       case "xai":
         return settings.xai || {};
+      case "deepseek":
+        return settings.deepseek || {};
       case "kimi":
         return settings.kimi || {};
       case "pi":
@@ -1814,6 +1828,8 @@ export function Settings({
             return settings.groq;
           case "xai":
             return settings.xai;
+          case "deepseek":
+            return settings.deepseek;
           case "kimi":
             return settings.kimi;
           case "pi":
@@ -1897,6 +1913,9 @@ export function Settings({
       case "xai":
         patchSettings("xai");
         return;
+      case "deepseek":
+        patchSettings("deepseek");
+        return;
       case "kimi":
         patchSettings("kimi");
         return;
@@ -1951,6 +1970,8 @@ export function Settings({
         return groqModel || settings.groq?.model || "";
       case "xai":
         return xaiModel || settings.xai?.model || "";
+      case "deepseek":
+        return deepseekModel || settings.deepseek?.model || "";
       case "kimi":
         return kimiModel || settings.kimi?.model || "";
       case "pi":
@@ -2368,6 +2389,17 @@ export function Settings({
         setXaiModel(loadedSettings.xai.model);
       }
 
+      // Set DeepSeek form state
+      if (loadedSettings.deepseek?.apiKey) {
+        setDeepseekApiKey(loadedSettings.deepseek.apiKey);
+      }
+      if (loadedSettings.deepseek?.baseUrl) {
+        setDeepseekBaseUrl(loadedSettings.deepseek.baseUrl);
+      }
+      if (loadedSettings.deepseek?.model) {
+        setDeepseekModel(loadedSettings.deepseek.model);
+      }
+
       // Set Kimi form state
       if (loadedSettings.kimi?.apiKey) {
         setKimiApiKey(loadedSettings.kimi.apiKey);
@@ -2736,6 +2768,30 @@ export function Settings({
     }
   };
 
+  const loadDeepSeekModels = async (apiKey?: string) => {
+    try {
+      setLoadingDeepseekModels(true);
+      const models = await window.electronAPI.getDeepSeekModels(
+        apiKey || deepseekApiKey,
+        deepseekBaseUrl || undefined,
+      );
+      const availableModels = models && models.length > 0 ? models : DEFAULT_DEEPSEEK_MODELS;
+      setDeepseekModels(availableModels);
+      if (
+        availableModels.length > 0 &&
+        !availableModels.some((m) => m.id === deepseekModel)
+      ) {
+        setDeepseekModel(availableModels[0].id);
+      }
+      onSettingsChanged?.();
+    } catch (error) {
+      console.error("Failed to load DeepSeek models:", error);
+      setDeepseekModels(DEFAULT_DEEPSEEK_MODELS);
+    } finally {
+      setLoadingDeepseekModels(false);
+    }
+  };
+
   const loadKimiModels = async (apiKey?: string) => {
     try {
       setLoadingKimiModels(true);
@@ -2925,6 +2981,8 @@ export function Settings({
       loadGroqModels();
     } else if (providerType === "xai") {
       loadXAIModels();
+    } else if (providerType === "deepseek") {
+      loadDeepSeekModels();
     } else if (providerType === "kimi") {
       loadKimiModels();
     } else if (providerType === "pi") {
@@ -3187,6 +3245,12 @@ export function Settings({
         setXaiModel("grok-4-fast-non-reasoning");
         setXaiModels([]);
         break;
+      case "deepseek":
+        setDeepseekApiKey("");
+        setDeepseekBaseUrl("");
+        setDeepseekModel("deepseek-chat");
+        setDeepseekModels(DEFAULT_DEEPSEEK_MODELS);
+        break;
       case "kimi":
         setKimiApiKey("");
         setKimiBaseUrl("");
@@ -3428,6 +3492,14 @@ export function Settings({
           baseUrl: xaiBaseUrl || undefined,
           ...routingFor("xai"),
           ...failoverFor("xai"),
+        },
+        // Always include DeepSeek settings
+        deepseek: {
+          apiKey: deepseekApiKey || undefined,
+          model: deepseekModel || undefined,
+          baseUrl: deepseekBaseUrl || undefined,
+          ...routingFor("deepseek"),
+          ...failoverFor("deepseek"),
         },
         // Always include Kimi settings
         kimi: {
@@ -3690,6 +3762,14 @@ export function Settings({
                 apiKey: xaiApiKey || undefined,
                 model: xaiModel || undefined,
                 baseUrl: xaiBaseUrl || undefined,
+              }
+            : undefined,
+        deepseek:
+          settings.providerType === "deepseek"
+            ? {
+                apiKey: deepseekApiKey || undefined,
+                model: deepseekModel || undefined,
+                baseUrl: deepseekBaseUrl || undefined,
               }
             : undefined,
         kimi:
@@ -5532,6 +5612,82 @@ export function Settings({
                   placeholder="grok-4-fast-non-reasoning"
                   value={xaiModel}
                   onChange={(e) => setXaiModel(e.target.value)}
+                />
+              )}
+            </div>
+          </>
+        )}
+
+        {settings.providerType === "deepseek" && (
+          <>
+            <div className="settings-section">
+              <h3>DeepSeek API Key</h3>
+              <p className="settings-description">
+                Enter your API key from{" "}
+                <a
+                  href="https://platform.deepseek.com/api_keys"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  DeepSeek Platform
+                </a>
+              </p>
+              <div className="settings-input-group">
+                <input
+                  type="password"
+                  className="settings-input"
+                  placeholder="sk-..."
+                  value={deepseekApiKey}
+                  onChange={(e) => setDeepseekApiKey(e.target.value)}
+                />
+                <button
+                  className="button-small button-secondary"
+                  onClick={() => loadDeepSeekModels(deepseekApiKey)}
+                  disabled={loadingDeepseekModels}
+                >
+                  {loadingDeepseekModels ? "Loading..." : "Refresh Models"}
+                </button>
+              </div>
+            </div>
+
+            <div className="settings-section">
+              <h3>Base URL</h3>
+              <p className="settings-description">
+                Optional override for the DeepSeek API endpoint.
+              </p>
+              <input
+                type="text"
+                className="settings-input"
+                placeholder="https://api.deepseek.com"
+                value={deepseekBaseUrl}
+                onChange={(e) => setDeepseekBaseUrl(e.target.value)}
+              />
+            </div>
+
+            <div className="settings-section">
+              <h3>Model</h3>
+              <p className="settings-description">
+                DeepSeek Chat is enabled for agentic tool use. DeepSeek
+                Reasoner is hidden until thinking-mode tool continuation is
+                supported.
+              </p>
+              {deepseekModels.length > 0 ? (
+                <SearchableSelect
+                  options={deepseekModels.map((model) => ({
+                    value: model.id,
+                    label: model.name,
+                  }))}
+                  value={deepseekModel}
+                  onChange={setDeepseekModel}
+                  placeholder="Select a model..."
+                />
+              ) : (
+                <input
+                  type="text"
+                  className="settings-input"
+                  placeholder="deepseek-chat"
+                  value={deepseekModel}
+                  onChange={(e) => setDeepseekModel(e.target.value)}
                 />
               )}
             </div>

--- a/src/renderer/hooks/useOnboardingFlow.ts
+++ b/src/renderer/hooks/useOnboardingFlow.ts
@@ -123,6 +123,7 @@ const SCRIPT = {
       bedrock: "AWS Bedrock. Enterprise-ready.",
       groq: "Groq. Speedy and efficient.",
       xai: "Grok. Let's put xAI to work.",
+      deepseek: "DeepSeek. Practical and cost-efficient.",
       kimi: "Kimi. Solid choice.",
     };
     return responses[provider] || "Good choice.";
@@ -1221,6 +1222,8 @@ export function useOnboardingFlow({ onComplete, workspaceId }: UseOnboardingOpti
         return "llama-3.1-8b-instant";
       case "xai":
         return "grok-4-fast-non-reasoning";
+      case "deepseek":
+        return "deepseek-chat";
       case "kimi":
         return "kimi-k2.5";
       default:
@@ -1268,6 +1271,9 @@ export function useOnboardingFlow({ onComplete, workspaceId }: UseOnboardingOpti
         case "xai":
           currentModel = existingSettings.xai?.model;
           break;
+        case "deepseek":
+          currentModel = existingSettings.deepseek?.model;
+          break;
         case "kimi":
           currentModel = existingSettings.kimi?.model;
           break;
@@ -1313,6 +1319,8 @@ export function useOnboardingFlow({ onComplete, workspaceId }: UseOnboardingOpti
           return !!existingSettings.groq?.apiKey;
         case "xai":
           return !!existingSettings.xai?.apiKey;
+        case "deepseek":
+          return !!existingSettings.deepseek?.apiKey;
         case "kimi":
           return !!existingSettings.kimi?.apiKey;
         default:
@@ -1343,6 +1351,8 @@ export function useOnboardingFlow({ onComplete, workspaceId }: UseOnboardingOpti
         testConfig.groq = { apiKey };
       } else if (provider === "xai") {
         testConfig.xai = { apiKey };
+      } else if (provider === "deepseek") {
+        testConfig.deepseek = { apiKey, model: "deepseek-chat" };
       } else if (provider === "kimi") {
         testConfig.kimi = { apiKey };
       }
@@ -1417,6 +1427,12 @@ export function useOnboardingFlow({ onComplete, workspaceId }: UseOnboardingOpti
       } else if (provider === "xai") {
         settings.xai = {
           ...existingSettings?.xai,
+          ...(trimmedApiKey ? { apiKey: trimmedApiKey } : {}),
+          model: modelKey,
+        };
+      } else if (provider === "deepseek") {
+        settings.deepseek = {
+          ...existingSettings?.deepseek,
           ...(trimmedApiKey ? { apiKey: trimmedApiKey } : {}),
           model: modelKey,
         };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6838,6 +6838,7 @@ export const IPC_CHANNELS = {
   LLM_GET_OLLAMA_MODELS: "llm:getOllamaModels",
   LLM_GET_GEMINI_MODELS: "llm:getGeminiModels",
   LLM_GET_OPENROUTER_MODELS: "llm:getOpenRouterModels",
+  LLM_GET_DEEPSEEK_MODELS: "llm:getDeepSeekModels",
   LLM_GET_OPENAI_MODELS: "llm:getOpenAIModels",
   LLM_GET_GROQ_MODELS: "llm:getGroqModels",
   LLM_GET_XAI_MODELS: "llm:getXAIModels",
@@ -7485,6 +7486,7 @@ export const BUILTIN_LLM_PROVIDER_TYPES = [
   "ollama",
   "gemini",
   "openrouter",
+  "deepseek",
   "openai",
   "azure",
   "azure-anthropic",
@@ -7537,6 +7539,7 @@ export const MULTI_LLM_PROVIDER_DISPLAY: Record<
   gemini: { name: "Gemini", icon: "\u{2728}", color: "#6366f1" },
   openrouter: { name: "OpenRouter", icon: "\u{1F310}", color: "#8b5cf6" },
   openai: { name: "OpenAI", icon: "\u{1F916}", color: "#10b981" },
+  deepseek: { name: "DeepSeek", icon: "\u{25C6}", color: "#2563eb" },
   azure: { name: "Azure OpenAI", icon: "\u{1F7E6}", color: "#0078d4" },
   "azure-anthropic": {
     name: "Azure Anthropic",
@@ -7655,6 +7658,11 @@ export interface LLMSettingsData {
     model?: string;
   } & ProviderRoutingSettings;
   openrouter?: {
+    apiKey?: string;
+    model?: string;
+    baseUrl?: string;
+  } & ProviderRoutingSettings;
+  deepseek?: {
     apiKey?: string;
     model?: string;
     baseUrl?: string;
@@ -7813,6 +7821,7 @@ export interface LLMSettingsData {
   cachedGroqModels?: CachedModelInfo[];
   cachedXaiModels?: CachedModelInfo[];
   cachedKimiModels?: CachedModelInfo[];
+  cachedDeepSeekModels?: CachedModelInfo[];
   cachedPiModels?: CachedModelInfo[];
   cachedOpenAICompatibleModels?: CachedModelInfo[];
   customProviders?: Record<string, CustomProviderConfig>;

--- a/tests/electron/control-plane-llm-configure.test.ts
+++ b/tests/electron/control-plane-llm-configure.test.ts
@@ -94,4 +94,21 @@ describe('control-plane llm-configure', () => {
       expect(String(error.message)).toContain('providerType=bedrock');
     }
   });
+
+  it('configures DeepSeek as a built-in provider', () => {
+    configureLlmFromControlPlaneParams({
+      providerType: 'deepseek',
+      apiKey: 'sk-deepseek',
+      model: 'deepseek-reasoner',
+    });
+
+    expect(mockFactory.applyModelSelection).toHaveBeenCalledWith(expect.any(Object), 'deepseek-reasoner');
+    expect(mockFactory.saveSettings).toHaveBeenCalledWith(expect.objectContaining({
+      providerType: 'deepseek',
+      modelKey: 'deepseek-reasoner',
+      deepseek: expect.objectContaining({
+        apiKey: 'sk-deepseek',
+      }),
+    }));
+  });
 });


### PR DESCRIPTION
## Summary
- Add DeepSeek as a first-class built-in provider across settings, onboarding, control-plane configuration, IPC, and env import.
- Introduce a dedicated DeepSeek provider with the documented API endpoint and built-in model selection.
- Keep `deepseek-chat` available for agentic use and block `deepseek-reasoner` for tool-using runs until reasoning replay is supported.
- Update docs and compatibility migration so earlier custom-provider DeepSeek settings flow into the new built-in shape.

## Testing
- Added and updated unit coverage for DeepSeek provider resolution, env import, and control-plane configuration.
- Ran focused Vitest suites, `type-check`, and lint successfully; formatting check still fails in this repo because the existing formatter config cannot load `vite.config.ts` as JSON-serializable config.