### PR TITLE
Fix Anthropic-compatible gateway model selection for overlapping custom models

### DIFF
--- a/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
+++ b/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
@@ -150,6 +150,36 @@ describe("LLMProviderFactory custom provider config resolution", () => {
     ]);
   });
 
+  it("keeps Anthropic-compatible gateway models that overlap another provider", () => {
+    const modelStatus = LLMProviderFactory.getProviderModelStatus({
+      providerType: "anthropic-compatible",
+      modelKey: "sonnet-4-6",
+      kimi: {
+        model: "moonshotai/kimi-k2.6:thinking",
+      },
+      customProviders: {
+        "anthropic-compatible": {
+          apiKey: "nano-key",
+          baseUrl: "https://nano-gpt.com/api/v1",
+          model: "moonshotai/kimi-k2.6:thinking",
+          cachedModels: [
+            {
+              key: "moonshotai/kimi-k2.6:thinking",
+              displayName: "Kimi K2.6 Thinking",
+              description: "NanoGPT Anthropic-compatible model",
+            },
+          ],
+        },
+      },
+    } as Any);
+
+    expect(modelStatus.currentModel).toBe("moonshotai/kimi-k2.6:thinking");
+    expect(modelStatus.models[0]).toMatchObject({
+      key: "moonshotai/kimi-k2.6:thinking",
+      displayName: "Kimi K2.6 Thinking",
+    });
+  });
+
   it("returns documented MiniMax Portal models when refreshing custom-provider models", async () => {
     vi.spyOn(LLMProviderFactory, "loadSettings").mockReturnValue({
       providerType: "minimax-portal",

--- a/src/electron/agent/llm/__tests__/provider-factory-model-selection.test.ts
+++ b/src/electron/agent/llm/__tests__/provider-factory-model-selection.test.ts
@@ -191,6 +191,31 @@ describe("LLMProviderFactory model status", () => {
     expect(resolved.modelKey).toBe("gpt-4o-mini");
     expect(resolved.modelId).toBe("gpt-5.5");
   });
+
+  it("runs the stored Anthropic-compatible gateway model even when another provider uses the same id", () => {
+    const settings: LLMSettings = {
+      providerType: "anthropic-compatible",
+      modelKey: "sonnet-4-6",
+      kimi: {
+        model: "moonshotai/kimi-k2.6:thinking",
+      },
+      customProviders: {
+        "anthropic-compatible": {
+          apiKey: "nano-key",
+          baseUrl: "https://nano-gpt.com/api/v1",
+          model: "moonshotai/kimi-k2.6:thinking",
+        },
+      },
+    };
+    vi.spyOn(LLMProviderFactory, "loadSettings").mockReturnValue(settings);
+
+    const resolved = LLMProviderFactory.resolveTaskModelSelection();
+
+    expect(resolved.providerType).toBe("anthropic-compatible");
+    expect(resolved.modelKey).toBe("moonshotai/kimi-k2.6:thinking");
+    expect(resolved.modelId).toBe("moonshotai/kimi-k2.6:thinking");
+    expect(resolved.modelSource).toBe("provider_default");
+  });
 });
 
 describe("LLMProviderFactory model selection persistence", () => {

--- a/src/electron/agent/llm/provider-factory.ts
+++ b/src/electron/agent/llm/provider-factory.ts
@@ -2619,28 +2619,8 @@ export class LLMProviderFactory {
         settings.customProviders?.[resolvedProviderType] ||
         settings.customProviders?.[settings.providerType];
 
-      // Guard against cross-provider model contamination: if the stored model for this
-      // custom provider matches a model that belongs to a different provider (e.g. an
-      // Azure deployment name stored as minimax-portal's model), ignore it and fall
-      // back to this provider's catalog default.
       const storedModel = customConfig?.model;
-      const isFromAnotherProvider =
-        storedModel != null &&
-        (settings.azure?.deployments?.includes(storedModel) ||
-          settings.azure?.deployment === storedModel ||
-          settings.openai?.model === storedModel ||
-          settings.gemini?.model === storedModel ||
-          settings.openrouter?.model === storedModel ||
-          settings.deepseek?.model === storedModel ||
-          settings.ollama?.model === storedModel ||
-          settings.groq?.model === storedModel ||
-          settings.xai?.model === storedModel ||
-          settings.kimi?.model === storedModel ||
-          settings.openaiCompatible?.model === storedModel);
-      const currentModel =
-        (!isFromAnotherProvider && storedModel) ||
-        customEntry.defaultModel ||
-        "";
+      const currentModel = storedModel || customEntry.defaultModel || "";
       const cachedModels =
         customConfig?.cachedModels && customConfig.cachedModels.length > 0
           ? customConfig.cachedModels


### PR DESCRIPTION
## Summary
- Preserve the stored model for Anthropic-compatible custom providers instead of discarding it when another provider happens to use the same model id.
- This fixes the NanoGPT flow where selecting `moonshotai/kimi-k2.6:thinking` was being reset to Claude Sonnet 4.6 in chat.
- Added regressions covering both the rendered model status and the resolved task model selection path.

## Testing
- `npx vitest run src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts src/electron/agent/llm/__tests__/provider-factory-model-selection.test.ts src/electron/ipc/__tests__/llm-settings-save.test.ts`
- `npm run lint`