### PR TITLE
Keep live lookup inferred chats in execution pipeline

### DIFF
--- a/src/electron/agent/__tests__/executor-chat-mode.test.ts
+++ b/src/electron/agent/__tests__/executor-chat-mode.test.ts
@@ -175,6 +175,9 @@ describe("TaskExecutor chat mode", () => {
     };
 
     expect((TaskExecutor as Any).prototype.isExplicitChatExecutionMode.call(executor)).toBe(false);
+    expect(
+      (TaskExecutor as Any).prototype.shouldHandleInitialPromptAsCompanion.call(executor, "hello"),
+    ).toBe(true);
 
     executor.shouldEmitAnswerFirst = vi.fn().mockReturnValue(true);
     executor.hasDirectAnswerReady = vi.fn().mockReturnValue(true);
@@ -261,6 +264,32 @@ describe("TaskExecutor chat mode", () => {
     expect((TaskExecutor as Any).prototype.buildFollowUpResultSummary.call(executor)).toBe(
       "Goal active.\n\nObjective: Track release blockers",
     );
+  });
+
+  it("does not route inferred chat live-lookup prompts through companion mode", () => {
+    const executor = Object.create(TaskExecutor.prototype) as Any;
+
+    executor.task = {
+      id: "task-inferred-chat-live",
+      title: "Premier League fixtures",
+      prompt: "please tell me which football clubs have games tomorrow in premier league",
+      userPrompt: "please tell me which football clubs have games tomorrow in premier league",
+      rawPrompt: "please tell me which football clubs have games tomorrow in premier league",
+      createdAt: Date.now(),
+      agentConfig: {
+        executionMode: "execute",
+        executionModeSource: "strategy",
+        conversationMode: "chat",
+        taskIntent: "chat",
+      },
+    };
+
+    expect(
+      (TaskExecutor as Any).prototype.shouldHandleInitialPromptAsCompanion.call(
+        executor,
+        "please tell me which football clubs have games tomorrow in premier league",
+      ),
+    ).toBe(false);
   });
 
   it("only exposes the last non-verification step as an assistant bubble", () => {

--- a/src/electron/agent/__tests__/executor-chat-mode.test.ts
+++ b/src/electron/agent/__tests__/executor-chat-mode.test.ts
@@ -36,6 +36,26 @@ vi.mock("../../settings/personality-manager", () => ({
 }));
 
 describe("TaskExecutor chat mode", () => {
+  const createInferredChatExecutor = (prompt: string, agentConfig: Record<string, unknown> = {}) => {
+    const executor = Object.create(TaskExecutor.prototype) as Any;
+    executor.task = {
+      id: "task-inferred-chat",
+      title: prompt,
+      prompt,
+      userPrompt: prompt,
+      rawPrompt: prompt,
+      createdAt: Date.now(),
+      agentConfig: {
+        executionMode: "execute",
+        executionModeSource: "strategy",
+        conversationMode: "chat",
+        taskIntent: "chat",
+        ...agentConfig,
+      },
+    };
+    return executor;
+  };
+
   it("records executor conversation history into durable context", () => {
     const executor = Object.create(TaskExecutor.prototype) as Any;
     executor.task = { id: "task-durable-history" };
@@ -267,28 +287,56 @@ describe("TaskExecutor chat mode", () => {
   });
 
   it("does not route inferred chat live-lookup prompts through companion mode", () => {
-    const executor = Object.create(TaskExecutor.prototype) as Any;
-
-    executor.task = {
-      id: "task-inferred-chat-live",
-      title: "Premier League fixtures",
-      prompt: "please tell me which football clubs have games tomorrow in premier league",
-      userPrompt: "please tell me which football clubs have games tomorrow in premier league",
-      rawPrompt: "please tell me which football clubs have games tomorrow in premier league",
-      createdAt: Date.now(),
-      agentConfig: {
-        executionMode: "execute",
-        executionModeSource: "strategy",
-        conversationMode: "chat",
-        taskIntent: "chat",
-      },
-    };
+    const executor = createInferredChatExecutor(
+      "please tell me which football clubs have games tomorrow in premier league",
+    );
 
     expect(
       (TaskExecutor as Any).prototype.shouldHandleInitialPromptAsCompanion.call(
         executor,
         "please tell me which football clubs have games tomorrow in premier league",
       ),
+    ).toBe(false);
+  });
+
+  it("keeps ambiguous inferred chat prompts in the normal executor path", () => {
+    const prompts = [
+      "are there premier league games tomorrow",
+      "weather in paris today",
+      "is apple stock up today",
+      "/schedule tomorrow remind me to send the report",
+      "/goal keep an eye on deploy health",
+      "/skill pdf summarize report.pdf",
+      "Use the Codex CLI Agent skill to review this change",
+      "answer_first=true explain the tradeoffs before planning",
+      "summarize report.pdf",
+      "describe this image",
+      "Attached files:\n- photo.png\nWhat is in this image?",
+      "PDF attachment: report.pdf\nPath: .cowork/uploads/123/report.pdf\nSummarize it",
+    ];
+
+    for (const prompt of prompts) {
+      const executor = createInferredChatExecutor(prompt);
+
+      expect(
+        (TaskExecutor as Any).prototype.shouldHandleInitialPromptAsCompanion.call(executor, prompt),
+      ).toBe(false);
+    }
+  });
+
+  it("keeps external runtime tasks out of inferred companion routing", () => {
+    const executor = createInferredChatExecutor("hello", {
+      externalRuntime: {
+        kind: "acpx",
+        agent: "claude",
+        sessionMode: "persistent",
+        outputMode: "json",
+        permissionMode: "approve-reads",
+      },
+    });
+
+    expect(
+      (TaskExecutor as Any).prototype.shouldHandleInitialPromptAsCompanion.call(executor, "hello"),
     ).toBe(false);
   });
 

--- a/src/electron/agent/__tests__/executor-chat-mode.test.ts
+++ b/src/electron/agent/__tests__/executor-chat-mode.test.ts
@@ -56,6 +56,51 @@ describe("TaskExecutor chat mode", () => {
     return executor;
   };
 
+  const createExecuteUnlockedRoutingExecutor = (
+    prompt: string,
+    agentConfig: Record<string, unknown> = {},
+  ) => {
+    const executor = createInferredChatExecutor(prompt, agentConfig);
+    executor.workspace = {
+      id: "ws-routing",
+      path: "/tmp",
+      isTemp: true,
+      permissions: { read: true, write: true, delete: true, network: true, shell: true },
+    };
+    executor.daemon = {
+      updateTaskStatus: vi.fn(),
+      updateTask: vi.fn(),
+      getTransientRetryCount: vi.fn().mockReturnValue(0),
+    };
+    executor.toolRegistry = {
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    };
+    executor.emitEvent = vi.fn();
+    executor.handleCompanionPrompt = vi.fn().mockResolvedValue(undefined);
+    executor.maybeHandleExplicitClaudeCodeDelegation = vi.fn().mockResolvedValue(false);
+    executor.maybeHandleOnboardingSlashCommand = vi.fn().mockResolvedValue(false);
+    executor.maybePrepareInitialGoalSlashCommand = vi.fn().mockResolvedValue(false);
+    executor.maybeHandleScheduleSlashCommand = vi.fn().mockResolvedValue(false);
+    executor.maybeHandleSkillSlashCommandOrInlineChain = vi.fn().mockResolvedValue(false);
+    executor.maybeHandleNaturalLlmWikiPrompt = vi.fn().mockResolvedValue(undefined);
+    executor.maybeAutoApplyExplicitSkillInvocation = vi.fn().mockResolvedValue(undefined);
+    executor.maybeHandleHighConfidenceSkillRouting = vi.fn().mockResolvedValue(undefined);
+    executor.analyzeTask = vi.fn().mockResolvedValue({ complexity: "simple" });
+    executor.ensureVerificationOutcomeSets = vi.fn();
+    executor.getBudgetConstrainedFailureStepIdSet = vi.fn().mockReturnValue(new Set());
+    executor.nonBlockingVerificationFailedStepIds = new Set();
+    executor.blockingVerificationFailedStepIds = new Set();
+    executor.stepStopReasons = new Map();
+    executor.taskFailureDomains = new Set();
+    executor.completionVerificationMetadata = null;
+    executor.terminalStatus = "ok";
+    executor.failureClass = undefined;
+    executor.cancelled = false;
+    executor.lastUserMessage = prompt;
+    executor.cancelReason = undefined;
+    return executor;
+  };
+
   it("records executor conversation history into durable context", () => {
     const executor = Object.create(TaskExecutor.prototype) as Any;
     executor.task = { id: "task-durable-history" };
@@ -174,6 +219,13 @@ describe("TaskExecutor chat mode", () => {
     expect(schedule).not.toHaveBeenCalled();
     expect(skillRouting).not.toHaveBeenCalled();
     expect(highConfidenceRouting).not.toHaveBeenCalled();
+    expect(executor.emitEvent).toHaveBeenCalledWith(
+      "log",
+      expect.objectContaining({
+        reason: "initial_companion_prompt",
+        explicitChat: true,
+      }),
+    );
   });
 
   it("does not treat inferred chat intent as explicit chat mode", async () => {
@@ -338,6 +390,41 @@ describe("TaskExecutor chat mode", () => {
     expect(
       (TaskExecutor as Any).prototype.shouldHandleInitialPromptAsCompanion.call(executor, "hello"),
     ).toBe(false);
+  });
+
+  it("keeps explicit chat ACP tasks on the external runtime path", async () => {
+    const executor = createExecuteUnlockedRoutingExecutor("hello", {
+      executionMode: "chat",
+      executionModeSource: "user",
+      conversationMode: "hybrid",
+      externalRuntime: {
+        kind: "acpx",
+        agent: "claude",
+        sessionMode: "persistent",
+        outputMode: "json",
+        permissionMode: "approve-reads",
+      },
+    });
+    executor.executeWithAcpxRuntime = vi.fn().mockResolvedValue(undefined);
+
+    await (TaskExecutor as Any).prototype.executeUnlocked.call(executor);
+
+    expect(executor.executeWithAcpxRuntime).toHaveBeenCalledWith("hello");
+    expect(executor.handleCompanionPrompt).not.toHaveBeenCalled();
+    expect(executor.maybeHandleScheduleSlashCommand).not.toHaveBeenCalled();
+  });
+
+  it("keeps slash commands on the executor entrypoint path", async () => {
+    const executor = createExecuteUnlockedRoutingExecutor(
+      "/schedule tomorrow remind me to send the report",
+    );
+    executor.maybeHandleScheduleSlashCommand = vi.fn().mockResolvedValue(true);
+
+    await (TaskExecutor as Any).prototype.executeUnlocked.call(executor);
+
+    expect(executor.handleCompanionPrompt).not.toHaveBeenCalled();
+    expect(executor.maybeHandleScheduleSlashCommand).toHaveBeenCalledTimes(1);
+    expect(executor.analyzeTask).not.toHaveBeenCalled();
   });
 
   it("only exposes the last non-verification step as an assistant bubble", () => {

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -4202,6 +4202,54 @@ export class TaskExecutor {
     );
   }
 
+  private shouldHandleInitialPromptAsCompanion(prompt: string): boolean {
+    if (this.shouldUseReadOnlyPdfAttachmentMode()) return false;
+    if (this.isExplicitChatExecutionMode()) return true;
+
+    const agentConfig = this.task.agentConfig;
+    const source = agentConfig?.executionModeSource;
+    const userSelectedNonChatMode = source === "user" && agentConfig?.executionMode !== "chat";
+    if (userSelectedNonChatMode) return false;
+
+    const conversationMode = agentConfig?.conversationMode;
+    const taskIntent = agentConfig?.taskIntent;
+    const strategyCompanionMode =
+      conversationMode === "chat" ||
+      conversationMode === "think" ||
+      taskIntent === "chat" ||
+      taskIntent === "thinking";
+    if (!strategyCompanionMode) return false;
+
+    const text = String(prompt || this.getContractPrompt() || "").trim();
+    if (!text) return false;
+    if (this.promptRequiresLiveLookup(text)) return false;
+    return true;
+  }
+
+  private promptRequiresLiveLookup(prompt: string): boolean {
+    const normalized = String(prompt || "")
+      .trim()
+      .toLowerCase();
+    if (!normalized) return false;
+
+    const asksForInformation =
+      /\b(?:tell\s+me|which|what|when|who|where|find|search|look\s*up|check|show|list|compare|summarize)\b/.test(
+        normalized,
+      );
+    if (!asksForInformation) return false;
+
+    const timeSensitiveCue =
+      /\b(?:today|tomorrow|yesterday|tonight|this\s+(?:week|month|season|year)|next\s+(?:week|month|season|year)|latest|current|recent|newest|now|upcoming|live)\b/.test(
+        normalized,
+      );
+    const volatileDataCue =
+      /\b(?:fixture|fixtures|schedule|games?|matches?|scores?|results?|standings|table|odds|price|prices|stock|weather|forecast|news|release|version)\b/.test(
+        normalized,
+      );
+
+    return timeSensitiveCue || volatileDataCue;
+  }
+
   private stripPinnedSummaryPrefixFromFirstUserMessage(messages: LLMMessage[]): LLMMessage[] {
     const cloned = messages.map((msg) => ({ ...msg })) as LLMMessage[];
 
@@ -22305,8 +22353,8 @@ You are continuing a previous conversation. The context from the previous conver
         });
       }
 
-      // Only explicit user-selected chat mode skips the task pipeline entirely.
-      if (this.isExplicitChatExecutionMode()) {
+      // Companion turns are text-only and should not enter native planning/tool execution.
+      if (this.shouldHandleInitialPromptAsCompanion(initialPrompt)) {
         await this.handleCompanionPrompt();
         return;
       }

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -4222,8 +4222,10 @@ export class TaskExecutor {
 
     const text = String(prompt || this.getContractPrompt() || "").trim();
     if (!text) return false;
+    if (this.isAcpxExternalRuntimeTask()) return false;
     if (this.promptRequiresLiveLookup(text)) return false;
-    return true;
+    if (this.promptHasExecutorRoutingCue(text)) return false;
+    return this.isClearlyTrivialCompanionPrompt(text);
   }
 
   private promptRequiresLiveLookup(prompt: string): boolean {
@@ -4231,12 +4233,6 @@ export class TaskExecutor {
       .trim()
       .toLowerCase();
     if (!normalized) return false;
-
-    const asksForInformation =
-      /\b(?:tell\s+me|which|what|when|who|where|find|search|look\s*up|check|show|list|compare|summarize)\b/.test(
-        normalized,
-      );
-    if (!asksForInformation) return false;
 
     const timeSensitiveCue =
       /\b(?:today|tomorrow|yesterday|tonight|this\s+(?:week|month|season|year)|next\s+(?:week|month|season|year)|latest|current|recent|newest|now|upcoming|live)\b/.test(
@@ -4248,6 +4244,43 @@ export class TaskExecutor {
       );
 
     return timeSensitiveCue || volatileDataCue;
+  }
+
+  private promptHasExecutorRoutingCue(prompt: string): boolean {
+    const normalized = String(prompt || "")
+      .trim()
+      .toLowerCase();
+    if (!normalized) return false;
+    if (/^\s*\/[\w-]+/.test(prompt)) return true;
+    if (/\banswer_first\s*=/.test(normalized)) return true;
+    if (/\b(?:skill|codex\s+cli\s+agent|claude\s+code|acpx)\b/.test(normalized)) return true;
+    if (
+      /\b(?:attached\s+files?|pdf\s+attachment|path:\s*|file|pdf|image|screenshot)\b/.test(
+        normalized,
+      )
+    ) {
+      return true;
+    }
+    if (/\.(?:pdf|png|jpe?g|gif|webp|csv|xlsx?|docx?|pptx?)\b/.test(normalized)) return true;
+    return /\b(?:create|write|edit|modify|build|make|generate|save|export|run|execute|fix|debug|install|open|browse|review|analyze|summarize|compare|monitor|remind|schedule)\b/.test(
+      normalized,
+    );
+  }
+
+  private isClearlyTrivialCompanionPrompt(prompt: string): boolean {
+    const normalized = String(prompt || "")
+      .trim()
+      .toLowerCase()
+      .replace(/[.!?\s]+$/g, "");
+    if (!normalized) return false;
+
+    if (/^(?:hi|hello|hey|yo)(?:\s+there)?$/.test(normalized)) return true;
+    if (/^(?:thanks|thank\s+you|thx|ok|okay|cool|nice|great|awesome|yes|no|yep|nope|sure)$/.test(normalized)) {
+      return true;
+    }
+    return /^(?:who\s+are\s+you|what\s+are\s+you|what\s+can\s+you\s+do|how\s+are\s+you|what'?s\s+up|are\s+you\s+there)$/.test(
+      normalized,
+    );
   }
 
   private stripPinnedSummaryPrefixFromFirstUserMessage(messages: LLMMessage[]): LLMMessage[] {

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -4204,6 +4204,7 @@ export class TaskExecutor {
 
   private shouldHandleInitialPromptAsCompanion(prompt: string): boolean {
     if (this.shouldUseReadOnlyPdfAttachmentMode()) return false;
+    if (this.isAcpxExternalRuntimeTask()) return false;
     if (this.isExplicitChatExecutionMode()) return true;
 
     const agentConfig = this.task.agentConfig;
@@ -4222,7 +4223,6 @@ export class TaskExecutor {
 
     const text = String(prompt || this.getContractPrompt() || "").trim();
     if (!text) return false;
-    if (this.isAcpxExternalRuntimeTask()) return false;
     if (this.promptRequiresLiveLookup(text)) return false;
     if (this.promptHasExecutorRoutingCue(text)) return false;
     return this.isClearlyTrivialCompanionPrompt(text);
@@ -4251,6 +4251,8 @@ export class TaskExecutor {
       .trim()
       .toLowerCase();
     if (!normalized) return false;
+    // Routing boundary: keep this denylist aligned with executor entrypoints that must
+    // run before companion short-circuiting (slash commands, runtimes, skills, attachments).
     if (/^\s*\/[\w-]+/.test(prompt)) return true;
     if (/\banswer_first\s*=/.test(normalized)) return true;
     if (/\b(?:skill|codex\s+cli\s+agent|claude\s+code|acpx)\b/.test(normalized)) return true;
@@ -22388,6 +22390,15 @@ You are continuing a previous conversation. The context from the previous conver
 
       // Companion turns are text-only and should not enter native planning/tool execution.
       if (this.shouldHandleInitialPromptAsCompanion(initialPrompt)) {
+        this.emitEvent("log", {
+          message: "Routing initial prompt through companion mode before planning.",
+          reason: "initial_companion_prompt",
+          explicitChat: this.isExplicitChatExecutionMode(),
+          executionMode: this.task.agentConfig?.executionMode,
+          executionModeSource: this.task.agentConfig?.executionModeSource,
+          conversationMode: this.task.agentConfig?.conversationMode,
+          taskIntent: this.task.agentConfig?.taskIntent,
+        });
         await this.handleCompanionPrompt();
         return;
       }


### PR DESCRIPTION
## Summary
- route inferred lightweight chat prompts through companion mode without entering the full execution pipeline
- keep live/current lookup prompts in the normal execution path so tools can run
- add regression coverage for inferred chat and live-lookup routing

## Validation
- `npx vitest run src/electron/agent/__tests__/executor-chat-mode.test.ts`
- `npm run type-check`

AI assisted