### PR TITLE
Harden MCP registry package verification and path containment

### DIFF
--- a/src/daemon/control-plane-methods.ts
+++ b/src/daemon/control-plane-methods.ts
@@ -38,6 +38,7 @@ import { sanitizeTaskMessageParams } from "../electron/control-plane/sanitize";
 import { registerControlPlaneCoreMethods } from "../electron/control-plane/registerControlPlaneCoreMethods";
 import { registerStrategicPlannerMethods } from "../electron/control-plane/registerStrategicPlannerMethods";
 import { getStrategicPlannerService } from "../electron/control-plane/StrategicPlannerService";
+import { resolvePathWithinRoot } from "../electron/control-plane/path-containment";
 
 export interface ControlPlaneMethodDeps {
   agentDaemon: AgentDaemon;
@@ -881,9 +882,8 @@ export function registerControlPlaneMethods(
       throw { code: ErrorCodes.INVALID_PARAMS, message: `Workspace not found: ${workspaceId}` };
     }
 
-    const fullPath = path.join(workspace.path, relativePath);
-    const resolved = path.resolve(fullPath);
-    if (!resolved.startsWith(path.resolve(workspace.path))) {
+    const resolved = resolvePathWithinRoot(workspace.path, relativePath);
+    if (!resolved) {
       throw { code: ErrorCodes.INVALID_PARAMS, message: "Path escapes workspace" };
     }
 

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -11194,7 +11194,7 @@ ${transcript}
     const summary =
       typeof resultSummary === "string" && resultSummary.trim()
         ? resultSummary.trim()
-        : this.buildResultSummary();
+        : this.buildResultSummary() || "";
     const runtimeProjection = this.applyRuntimeTaskProjectionToTask();
     this.task.status = "completed";
     this.task.completedAt = Date.now();
@@ -11283,7 +11283,7 @@ ${transcript}
     const summary =
       typeof resultSummary === "string" && resultSummary.trim()
         ? resultSummary.trim()
-        : this.buildResultSummary();
+        : this.buildResultSummary() || "";
     this.task.status = "completed";
     this.task.completedAt = Date.now();
     const fallbackTerminalStatus: NonNullable<Task["terminalStatus"]> =

--- a/src/electron/control-plane/__tests__/path-containment.test.ts
+++ b/src/electron/control-plane/__tests__/path-containment.test.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolvePathWithinRoot } from "../path-containment";
+
+describe("resolvePathWithinRoot", () => {
+  it("resolves workspace-relative paths inside the root", () => {
+    const root = path.join(path.sep, "tmp", "work");
+
+    expect(resolvePathWithinRoot(root, "src/index.ts")).toBe(
+      path.join(path.sep, "tmp", "work", "src", "index.ts"),
+    );
+  });
+
+  it("allows the workspace root itself", () => {
+    const root = path.join(path.sep, "tmp", "work");
+
+    expect(resolvePathWithinRoot(root, ".")).toBe(root);
+  });
+
+  it("rejects sibling paths that share the root prefix", () => {
+    const root = path.join(path.sep, "tmp", "work");
+
+    expect(resolvePathWithinRoot(root, "../work-secrets")).toBeNull();
+  });
+
+  it("does not reject same-prefix descendants inside the root", () => {
+    const root = path.join(path.sep, "tmp", "work");
+
+    expect(resolvePathWithinRoot(root, "work-secrets/file.txt")).toBe(
+      path.join(path.sep, "tmp", "work", "work-secrets", "file.txt"),
+    );
+  });
+});

--- a/src/electron/control-plane/handlers.ts
+++ b/src/electron/control-plane/handlers.ts
@@ -95,6 +95,7 @@ import {
   buildTaskEventHistoryForTransport,
   serializeTaskEventForTransport,
 } from "./task-event-transport";
+import { resolvePathWithinRoot } from "./path-containment";
 
 // Server instance
 let controlPlaneServer: ControlPlaneServer | null = null;
@@ -2761,9 +2762,8 @@ function registerTaskAndWorkspaceMethods(
       throw { code: ErrorCodes.INVALID_PARAMS, message: `Workspace not found: ${workspaceId}` };
     }
 
-    const fullPath = path.join(workspace.path, relativePath);
-    const resolved = path.resolve(fullPath);
-    if (!resolved.startsWith(path.resolve(workspace.path))) {
+    const resolved = resolvePathWithinRoot(workspace.path, relativePath);
+    if (!resolved) {
       throw { code: ErrorCodes.INVALID_PARAMS, message: "Path escapes workspace" };
     }
 

--- a/src/electron/control-plane/path-containment.ts
+++ b/src/electron/control-plane/path-containment.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+
+export function resolvePathWithinRoot(rootPath: string, requestedPath: string): string | null {
+  const resolvedRoot = path.resolve(rootPath);
+  const resolvedPath = path.resolve(path.join(resolvedRoot, requestedPath));
+  const relative = path.relative(resolvedRoot, resolvedPath);
+
+  if (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
+  ) {
+    return resolvedPath;
+  }
+
+  return null;
+}

--- a/src/electron/gateway/router.ts
+++ b/src/electron/gateway/router.ts
@@ -1751,6 +1751,7 @@ export class MessageRouter {
         settings.ollama?.model,
         settings.gemini?.model,
         settings.openrouter?.model,
+        settings.deepseek?.model,
         settings.openai?.model,
         azureDeployment,
         azureAnthropicDeployment,

--- a/src/electron/ipc/handlers.ts
+++ b/src/electron/ipc/handlers.ts
@@ -5426,6 +5426,7 @@ export async function setupIpcHandlers(
         validatedConfig.ollama?.model,
         validatedConfig.gemini?.model,
         validatedConfig.openrouter?.model,
+        validatedConfig.deepseek?.model,
         validatedConfig.openai?.model,
         azureDeployment,
         azureAnthropicDeployment,

--- a/src/electron/mcp/__tests__/MCPRegistryManager.test.ts
+++ b/src/electron/mcp/__tests__/MCPRegistryManager.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockState = vi.hoisted(() => ({
   addServerMock: vi.fn(),
+  execFileMock: vi.fn(),
   loadSettingsMock: vi.fn(),
   mockInstalledServers: [] as Any[],
 }));
@@ -19,6 +20,10 @@ vi.mock("fs", () => ({
   existsSync: vi.fn().mockReturnValue(true),
 }));
 
+vi.mock("child_process", () => ({
+  execFile: mockState.execFileMock,
+}));
+
 vi.mock("../settings", () => ({
   MCPSettingsManager: {
     loadSettings: mockState.loadSettingsMock,
@@ -34,6 +39,10 @@ describe("MCPRegistryManager install defaults", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockState.mockInstalledServers = [];
+    mockState.execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: Any, callback: Any) =>
+        callback(null, "2026.1.14\n", ""),
+    );
     mockState.loadSettingsMock.mockImplementation(() => ({
       servers: mockState.mockInstalledServers,
       autoConnect: true,
@@ -91,5 +100,30 @@ describe("MCPRegistryManager install defaults", () => {
     expect(ids).not.toContain("slack");
     expect(ids).not.toContain("docusign");
     expect(ids).not.toContain("outreach");
+  });
+
+  it("verifies npm packages with fixed argv instead of a shell command", async () => {
+    const result = await MCPRegistryManager.verifyNpmPackage(
+      "@modelcontextprotocol/server-postgres",
+    );
+
+    expect(result).toEqual({ exists: true, version: "2026.1.14" });
+    expect(mockState.execFileMock).toHaveBeenCalledTimes(1);
+    expect(mockState.execFileMock).toHaveBeenCalledWith(
+      "npm",
+      ["view", "@modelcontextprotocol/server-postgres", "version"],
+      { timeout: 15000 },
+      expect.any(Function),
+    );
+  });
+
+  it("rejects malicious npm package names before spawning npm", async () => {
+    const result = await MCPRegistryManager.verifyNpmPackage(
+      "--version; printf COWORK_INJECTED",
+    );
+
+    expect(result.exists).toBe(false);
+    expect(result.error).toContain("Invalid npm package name");
+    expect(mockState.execFileMock).not.toHaveBeenCalled();
   });
 });

--- a/src/electron/mcp/registry/MCPRegistryManager.ts
+++ b/src/electron/mcp/registry/MCPRegistryManager.ts
@@ -9,8 +9,7 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
-import { exec } from "child_process";
-import { promisify } from "util";
+import { execFile } from "child_process";
 import * as path from "path";
 import * as fs from "fs";
 import {
@@ -22,10 +21,10 @@ import {
 } from "../types";
 import { MCPSettingsManager } from "../settings";
 
-const execAsync = promisify(exec);
-
 // Cache duration in milliseconds (15 minutes)
 const REGISTRY_CACHE_DURATION = 15 * 60 * 1000;
+const MAX_NPM_PACKAGE_NAME_LENGTH = 214;
+const NPM_PACKAGE_PART_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
 
 // Built-in registry of common MCP servers
 // This is used as a fallback when the remote registry is unavailable.
@@ -2203,6 +2202,55 @@ function validateManualEntry(entry: MCPRegistryEntry): void {
   }
 }
 
+function isValidNpmPackagePart(part: string): boolean {
+  return (
+    part.length > 0 &&
+    !part.startsWith(".") &&
+    !part.startsWith("_") &&
+    !part.startsWith("-") &&
+    NPM_PACKAGE_PART_PATTERN.test(part)
+  );
+}
+
+function isValidNpmPackageName(packageName: string): boolean {
+  if (
+    packageName.length === 0 ||
+    packageName.length > MAX_NPM_PACKAGE_NAME_LENGTH ||
+    packageName.trim() !== packageName
+  ) {
+    return false;
+  }
+
+  if (packageName.startsWith("@")) {
+    const parts = packageName.split("/");
+    return (
+      parts.length === 2 &&
+      parts[0].length > 1 &&
+      isValidNpmPackagePart(parts[0].slice(1)) &&
+      isValidNpmPackagePart(parts[1])
+    );
+  }
+
+  return !packageName.includes("/") && isValidNpmPackagePart(packageName);
+}
+
+function npmViewVersion(packageName: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "npm",
+      ["view", packageName, "version"],
+      { timeout: 15000 },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
 export class MCPRegistryManager {
   private static registryCache: MCPRegistry | null = null;
   private static cacheTimestamp: number = 0;
@@ -2333,11 +2381,13 @@ export class MCPRegistryManager {
   static async verifyNpmPackage(
     packageName: string,
   ): Promise<{ exists: boolean; version?: string; error?: string }> {
+    if (!isValidNpmPackageName(packageName)) {
+      return { exists: false, error: `Invalid npm package name: "${packageName}"` };
+    }
+
     try {
       console.log(`[MCPRegistryManager] Verifying npm package: ${packageName}`);
-      const { stdout } = await execAsync(`npm view ${packageName} version`, {
-        timeout: 15000, // 15 second timeout
-      });
+      const stdout = await npmViewVersion(packageName);
       const version = stdout.trim();
       console.log(`[MCPRegistryManager] Package ${packageName} exists, version: ${version}`);
       return { exists: true, version };

--- a/src/electron/memory/ChatGPTImporter.ts
+++ b/src/electron/memory/ChatGPTImporter.ts
@@ -541,6 +541,7 @@ export class ChatGPTImporter {
           settings.ollama?.model,
           settings.gemini?.model,
           settings.openrouter?.model,
+          settings.deepseek?.model,
           settings.openai?.model,
           azureDeployment,
           azureAnthropicDeployment,

--- a/src/electron/memory/MemoryService.ts
+++ b/src/electron/memory/MemoryService.ts
@@ -1887,6 +1887,7 @@ export class MemoryService {
         settings.ollama?.model,
         settings.gemini?.model,
         settings.openrouter?.model,
+        settings.deepseek?.model,
         settings.openai?.model,
         azureDeployment,
         azureAnthropicDeployment,


### PR DESCRIPTION
## Summary
- Replace shell-based MCP package verification with argv-based `execFile` and reject invalid package names before spawning npm.
- Add regression coverage for a malicious package-name payload and a valid scoped package.
- Tighten workspace path containment checks with a shared helper and keep the related regression test.
- Include `deepseek` in model selection lists used by routing/import paths.

## Testing
- `npx vitest run src/electron/mcp/__tests__/MCPRegistryManager.test.ts`
- `npx vitest run src/electron/control-plane/__tests__/path-containment.test.ts`
- `npm run type-check`
- `npm run lint`