### PR TITLE
[codex] fix sqlite task archive cleanup

### DIFF
--- a/src/electron/database/__tests__/TaskRepository.delete.test.ts
+++ b/src/electron/database/__tests__/TaskRepository.delete.test.ts
@@ -368,6 +368,50 @@ describeWithSqlite("TaskRepository.delete", () => {
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
+  it("cleans legacy task foreign keys that are not hard-coded in the delete path", () => {
+    const workspace = insertWorkspace();
+    const task = taskRepo.create({
+      title: "Task with legacy references",
+      prompt: "archive me from an upgraded database",
+      status: "completed",
+      workspaceId: workspace.id,
+    });
+
+    db.exec(`
+      CREATE TABLE legacy_required_task_refs (
+        id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL REFERENCES tasks(id),
+        note TEXT NOT NULL
+      );
+
+      CREATE TABLE legacy_optional_task_refs (
+        id TEXT PRIMARY KEY,
+        source_task_id TEXT REFERENCES tasks(id),
+        note TEXT NOT NULL
+      );
+    `);
+    db.prepare("INSERT INTO legacy_required_task_refs (id, task_id, note) VALUES (?, ?, ?)").run(
+      randomUUID(),
+      task.id,
+      "delete this row",
+    );
+    const optionalRefId = randomUUID();
+    db.prepare(
+      "INSERT INTO legacy_optional_task_refs (id, source_task_id, note) VALUES (?, ?, ?)",
+    ).run(optionalRefId, task.id, "preserve this row");
+
+    taskRepo.delete(task.id);
+
+    expect(taskRepo.findById(task.id)).toBeUndefined();
+    expect(db.prepare("SELECT COUNT(1) AS count FROM legacy_required_task_refs").get()).toEqual({
+      count: 0,
+    });
+    expect(
+      db.prepare("SELECT source_task_id FROM legacy_optional_task_refs WHERE id = ?").get(optionalRefId),
+    ).toEqual({ source_task_id: null });
+    expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+  });
+
   it("prunes only stale remote shadow tasks covered by the fetched window", () => {
     const workspace = insertWorkspace();
     const now = Date.now();

--- a/src/electron/database/repositories.ts
+++ b/src/electron/database/repositories.ts
@@ -56,6 +56,27 @@ function safeJsonParse<T>(jsonString: string, defaultValue: T, context?: string)
 }
 
 const taskRepositoryLogger = createLogger("TaskRepository");
+const SAFE_SQL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const quoteSqlIdentifier = (identifier: string): string => {
+  if (!SAFE_SQL_IDENTIFIER.test(identifier)) {
+    throw new Error(`Unsafe SQL identifier: ${identifier}`);
+  }
+  return `"${identifier}"`;
+};
+
+interface SqliteForeignKeyRow {
+  table?: string;
+  from?: string;
+  to?: string;
+  on_delete?: string;
+}
+
+interface SqliteTableInfoRow {
+  name?: string;
+  notnull?: number;
+  pk?: number;
+}
 
 export class WorkspaceRepository {
   constructor(private db: Database.Database) {}
@@ -831,12 +852,92 @@ export class TaskRepository {
       );
       deleteSubscriptions.run(taskId);
 
+      this.cleanupTaskForeignKeyReferences(taskId);
+
       // Finally delete the task
       const deleteTask = this.db.prepare("DELETE FROM tasks WHERE id = ?");
       deleteTask.run(taskId);
     });
 
     deleteTransaction(id);
+  }
+
+  private cleanupTaskForeignKeyReferences(taskId: string): void {
+    const tableRows = this.db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all() as Array<{ name?: string }>;
+
+    for (const tableRow of tableRows) {
+      const tableName = String(tableRow.name || "");
+      if (!tableName || tableName.startsWith("sqlite_") || tableName === "tasks") {
+        continue;
+      }
+      if (!SAFE_SQL_IDENTIFIER.test(tableName)) {
+        taskRepositoryLogger.warn(
+          `Skipping task delete FK cleanup for unsafe table name: ${tableName}`,
+        );
+        continue;
+      }
+
+      const tableInfo = this.db
+        .prepare(`PRAGMA table_info(${quoteSqlIdentifier(tableName)})`)
+        .all() as SqliteTableInfoRow[];
+      const columns = new Map(
+        tableInfo
+          .map(
+            (column) =>
+              [
+                String(column.name || ""),
+                Number(column.notnull || 0) || Number(column.pk || 0),
+              ] as const,
+          )
+          .filter(([column]) => SAFE_SQL_IDENTIFIER.test(column)),
+      );
+
+      const foreignKeys = this.db
+        .prepare(`PRAGMA foreign_key_list(${quoteSqlIdentifier(tableName)})`)
+        .all() as SqliteForeignKeyRow[];
+
+      for (const foreignKey of foreignKeys) {
+        const referencedTable = String(foreignKey.table || "");
+        const referencedColumn = String(foreignKey.to || "id");
+        const columnName = String(foreignKey.from || "");
+        if (referencedTable !== "tasks" || referencedColumn !== "id") {
+          continue;
+        }
+        if (!SAFE_SQL_IDENTIFIER.test(columnName) || !columns.has(columnName)) {
+          taskRepositoryLogger.warn(
+            `Skipping task delete FK cleanup for unsafe column ${tableName}.${columnName}`,
+          );
+          continue;
+        }
+
+        const quotedTable = quoteSqlIdentifier(tableName);
+        const quotedColumn = quoteSqlIdentifier(columnName);
+        const onDelete = String(foreignKey.on_delete || "").toUpperCase();
+        const columnIsNullable = columns.get(columnName) === 0;
+
+        if (columnIsNullable && onDelete !== "CASCADE") {
+          this.db
+            .prepare(`UPDATE ${quotedTable} SET ${quotedColumn} = NULL WHERE ${quotedColumn} = ?`)
+            .run(taskId);
+        } else {
+          this.db.prepare(`DELETE FROM ${quotedTable} WHERE ${quotedColumn} = ?`).run(taskId);
+        }
+      }
+    }
+
+    const quotedTasksTable = quoteSqlIdentifier("tasks");
+    for (const columnName of ["parent_task_id", "branch_from_task_id"]) {
+      try {
+        const quotedColumn = quoteSqlIdentifier(columnName);
+        this.db
+          .prepare(`UPDATE ${quotedTasksTable} SET ${quotedColumn} = NULL WHERE ${quotedColumn} = ?`)
+          .run(taskId);
+      } catch {
+        // Older databases may not have every self-reference column.
+      }
+    }
   }
 
   private mapRowToTask(row: Any): Task {


### PR DESCRIPTION
## Summary

Fixes #117 by making task archive/delete clean up actual SQLite foreign key references to `tasks(id)` before deleting the task row.

## Root Cause

The archive action calls the task delete IPC path. That path manually cleared known task-linked tables, but upgraded databases can contain task foreign keys that are not represented in the hard-coded cleanup list, causing SQLite to reject the final task delete with `FOREIGN KEY constraint failed`.

## Changes

- Add schema-driven task foreign key cleanup in `TaskRepository.delete`.
- Null nullable task references and delete required/cascade child rows before deleting the task.
- Keep explicit cleanup for task self-references across older schemas.
- Add a regression test covering legacy required and optional task FK tables.

## Validation

- `npm run build:electron`
- `npm run lint` exits 0 with existing warnings
- Electron-side SQLite regression script passed: `issue117 regression ok`

Note: the Vitest SQLite file is skipped in the local Node runtime because the installed `better-sqlite3` binary is built for Electron ABI 143 while local Node expects ABI 137.