### PR TITLE
fix: WSL window move/resize with native frame (AI-assisted)

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1088,6 +1088,10 @@ if (!gotTheLock) {
 
   function createWindow() {
     const isMac = process.platform === "darwin";
+    const isWsl =
+      process.platform === "linux" &&
+      (Boolean(process.env.WSL_DISTRO_NAME) ||
+        os.release().toLowerCase().includes("microsoft"));
     let useMacVibrancy = isMac && !nativeTheme.prefersReducedTransparency;
     const {
       isMaximized: shouldStartMaximized,
@@ -1120,7 +1124,8 @@ if (!gotTheLock) {
         initialWindowBounds.x === undefined ||
         initialWindowBounds.y === undefined,
       icon: getDesktopIconPath(),
-      titleBarStyle: isMac ? "hiddenInset" : "hidden",
+      ...(isWsl ? {} : { titleBarStyle: isMac ? "hiddenInset" : "hidden" }),
+      ...(isWsl ? { frame: true } : {}),
       ...(isMac ? { trafficLightPosition: { x: 18, y: 18 } } : {}),
       ...(useMacVibrancy
         ? {


### PR DESCRIPTION
## Description
This AI-assisted PR fixes an Electron window-manager issue on WSL where the frameless/custom title bar prevents reliable window move and resize behavior.

## Related Issue
Fixes #

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Security improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Reliability Regression Policy
- [ ] This PR fixes a production failure/incident.
- [ ] If checked above, I added or updated at least one eval case file under `scripts/qa/eval-cases/`.
- Eval case file path(s): 
  - `scripts/qa/eval-cases/...`

## Category
- [ ] Security / Guardrails
- [ ] Messaging Channels (WhatsApp, Telegram, Discord, Slack, Teams, Google Chat, iMessage, Signal, Matrix, etc.)
- [ ] LLM Providers
- [ ] Agent Capabilities / Tools
- [ ] Cloud Storage (Google Workspace, OneDrive, Dropbox, Box, SharePoint, Notion)
- [x] UI / UX
- [ ] MCP Integration
- [ ] Remote Access (Tailscale, SSH, WebSocket API)
- [ ] Database / IPC
- [ ] Other

## Changes Made
- Added WSL runtime detection in Electron main process when creating the main window.
- On WSL only, switched to native framed window (`frame: true`) and skipped hidden custom title bar.
- Preserved existing title bar behavior for macOS and native Linux.

## Security Considerations
- [x] This change has NO security implications
- [ ] This change has been reviewed for security implications (describe below)

## Screenshots
N/A

## Testing
- AI assistance: yes (Codex/OpenCode)
- Testing level: lightly tested
- [ ] Tested locally on macOS
- [ ] Tested with at least one LLM provider (Anthropic/Bedrock/Gemini/OpenRouter/OpenAI/Ollama)
- [ ] Tested messaging channel integration (if applicable)
- [ ] Tested MCP functionality (if applicable)
- [ ] Verified no console errors
- [ ] Security tests pass (if applicable)
- Ran `npm run type-check` (pass)
- Ran `npm run lint` (repo currently has existing warnings; no new errors introduced by this PR)
- Ran `npm run fmt:check` (currently fails in repo due existing `vite.config.ts` config issue, unrelated to this PR)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated `docs/architecture.md` if this PR changes capabilities, defaults, or architecture
- [ ] My changes generate no new warnings
- [x] I have considered security implications of my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
This change targets WSL only to avoid changing native Linux behavior.