### PR TITLE
Handle NanoGPT Anthropic-compatible requests without CoWork-managed caching

### DIFF
--- a/src/electron/agent/llm/__tests__/anthropic-compatible-provider.test.ts
+++ b/src/electron/agent/llm/__tests__/anthropic-compatible-provider.test.ts
@@ -78,6 +78,59 @@ describe("AnthropicCompatibleProvider URL resolution", () => {
     );
   });
 
+  it("sends bearer auth alongside x-api-key for compatible gateways", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockUnauthorizedResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new AnthropicCompatibleProvider({
+      type: "anthropic-compatible",
+      providerName: "Anthropic-Compatible",
+      apiKey: "test-key",
+      baseUrl: "https://example.com/anthropic",
+      defaultModel: "custom-model",
+    });
+
+    await provider.testConnection();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/anthropic/v1/messages",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-api-key": "test-key",
+          Authorization: "Bearer test-key",
+        }),
+      }),
+    );
+  });
+
+  it("surfaces simple gateway error strings during connection tests", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 402,
+        statusText: "Payment Required",
+        json: vi.fn().mockResolvedValue({
+          error: "Insufficient balance",
+          status: 402,
+        }),
+      } as unknown as Response),
+    );
+
+    const provider = new AnthropicCompatibleProvider({
+      type: "anthropic-compatible",
+      providerName: "Anthropic-Compatible",
+      apiKey: "test-key",
+      baseUrl: "https://example.com/anthropic",
+      defaultModel: "custom-model",
+    });
+
+    await expect(provider.testConnection()).resolves.toEqual({
+      success: false,
+      error: "Insufficient balance",
+    });
+  });
+
   it("uses /v1/models when refreshing models from an unversioned Anthropic-compatible base URL", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -362,5 +415,63 @@ describe("AnthropicCompatibleProvider prompt caching", () => {
     expect(requestBodies[1].messages[0].content[0].cache_control).toEqual({ type: "ephemeral" });
     expect(requestBodies[1].messages[1].content[0].cache_control).toEqual({ type: "ephemeral" });
     expect(requestBodies[1].messages[2].content[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("does not send managed prompt-cache controls to NanoGPT", async () => {
+    let capturedBody: Any = null;
+    let capturedHeaders: HeadersInit | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
+        capturedHeaders = init?.headers;
+        return {
+          ok: true,
+          json: async () => ({
+            content: [{ type: "text", text: "ok" }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 10, output_tokens: 5 },
+          }),
+        } as Response;
+      }),
+    );
+
+    const provider = new AnthropicCompatibleProvider({
+      type: "anthropic-compatible",
+      providerName: "Anthropic-Compatible",
+      apiKey: "test-key",
+      baseUrl: "https://nano-gpt.com/api/v1",
+      defaultModel: "moonshotai/kimi-k2.6:thinking",
+    });
+
+    await provider.createMessage({
+      model: "moonshotai/kimi-k2.6:thinking",
+      maxTokens: 4096,
+      system: "legacy system",
+      systemBlocks: [
+        {
+          text: "Stable instructions",
+          scope: "session",
+          cacheable: true,
+          stableKey: "identity:1",
+        },
+      ],
+      promptCache: {
+        mode: "anthropic_auto",
+        ttl: "5m",
+        explicitRecentMessages: 3,
+      },
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(capturedBody.cache_control).toBeUndefined();
+    expect(capturedBody.system).toEqual([{ type: "text", text: "Stable instructions" }]);
+    expect(capturedBody.messages).toEqual([{ role: "user", content: "hello" }]);
+    expect(capturedHeaders).toEqual(
+      expect.objectContaining({
+        "x-api-key": "test-key",
+        Authorization: "Bearer test-key",
+      }),
+    );
   });
 });

--- a/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
+++ b/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
@@ -228,6 +228,7 @@ describe("LLMProviderFactory custom provider config resolution", () => {
         method: "POST",
         headers: expect.objectContaining({
           "x-api-key": "nano-key",
+          Authorization: "Bearer nano-key",
         }),
       }),
     );

--- a/src/electron/agent/llm/anthropic-compatible-provider.ts
+++ b/src/electron/agent/llm/anthropic-compatible-provider.ts
@@ -53,6 +53,26 @@ function resolveModelsUrl(baseUrl: string): string {
   return joinUrl(trimmedBase, "/v1/models");
 }
 
+function isNanoGptBaseUrl(baseUrl: string): boolean {
+  try {
+    const hostname = new URL(baseUrl.trim()).hostname.toLowerCase();
+    return hostname === "nano-gpt.com" || hostname.endsWith(".nano-gpt.com");
+  } catch {
+    return false;
+  }
+}
+
+function extractProviderErrorMessage(errorData: Any): string {
+  const error = errorData?.error;
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object") {
+    return typeof error.message === "string" ? error.message : "";
+  }
+  return typeof errorData?.message === "string" ? errorData.message : "";
+}
+
 export interface AnthropicCompatibleProviderOptions {
   type: LLMProviderType;
   providerName: string;
@@ -69,6 +89,7 @@ export class AnthropicCompatibleProvider implements LLMProvider {
   private defaultModel: string;
   private providerName: string;
   private promptCacheAutoSupported = true;
+  private managedPromptCacheSupported = true;
 
   constructor(options: AnthropicCompatibleProviderOptions) {
     this.type = options.type;
@@ -77,6 +98,7 @@ export class AnthropicCompatibleProvider implements LLMProvider {
     this.messagesUrl = resolveMessagesUrl(options.baseUrl);
     this.defaultModel = options.defaultModel;
     this.providerName = options.providerName;
+    this.managedPromptCacheSupported = !isNanoGptBaseUrl(options.baseUrl);
   }
 
   async createMessage(request: LLMRequest): Promise<LLMResponse> {
@@ -87,7 +109,9 @@ export class AnthropicCompatibleProvider implements LLMProvider {
       (message) => console.warn(`[${this.providerName}] ${message}`),
     );
     const requestedPromptCache =
-      request.promptCache?.mode === "disabled" ? undefined : request.promptCache;
+      request.promptCache?.mode === "disabled" || !this.managedPromptCacheSupported
+        ? undefined
+        : request.promptCache;
     const effectivePromptCache =
       requestedPromptCache?.mode === "anthropic_auto" && !this.promptCacheAutoSupported
         ? { ...requestedPromptCache, mode: "anthropic_explicit" as const }
@@ -122,8 +146,13 @@ export class AnthropicCompatibleProvider implements LLMProvider {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-api-key": this.apiKey,
           "anthropic-version": ANTHROPIC_VERSION,
+          ...(this.apiKey
+            ? {
+                "x-api-key": this.apiKey,
+                Authorization: `Bearer ${this.apiKey}`,
+              }
+            : {}),
         },
         body: JSON.stringify({
           model: this.defaultModel,
@@ -133,12 +162,11 @@ export class AnthropicCompatibleProvider implements LLMProvider {
       });
 
       if (!response.ok) {
-        const errorData = (await response.json().catch(() => ({}))) as {
-          error?: { message?: string };
-        };
+        const errorData = (await response.json().catch(() => ({}))) as Any;
+        const providerMessage = extractProviderErrorMessage(errorData);
         return {
           success: false,
-          error: errorData.error?.message || `HTTP ${response.status}: ${response.statusText}`,
+          error: providerMessage || `HTTP ${response.status}: ${response.statusText}`,
         };
       }
 
@@ -276,8 +304,13 @@ export class AnthropicCompatibleProvider implements LLMProvider {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-api-key": this.apiKey,
         "anthropic-version": ANTHROPIC_VERSION,
+        ...(this.apiKey
+          ? {
+              "x-api-key": this.apiKey,
+              Authorization: `Bearer ${this.apiKey}`,
+            }
+          : {}),
       },
       body: JSON.stringify({
         model: args.model,
@@ -293,10 +326,8 @@ export class AnthropicCompatibleProvider implements LLMProvider {
     });
 
     if (!response.ok) {
-      const errorData = (await response.json().catch(() => ({}))) as {
-        error?: { message?: string };
-      };
-      const providerMessage = errorData.error?.message || "";
+      const errorData = (await response.json().catch(() => ({}))) as Any;
+      const providerMessage = extractProviderErrorMessage(errorData);
       if (
         args.promptCache?.mode === "anthropic_auto" &&
         isPromptCacheAutoUnsupportedError(response.status, providerMessage)


### PR DESCRIPTION
## Summary
- Updated the Anthropic-compatible provider to send both `x-api-key` and `Authorization: Bearer ...`, which matches NanoGPT-style gateways.
- Disabled CoWork-managed prompt-cache controls for NanoGPT base URLs so `anthropic_auto` does not inject unsupported cache metadata.
- Improved error parsing so simple gateway responses like `402 Payment Required` surface the provider message instead of only the HTTP status.
- Added regression coverage for auth headers, NanoGPT prompt-cache behavior, and simple `402` error bodies.

## Testing
- `npx vitest run src/electron/agent/llm/__tests__/anthropic-compatible-provider.test.ts src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts`
- `npm run type-check`
- `npm run lint`