### PR TITLE
Prefer latest follow-up assistant summary

### DIFF
--- a/src/electron/agent/__tests__/executor-chat-mode.test.ts
+++ b/src/electron/agent/__tests__/executor-chat-mode.test.ts
@@ -184,6 +184,29 @@ describe("TaskExecutor chat mode", () => {
     expect((TaskExecutor as Any).prototype.shouldShortCircuitSimpleNonExecuteAnswer.call(executor)).toBe(false);
   });
 
+  it("prefers the latest follow-up assistant text over stale prior summaries", () => {
+    const executor = Object.create(TaskExecutor.prototype) as Any;
+
+    executor.task = {
+      id: "task-follow-up-summary",
+      title: "Research Analyst run",
+      prompt: "Research prompt",
+      resultSummary: "Research Analyst - Awaiting Input",
+    };
+    executor.bestKnownOutcome = {
+      resultSummary: "Yo! What's up? How can I help you today?",
+    };
+    executor.lastNonVerificationOutput = "Research Analyst - Awaiting Input";
+    executor.lastAssistantOutput = "Research Analyst - Awaiting Input";
+    executor.lastAssistantText =
+      "Premier League fixtures: Liverpool vs Chelsea; Brentford vs Manchester City.";
+    executor.getContentFallback = vi.fn().mockReturnValue("");
+
+    expect((TaskExecutor as Any).prototype.buildFollowUpResultSummary.call(executor)).toBe(
+      "Premier League fixtures: Liverpool vs Chelsea; Brentford vs Manchester City.",
+    );
+  });
+
   it("only exposes the last non-verification step as an assistant bubble", () => {
     const executor = Object.create(TaskExecutor.prototype) as Any;
     executor.plan = {

--- a/src/electron/agent/__tests__/executor-chat-mode.test.ts
+++ b/src/electron/agent/__tests__/executor-chat-mode.test.ts
@@ -207,6 +207,62 @@ describe("TaskExecutor chat mode", () => {
     );
   });
 
+  it("prefers the latest persisted follow-up assistant message over stale assistant text", () => {
+    const executor = Object.create(TaskExecutor.prototype) as Any;
+
+    executor.task = {
+      id: "task-follow-up-history-summary",
+      title: "Persistent goal",
+      prompt: "Track release blockers",
+      resultSummary: "Release blocker analysis from the prior run.",
+    };
+    executor.bestKnownOutcome = {
+      resultSummary: "Older best-known release blocker summary.",
+    };
+    executor.conversationHistory = [
+      { role: "user", content: [{ type: "text", text: "/goal status" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Goal active.\n\nObjective: Track release blockers" }],
+      },
+    ];
+    executor.lastAssistantText = "A stale assistant reply from before the follow-up.";
+    executor.lastNonVerificationOutput = "Goal active.\n\nObjective: Track release blockers";
+    executor.lastAssistantOutput = "Goal active.\n\nObjective: Track release blockers";
+    executor.getContentFallback = vi.fn().mockReturnValue("");
+
+    expect((TaskExecutor as Any).prototype.buildFollowUpResultSummary.call(executor)).toBe(
+      "Goal active.\n\nObjective: Track release blockers",
+    );
+  });
+
+  it("keeps local goal follow-up messages aligned with last assistant text", () => {
+    const executor = Object.create(TaskExecutor.prototype) as Any;
+
+    executor.task = {
+      id: "task-goal-follow-up",
+      title: "Persistent goal",
+      prompt: "Track release blockers",
+    };
+    executor.workspace = {
+      id: "ws-goal-follow-up",
+      path: "/tmp",
+      permissions: { read: true, write: true, delete: true, network: true, shell: true },
+    };
+    executor.emitEvent = vi.fn();
+
+    (TaskExecutor as Any).prototype.emitGoalAssistantMessage.call(
+      executor,
+      "/goal status",
+      "Goal active.\n\nObjective: Track release blockers",
+    );
+
+    expect(executor.lastAssistantText).toBe("Goal active.\n\nObjective: Track release blockers");
+    expect((TaskExecutor as Any).prototype.buildFollowUpResultSummary.call(executor)).toBe(
+      "Goal active.\n\nObjective: Track release blockers",
+    );
+  });
+
   it("only exposes the last non-verification step as an assistant bubble", () => {
     const executor = Object.create(TaskExecutor.prototype) as Any;
     executor.plan = {

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -1295,8 +1295,7 @@ export class TaskExecutor {
     const completedAt = Date.now();
     const clearError = opts?.clearError !== false;
     const clearTerminalFailure = opts?.clearTerminalFailure === true;
-    const summary =
-      this.buildResultSummary() || this.getContentFallback() || this.task.resultSummary || "";
+    const summary = this.buildFollowUpResultSummary();
     const trimmedSummary = typeof summary === "string" ? summary.trim() : "";
 
     this.task.status = "completed";
@@ -1330,6 +1329,27 @@ export class TaskExecutor {
       ...runtimeProjection,
       ...this.getCompletionProjectionFields(),
     });
+  }
+
+  private buildFollowUpResultSummary(): string {
+    const bestKnownSummary = String(this.bestKnownOutcome?.resultSummary || "").trim();
+    const candidates = [
+      this.lastAssistantText,
+      this.lastNonVerificationOutput,
+      this.lastAssistantOutput,
+      this.getContentFallback(),
+      bestKnownSummary,
+      this.task.resultSummary,
+    ];
+
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      const trimmed = String(candidate).trim();
+      if (!this.isUsefulResultSummaryCandidate(trimmed)) continue;
+      return trimmed.length > 4000 ? `${trimmed.slice(0, 4000)}...` : trimmed;
+    }
+
+    return "";
   }
 
   private finalizeFollowUpFailure(error: Any): void {

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -1334,6 +1334,7 @@ export class TaskExecutor {
   private buildFollowUpResultSummary(): string {
     const bestKnownSummary = String(this.bestKnownOutcome?.resultSummary || "").trim();
     const candidates = [
+      this.getLatestAssistantConversationText(),
       this.lastAssistantText,
       this.lastNonVerificationOutput,
       this.lastAssistantOutput,
@@ -1350,6 +1351,31 @@ export class TaskExecutor {
     }
 
     return "";
+  }
+
+  private getLatestAssistantConversationText(): string {
+    const history = Array.isArray(this.conversationHistory) ? this.conversationHistory : [];
+    for (let index = history.length - 1; index >= 0; index -= 1) {
+      const message = history[index];
+      if (message?.role !== "assistant") continue;
+      const text = this.extractTextFromMessageContent(message.content).trim();
+      if (text) return text;
+    }
+    return "";
+  }
+
+  private extractTextFromMessageContent(content: LLMMessage["content"]): string {
+    if (typeof content === "string") return content;
+    if (!Array.isArray(content)) return "";
+    return content
+      .map((block) => {
+        if (block && typeof block === "object" && "type" in block && block.type === "text") {
+          return String((block as { text?: unknown }).text || "");
+        }
+        return "";
+      })
+      .filter((text) => text.trim().length > 0)
+      .join("\n");
   }
 
   private finalizeFollowUpFailure(error: Any): void {
@@ -19653,6 +19679,7 @@ You are continuing a previous conversation. The context from the previous conver
     ]);
     this.lastAssistantOutput = message;
     this.lastNonVerificationOutput = message;
+    this.lastAssistantText = message;
   }
 
   private updateGoalAgentConfig(agentConfig: AgentConfig): void {


### PR DESCRIPTION
## Summary
- add a follow-up-specific result summary selector
- prefer the latest assistant text before older task summaries or best-known outcomes
- add regression coverage for stale follow-up summary replacement

## Validation
- `npx vitest run src/electron/agent/__tests__/executor-chat-mode.test.ts`
- `npm run type-check`

AI assisted