### PR TITLE
Replace unexecuted chat tool-call text with fallback

### DIFF
--- a/src/electron/agent/__tests__/executor-chat-mode.test.ts
+++ b/src/electron/agent/__tests__/executor-chat-mode.test.ts
@@ -184,6 +184,77 @@ describe("TaskExecutor chat mode", () => {
     expect((TaskExecutor as Any).prototype.shouldShortCircuitSimpleNonExecuteAnswer.call(executor)).toBe(false);
   });
 
+  it("replaces plaintext tool-call syntax in chat mode with an honest fallback", async () => {
+    const executor = Object.create(TaskExecutor.prototype) as Any;
+    const createMessageWithTimeout = vi.fn().mockResolvedValue({
+      content: [
+        {
+          type: "text",
+          text: 'I will check. search_web:0{"queries":["Premier League fixtures tomorrow"]}',
+        },
+      ],
+      stopReason: "end_turn",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+
+    executor.task = {
+      id: "task-chat-fake-tool",
+      title: "Premier League fixtures",
+      prompt: "please tell me which football clubs have games tomorrow in premier league",
+      userPrompt: "please tell me which football clubs have games tomorrow in premier league",
+      rawPrompt: "please tell me which football clubs have games tomorrow in premier league",
+      createdAt: Date.now(),
+      agentConfig: {
+        executionMode: "chat",
+        executionModeSource: "user",
+        conversationMode: "chat",
+      },
+    };
+    executor.workspace = {
+      id: "ws-chat-fake-tool",
+      path: "/tmp",
+      isTemp: true,
+      permissions: { read: true, write: true, delete: true, network: true, shell: true },
+    };
+    executor.daemon = {
+      updateTaskStatus: vi.fn(),
+      updateTask: vi.fn(),
+    };
+    executor.emitEvent = vi.fn();
+    executor.getRoleContextPrompt = vi.fn().mockReturnValue("");
+    executor.buildUserProfileBlock = vi.fn().mockReturnValue("");
+    executor.buildUserContent = vi.fn().mockResolvedValue("please tell me which football clubs have games tomorrow in premier league");
+    executor.callLLMWithRetry = vi.fn(async (fn: Any) => fn());
+    executor.createMessageWithTimeout = createMessageWithTimeout;
+    executor.updateTracking = vi.fn();
+    executor.extractTextFromLLMContent = vi
+      .fn()
+      .mockReturnValue('I will check. search_web:0{"queries":["Premier League fixtures tomorrow"]}');
+    executor.updateConversationHistory = vi.fn();
+    executor.saveConversationSnapshot = vi.fn();
+    executor.finalizeTaskBestEffort = vi.fn();
+    executor.generateCompanionFallbackResponse = vi.fn().mockReturnValue("fallback");
+    executor.getCumulativeInputTokens = vi.fn().mockReturnValue(0);
+    executor.getCumulativeOutputTokens = vi.fn().mockReturnValue(0);
+    executor.taskCompleted = false;
+    executor.cancelled = false;
+
+    await (TaskExecutor as Any).prototype.handleCompanionPrompt.call(executor);
+
+    expect(executor.emitEvent).toHaveBeenCalledWith(
+      "assistant_message",
+      expect.objectContaining({
+        message: expect.stringContaining("did not execute a tool"),
+      }),
+    );
+    expect(executor.emitEvent).not.toHaveBeenCalledWith(
+      "assistant_message",
+      expect.objectContaining({
+        message: expect.stringContaining("search_web:0"),
+      }),
+    );
+  });
+
   it("only exposes the last non-verification step as an assistant bubble", () => {
     const executor = Object.create(TaskExecutor.prototype) as Any;
     executor.plan = {

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -4152,6 +4152,23 @@ export class TaskExecutor {
     );
   }
 
+  private responseLooksLikeUnexecutedToolCall(text: string): boolean {
+    const normalized = String(text || "").trim();
+    if (!normalized) return false;
+
+    return (
+      /\b(?:search_web|web_search|web_fetch|browser_search|browser_navigate|tool_call)\s*:\s*\d+\s*\{/.test(
+        normalized,
+      ) ||
+      /<invoke\b[\s\S]{0,240}<\/invoke>/i.test(normalized) ||
+      /<invoke\s+name=["'][^"']+["']\s*\/>/i.test(normalized)
+    );
+  }
+
+  private buildUnexecutedToolCallChatFallback(): string {
+    return "I did not execute a tool in this chat turn, so I cannot treat that tool-call text as a completed result.";
+  }
+
   private stripPinnedSummaryPrefixFromFirstUserMessage(messages: LLMMessage[]): LLMMessage[] {
     const cloned = messages.map((msg) => ({ ...msg })) as LLMMessage[];
 
@@ -6775,12 +6792,25 @@ ${transcript}
           ? "Could you say more about that? I'd like to explore this further with you."
           : this.generateCompanionFallbackResponse(message),
       });
-      const assistantText = turnResult.assistantText;
+      const rawAssistantText = turnResult.assistantText;
+      const assistantText = this.responseLooksLikeUnexecutedToolCall(rawAssistantText)
+        ? this.buildUnexecutedToolCallChatFallback()
+        : rawAssistantText;
       this.emitEvent("assistant_message", { message: assistantText });
       this.lastAssistantOutput = assistantText;
       this.lastNonVerificationOutput = assistantText;
       this.lastAssistantText = assistantText;
-      this.updateConversationHistory(turnResult.messages);
+      this.updateConversationHistory(
+        assistantText === rawAssistantText
+          ? turnResult.messages
+          : [
+              ...messages,
+              {
+                role: "assistant" as const,
+                content: [{ type: "text" as const, text: assistantText }],
+              },
+            ],
+      );
       this.saveConversationSnapshot();
       this.emitEvent("follow_up_completed", {
         message: "Follow-up message processed (chat mode)",
@@ -21769,7 +21799,10 @@ You are continuing a previous conversation. The context from the previous conver
       const emptyFallback = isThinkMode
         ? "I'd like to help you think through this. Could you share more about what's on your mind?"
         : this.generateCompanionFallbackResponse(rawPrompt);
-      const assistantText = String(text || "").trim() || emptyFallback;
+      const rawAssistantText = String(text || "").trim() || emptyFallback;
+      const assistantText = this.responseLooksLikeUnexecutedToolCall(rawAssistantText)
+        ? this.buildUnexecutedToolCallChatFallback()
+        : rawAssistantText;
 
       this.emitEvent("assistant_message", { message: assistantText });
       this.lastAssistantOutput = assistantText;


### PR DESCRIPTION
## Summary
- detect assistant text that looks like an unexecuted tool call in chat surfaces
- replace that text with an honest fallback instead of saving or displaying fake tool output
- apply the guard to initial companion replies and chat-mode follow-up replies

## Validation
- `npx vitest run src/electron/agent/__tests__/executor-chat-mode.test.ts`
- `npm run type-check`

AI assisted