### PR TITLE
Add step loop budget stop propagation

### DIFF
--- a/src/electron/agent/__tests__/executor-entrypoints.test.ts
+++ b/src/electron/agent/__tests__/executor-entrypoints.test.ts
@@ -32,6 +32,28 @@ describe("TaskExecutor entrypoint guards", () => {
     expect(executor.executeStepLegacy).not.toHaveBeenCalled();
   });
 
+  it("maps loop budget stops to precise step failure telemetry reasons", () => {
+    const executor = Object.create(TaskExecutor.prototype) as Any;
+
+    expect(
+      (TaskExecutor.prototype as Any).deriveStepStopReason.call(executor, {
+        stepFailed: true,
+        failureReason: "Step loop budget exhausted: reached the total LLM call limit.",
+        awaitingUserInput: false,
+        iterationCount: 4,
+        maxIterations: 32,
+        loopBudgetStopReason: "max_llm_calls",
+      }),
+    ).toBe("max_llm_calls");
+
+    expect(
+      (TaskExecutor.prototype as Any).getStepLoopBudgetFailureReason.call(
+        executor,
+        "max_recovered_responses",
+      ),
+    ).toBe("Step loop budget exhausted: reached the recovered response limit.");
+  });
+
   it("routes sendMessageUnlocked through the unified branch", async () => {
     const executor = Object.create(TaskExecutor.prototype) as Any;
 

--- a/src/electron/agent/__tests__/executor-entrypoints.test.ts
+++ b/src/electron/agent/__tests__/executor-entrypoints.test.ts
@@ -3,6 +3,7 @@ import { TaskExecutor } from "../executor";
 import { AcpxRuntimeUnavailableError } from "../AcpxRuntimeRunner";
 import { PlaybookService } from "../../memory/PlaybookService";
 import { SessionRecallService } from "../../memory/SessionRecallService";
+import type { Task, TaskBestKnownOutcome } from "../../../shared/types";
 
 describe("TaskExecutor entrypoint guards", () => {
   it("serializes execute/sendMessage via lifecycle mutex wrappers", async () => {
@@ -34,6 +35,9 @@ describe("TaskExecutor entrypoint guards", () => {
 
   it("maps loop budget stops to precise step failure telemetry reasons", () => {
     const executor = Object.create(TaskExecutor.prototype) as Any;
+    const taskStopReasons: Pick<Task, "stopReasons"> = {
+      stopReasons: ["max_llm_calls", "max_recovered_responses", "max_repeated_iterations"],
+    };
 
     expect(
       (TaskExecutor.prototype as Any).deriveStepStopReason.call(executor, {
@@ -52,6 +56,11 @@ describe("TaskExecutor entrypoint guards", () => {
         "max_recovered_responses",
       ),
     ).toBe("Step loop budget exhausted: reached the recovered response limit.");
+    expect(taskStopReasons.stopReasons).toEqual([
+      "max_llm_calls",
+      "max_recovered_responses",
+      "max_repeated_iterations",
+    ]);
   });
 
   it("routes sendMessageUnlocked through the unified branch", async () => {
@@ -311,13 +320,15 @@ describe("TaskExecutor entrypoint guards", () => {
       resultSummary: "older summary",
       semanticSummary: "Opened canvas",
     };
+    const freshSummary = "Fresh follow-up summary with useful completion details.";
     executor.bestKnownOutcome = {
-      summary: "fresh summary",
+      capturedAt: 1,
+      resultSummary: freshSummary,
       terminalStatus: "ok",
       failureClass: undefined,
       outputSummary: { outputCount: 1, fileCount: 1, files: [] },
-    };
-    executor.buildResultSummary = vi.fn(() => "fresh summary");
+    } satisfies TaskBestKnownOutcome;
+    executor.buildResultSummary = vi.fn(() => freshSummary);
     executor.getContentFallback = vi.fn(() => "");
     executor.daemon = {
       updateTask: vi.fn(),
@@ -335,7 +346,7 @@ describe("TaskExecutor entrypoint guards", () => {
     expect(executor.task.error).toBeUndefined();
     expect(executor.task.terminalStatus).toBeUndefined();
     expect(executor.task.failureClass).toBeUndefined();
-    expect(executor.task.resultSummary).toBe("fresh summary");
+    expect(executor.task.resultSummary).toBe(freshSummary);
     expect(executor.daemon.updateTask).toHaveBeenCalledWith(
       "task-follow-up",
       expect.objectContaining({
@@ -343,7 +354,7 @@ describe("TaskExecutor entrypoint guards", () => {
         error: null,
         terminalStatus: undefined,
         failureClass: undefined,
-        resultSummary: "fresh summary",
+        resultSummary: freshSummary,
         semanticSummary: "Opened canvas",
         bestKnownOutcome: executor.bestKnownOutcome,
       }),
@@ -352,7 +363,7 @@ describe("TaskExecutor entrypoint guards", () => {
       "task_completed",
       expect.objectContaining({
         message: "Follow-up completed (24 tool calls)",
-        resultSummary: "fresh summary",
+        resultSummary: freshSummary,
         semanticSummary: "Opened canvas",
       }),
     );
@@ -367,11 +378,12 @@ describe("TaskExecutor entrypoint guards", () => {
       semanticSummary: "Verified markdown targets",
     };
     executor.bestKnownOutcome = {
-      summary: "Verification failed after follow-up",
+      capturedAt: 1,
+      resultSummary: "Verification failed after follow-up",
       terminalStatus: "failed",
       failureClass: "contract_error",
       outputSummary: { outputCount: 1, fileCount: 1, files: [] },
-    };
+    } satisfies TaskBestKnownOutcome;
     executor.applyRuntimeTaskProjectionToTask = vi.fn(() => ({
       continuationCount: 1,
       continuationWindow: 1,

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -90,6 +90,7 @@ import {
   type SessionRuntimeState,
   type SessionRuntimeTaskProjection,
 } from "./runtime/SessionRuntime";
+import { defaultStepLoopBudget, type LoopBudgetStopReason } from "./runtime/LoopBudgetPolicy";
 import type {
   TurnKernelIterationState,
   TurnKernelPolicy,
@@ -4947,6 +4948,7 @@ ${transcript}
   private stepStopReasons: Set<
     | "completed"
     | "max_turns"
+    | LoopBudgetStopReason
     | "tool_error"
     | "contract_block"
     | "verification_block"
@@ -24903,10 +24905,11 @@ Return ONLY a JSON object:
       let foundBrowserInspectionEvidence = false;
       let browserInspectionEvidenceText = "";
       let currentStepTargetVerificationObserved = false;
-      const maxIterations = 32; // Allow enough iterations for scaffolding steps and build-fix cycles
+      const stepLoopBudget = defaultStepLoopBudget();
+      const maxIterations = stepLoopBudget.maxIterations;
       const maxEmptyResponses = 3;
-      const maxMaxTokensRecoveries = 6; // Max recovery attempts for max_tokens truncation
-      const maxContextCapacityRecoveries = 2;
+      const maxMaxTokensRecoveries = stepLoopBudget.maxMaxTokenRecoveries;
+      const maxContextCapacityRecoveries = stepLoopBudget.maxContextRecoveries;
       let maxTokensRecoveryCount = 0;
       let contextCapacityRecoveryCount = 0;
       let lastTurnMemoryRecallQuery = "";
@@ -29298,18 +29301,36 @@ Return ONLY a JSON object:
         mode: "step",
         messages,
         maxIterations,
+        maxLlmCalls: stepLoopBudget.maxLlmCalls,
         maxEmptyResponses,
+        maxRecoveredResponses: stepLoopBudget.maxRecoveredResponses,
+        maxRepeatedIterations: stepLoopBudget.maxRepeatedIterations,
         policy: stepKernelPolicy,
       });
       messages = stepKernelOutcome.messages;
       iterationCount = stepKernelOutcome.iterations;
       emptyResponseCount = stepKernelOutcome.emptyResponseCount;
+      const stepLoopBudgetStopReason = stepKernelOutcome.loopBudgetStopReason;
+      if (stepLoopBudgetStopReason) {
+        stepFailed = true;
+        lastFailureReason = this.getStepLoopBudgetFailureReason(stepLoopBudgetStopReason);
+        this.emitEvent("log", {
+          metric: "step_loop_budget_stop",
+          stepId: step.id,
+          reason: stepLoopBudgetStopReason,
+          message: lastFailureReason,
+        });
+      }
 
       if (stepKernelSkipped || stepKernelRetried) {
         return;
       }
 
-      if (hadRecoverableUnavailableAlternative && (hadToolSuccessAfterError || hadAnyToolSuccess)) {
+      if (
+        !stepLoopBudgetStopReason &&
+        hadRecoverableUnavailableAlternative &&
+        (hadToolSuccessAfterError || hadAnyToolSuccess)
+      ) {
         stepFailed = false;
         if (/Tool .* failed: Tool not available/i.test(String(lastFailureReason || ""))) {
           lastFailureReason = "";
@@ -29719,6 +29740,7 @@ Return ONLY a JSON object:
 
       if (
         stepFailed &&
+        !stepLoopBudgetStopReason &&
         strictVerificationOutcome === "required_fail" &&
         enforceVerificationOk &&
         !verificationRewindAttempted &&
@@ -29817,6 +29839,7 @@ Return ONLY a JSON object:
         awaitingUserInput,
         iterationCount,
         maxIterations,
+        loopBudgetStopReason: stepLoopBudgetStopReason,
       });
       this.stepStopReasons.add(stepStopReason);
       this.emitEvent("log", {
@@ -29872,6 +29895,7 @@ Return ONLY a JSON object:
         const recoveryState = runtime.getRecoveryState();
         const shouldHandleRecovery =
           !isNonBlockingVerificationFailure &&
+          !stepLoopBudgetStopReason &&
           (userRequestedRecovery || autoRecoveryRequested) &&
           recoveryClass !== "user_blocker" &&
           recoveryState.lastRecoveryFailureSignature !== recoverySignature;
@@ -30897,9 +30921,11 @@ Return ONLY a JSON object:
     awaitingUserInput: boolean;
     iterationCount: number;
     maxIterations: number;
+    loopBudgetStopReason?: LoopBudgetStopReason;
   }):
     | "completed"
     | "max_turns"
+    | LoopBudgetStopReason
     | "tool_error"
     | "contract_block"
     | "verification_block"
@@ -30908,6 +30934,7 @@ Return ONLY a JSON object:
     if (opts.awaitingUserInput) return "awaiting_user_input";
     const lower = String(opts.failureReason || "").toLowerCase();
     if (!opts.stepFailed) return "completed";
+    if (opts.loopBudgetStopReason) return opts.loopBudgetStopReason;
     if (opts.iterationCount >= opts.maxIterations) return "max_turns";
     if (
       /enotfound|err_network|network changed|opening handshake has timed out|dependency_unavailable|status:\s*408/.test(
@@ -30923,6 +30950,17 @@ Return ONLY a JSON object:
       return "verification_block";
     }
     return "tool_error";
+  }
+
+  private getStepLoopBudgetFailureReason(reason: LoopBudgetStopReason): string {
+    switch (reason) {
+      case "max_llm_calls":
+        return "Step loop budget exhausted: reached the total LLM call limit.";
+      case "max_recovered_responses":
+        return "Step loop budget exhausted: reached the recovered response limit.";
+      case "max_repeated_iterations":
+        return "Step loop budget exhausted: reached the repeated iteration limit.";
+    }
   }
 
   private inferFailureDomainsFromReason(reason: string): string[] {
@@ -30968,6 +31006,7 @@ Return ONLY a JSON object:
       | "verification_block"
       | "awaiting_user_input"
       | "dependency_unavailable"
+      | LoopBudgetStopReason
     >;
   } {
     this.ensureVerificationOutcomeSets();

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -45,6 +45,7 @@ import {
   type SkillApplicationTrigger,
   type QuotedAssistantMessage,
   type TaskFollowUpInput,
+  type TaskStopReason,
 } from "../../shared/types";
 import { resolveModelPreferenceToModelKey } from "../../shared/agent-preferences";
 import { isVerificationStepDescription } from "../../shared/plan-utils";
@@ -4945,16 +4946,7 @@ ${transcript}
   private softDeadlineTriggered: boolean = false;
   private wrapUpRequested: boolean = false;
   private completionVerificationMetadata: VerificationCompletionMetadata | null = null;
-  private stepStopReasons: Set<
-    | "completed"
-    | "max_turns"
-    | LoopBudgetStopReason
-    | "tool_error"
-    | "contract_block"
-    | "verification_block"
-    | "awaiting_user_input"
-    | "dependency_unavailable"
-  > = new Set();
+  private stepStopReasons: Set<TaskStopReason> = new Set();
   private capabilityGapSignalCount = 0;
   private capabilityGapHintInjectedTurn = -1;
   private capabilityGapHintInjectedSteps: Set<string> = new Set();
@@ -18026,15 +18018,7 @@ You are continuing a previous conversation. The context from the previous conver
 
   private ensureReliabilityTrackingSets(): void {
     if (!(this.stepStopReasons instanceof Set)) {
-      this.stepStopReasons = new Set<
-        | "completed"
-        | "max_turns"
-        | "tool_error"
-        | "contract_block"
-        | "verification_block"
-        | "awaiting_user_input"
-        | "dependency_unavailable"
-      >();
+      this.stepStopReasons = new Set<TaskStopReason>();
     }
     if (!(this.taskFailureDomains instanceof Set)) {
       this.taskFailureDomains = new Set();
@@ -30922,15 +30906,7 @@ Return ONLY a JSON object:
     iterationCount: number;
     maxIterations: number;
     loopBudgetStopReason?: LoopBudgetStopReason;
-  }):
-    | "completed"
-    | "max_turns"
-    | LoopBudgetStopReason
-    | "tool_error"
-    | "contract_block"
-    | "verification_block"
-    | "awaiting_user_input"
-    | "dependency_unavailable" {
+  }): TaskStopReason {
     if (opts.awaitingUserInput) return "awaiting_user_input";
     const lower = String(opts.failureReason || "").toLowerCase();
     if (!opts.stepFailed) return "completed";
@@ -30998,16 +30974,7 @@ Return ONLY a JSON object:
     coreOutcome: "ok" | "partial" | "failed";
     dependencyOutcome: "healthy" | "degraded" | "down";
     failureDomains: string[];
-    stopReasons: Array<
-      | "completed"
-      | "max_turns"
-      | "tool_error"
-      | "contract_block"
-      | "verification_block"
-      | "awaiting_user_input"
-      | "dependency_unavailable"
-      | LoopBudgetStopReason
-    >;
+    stopReasons: TaskStopReason[];
   } {
     this.ensureVerificationOutcomeSets();
     const domains = new Set<string>(this.taskFailureDomains);

--- a/src/electron/agent/runtime/LoopBudgetPolicy.ts
+++ b/src/electron/agent/runtime/LoopBudgetPolicy.ts
@@ -1,0 +1,24 @@
+export type LoopBudgetStopReason =
+  | "max_llm_calls"
+  | "max_recovered_responses"
+  | "max_repeated_iterations";
+
+export interface StepLoopBudget {
+  maxIterations: number;
+  maxLlmCalls: number;
+  maxRecoveredResponses: number;
+  maxRepeatedIterations: number;
+  maxContextRecoveries: number;
+  maxMaxTokenRecoveries: number;
+}
+
+export function defaultStepLoopBudget(): StepLoopBudget {
+  return {
+    maxIterations: 32,
+    maxLlmCalls: 40,
+    maxRecoveredResponses: 2,
+    maxRepeatedIterations: 6,
+    maxContextRecoveries: 2,
+    maxMaxTokenRecoveries: 6,
+  };
+}

--- a/src/electron/agent/runtime/SessionRuntime.ts
+++ b/src/electron/agent/runtime/SessionRuntime.ts
@@ -565,7 +565,10 @@ export class SessionRuntime {
         mode: "step",
         messages: input.messages,
         maxIterations: input.maxIterations,
+        maxLlmCalls: input.maxLlmCalls,
         maxEmptyResponses: input.maxEmptyResponses,
+        maxRecoveredResponses: input.maxRecoveredResponses,
+        maxRepeatedIterations: input.maxRepeatedIterations,
       },
       input.policy,
     ).run();
@@ -577,7 +580,10 @@ export class SessionRuntime {
         mode: "follow_up",
         messages: input.messages,
         maxIterations: input.maxIterations,
+        maxLlmCalls: input.maxLlmCalls,
         maxEmptyResponses: input.maxEmptyResponses,
+        maxRecoveredResponses: input.maxRecoveredResponses,
+        maxRepeatedIterations: input.maxRepeatedIterations,
       },
       input.policy,
     ).run();

--- a/src/electron/agent/runtime/__tests__/turn-kernel.test.ts
+++ b/src/electron/agent/runtime/__tests__/turn-kernel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { TurnKernel } from "../turn-kernel";
+import type { LoopBudgetStopReason } from "../LoopBudgetPolicy";
 
 describe("TurnKernel", () => {
   it("retries the same iteration when response preparation recovers messages", async () => {
@@ -59,6 +60,193 @@ describe("TurnKernel", () => {
 
     expect(result.stopReason).toBe("max_empty_responses");
     expect(result.iterations).toBe(1);
+  });
+
+  it("allows the final configured recovered response to issue its retry request", async () => {
+    const requestResponse = vi
+      .fn()
+      .mockResolvedValueOnce({
+        recovered: true,
+        messages: [{ role: "user", content: "recovered once" }],
+      })
+      .mockResolvedValueOnce({
+        recovered: true,
+        messages: [{ role: "user", content: "recovered twice" }],
+      })
+      .mockResolvedValueOnce({
+        response: { stopReason: "end_turn", content: [{ type: "text", text: "done" }] },
+        availableTools: [],
+      });
+
+    const kernel = new TurnKernel(
+      {
+        mode: "step",
+        messages: [{ role: "user", content: "start" }],
+        maxIterations: 5,
+        maxEmptyResponses: 2,
+        maxRecoveredResponses: 2,
+      },
+      {
+        requestResponse,
+        handleResponse: async () => ({ continueLoop: false }),
+      },
+    );
+
+    const result = await kernel.run();
+
+    expect(requestResponse).toHaveBeenCalledTimes(3);
+    expect(result.stopReason).toBeUndefined();
+    expect(result.iterations).toBe(1);
+    expect(result.messages).toEqual([{ role: "user", content: "recovered twice" }]);
+  });
+
+  it("stops recovered responses before exceeding the configured retry request cap", async () => {
+    const requestResponse = vi.fn().mockResolvedValue({
+      recovered: true,
+      messages: [{ role: "user", content: "still recovering" }],
+    });
+
+    const kernel = new TurnKernel(
+      {
+        mode: "step",
+        messages: [{ role: "user", content: "start" }],
+        maxIterations: 5,
+        maxEmptyResponses: 2,
+        maxRecoveredResponses: 2,
+      },
+      {
+        requestResponse,
+        handleResponse: async () => ({ continueLoop: false }),
+      },
+    );
+
+    const result = await kernel.run();
+
+    expect(requestResponse).toHaveBeenCalledTimes(3);
+    expect(result.stopReason).toBe("max_recovered_responses");
+    expect(result.loopBudgetStopReason).toBe("max_recovered_responses");
+    expect(result.iterations).toBe(0);
+    expect(result.messages).toEqual([{ role: "user", content: "still recovering" }]);
+  });
+
+  it("allows the final configured repeated iteration to issue its retry request", async () => {
+    const requestResponse = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: { stopReason: "max_tokens", content: [{ type: "text", text: "repeat once" }] },
+        availableTools: [],
+      })
+      .mockResolvedValueOnce({
+        response: { stopReason: "max_tokens", content: [{ type: "text", text: "repeat twice" }] },
+        availableTools: [],
+      })
+      .mockResolvedValueOnce({
+        response: { stopReason: "end_turn", content: [{ type: "text", text: "done" }] },
+        availableTools: [],
+      });
+    const handleResponse = vi
+      .fn()
+      .mockResolvedValueOnce({ continueLoop: true, repeatIteration: true })
+      .mockResolvedValueOnce({ continueLoop: true, repeatIteration: true })
+      .mockResolvedValueOnce({ continueLoop: false });
+
+    const kernel = new TurnKernel(
+      {
+        mode: "step",
+        messages: [{ role: "user", content: "start" }],
+        maxIterations: 5,
+        maxLlmCalls: 10,
+        maxEmptyResponses: 2,
+        maxRepeatedIterations: 2,
+      },
+      {
+        requestResponse,
+        handleResponse,
+      },
+    );
+
+    const result = await kernel.run();
+
+    expect(requestResponse).toHaveBeenCalledTimes(3);
+    expect(result.stopReason).toBeUndefined();
+    expect(result.iterations).toBe(1);
+  });
+
+  it("stops repeated iterations before exceeding the configured retry request cap", async () => {
+    const requestResponse = vi.fn().mockResolvedValue({
+      response: { stopReason: "tool_use", content: [{ type: "text", text: "repeat" }] },
+      availableTools: [],
+    });
+
+    const kernel = new TurnKernel(
+      {
+        mode: "step",
+        messages: [{ role: "user", content: "start" }],
+        maxIterations: 5,
+        maxLlmCalls: 10,
+        maxEmptyResponses: 2,
+        maxRepeatedIterations: 2,
+      },
+      {
+        requestResponse,
+        handleResponse: async () => ({ continueLoop: true, repeatIteration: true }),
+      },
+    );
+
+    const result = await kernel.run();
+
+    expect(requestResponse).toHaveBeenCalledTimes(3);
+    expect(result.stopReason).toBe("max_repeated_iterations");
+    expect(result.loopBudgetStopReason).toBe("max_repeated_iterations");
+    expect(result.iterations).toBe(0);
+  });
+
+  it("enforces one total LLM-call budget across recovered and repeated turns", async () => {
+    const requestResponse = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: { stopReason: "tool_use", content: [{ type: "text", text: "repeat" }] },
+        availableTools: [],
+      })
+      .mockResolvedValueOnce({
+        recovered: true,
+        messages: [{ role: "user", content: "recovered once" }],
+      })
+      .mockResolvedValueOnce({
+        response: { stopReason: "tool_use", content: [{ type: "text", text: "repeat again" }] },
+        availableTools: [],
+      })
+      .mockResolvedValueOnce({
+        recovered: true,
+        messages: [{ role: "user", content: "recovered twice" }],
+      })
+      .mockResolvedValue({
+        response: { stopReason: "tool_use", content: [{ type: "text", text: "budget edge" }] },
+        availableTools: [],
+      });
+
+    const kernel = new TurnKernel(
+      {
+        mode: "step",
+        messages: [{ role: "user", content: "start" }],
+        maxIterations: 32,
+        maxLlmCalls: 5,
+        maxEmptyResponses: 2,
+        maxRecoveredResponses: 10,
+        maxRepeatedIterations: 10,
+      },
+      {
+        requestResponse,
+        handleResponse: async () => ({ continueLoop: true, repeatIteration: true }),
+      },
+    );
+
+    const result = await kernel.run();
+    const loopBudgetStopReason: LoopBudgetStopReason | undefined = result.loopBudgetStopReason;
+
+    expect(requestResponse).toHaveBeenCalledTimes(5);
+    expect(result.stopReason).toBe("max_llm_calls");
+    expect(loopBudgetStopReason).toBe("max_llm_calls");
   });
 
   it("stops immediately when response preparation requests a terminal stop", async () => {

--- a/src/electron/agent/runtime/turn-kernel.ts
+++ b/src/electron/agent/runtime/turn-kernel.ts
@@ -1,4 +1,15 @@
 import type { LLMMessage } from "../llm/types";
+import type { LoopBudgetStopReason } from "./LoopBudgetPolicy";
+
+export type TurnKernelStopReason =
+  | LoopBudgetStopReason
+  | "max_empty_responses"
+  | "context_capacity_exhausted"
+  | "cancelled"
+  | "cancelled_or_completed"
+  | "wrap_up_requested"
+  | "step_feedback_skip"
+  | "step_feedback_retry";
 
 export type TurnKernelMode = "step" | "follow_up";
 
@@ -6,7 +17,10 @@ export interface TurnKernelInput {
   mode: TurnKernelMode;
   messages: LLMMessage[];
   maxIterations: number;
+  maxLlmCalls?: number;
   maxEmptyResponses: number;
+  maxRecoveredResponses?: number;
+  maxRepeatedIterations?: number;
 }
 
 export interface TurnKernelIterationState {
@@ -31,20 +45,20 @@ export interface TurnKernelRecoveredResponse {
 export interface TurnKernelStoppedResponse {
   stopped: true;
   messages: LLMMessage[];
-  stopReason?: string;
+  stopReason?: TurnKernelStopReason;
 }
 
 export interface TurnKernelDecision {
   continueLoop?: boolean;
   emptyResponseCount?: number;
   repeatIteration?: boolean;
-  stopReason?: string;
+  stopReason?: TurnKernelStopReason;
 }
 
 export interface TurnKernelPolicy {
   shouldStopBeforeIteration?: (
     state: TurnKernelIterationState,
-  ) => { stop: boolean; reason?: string } | void;
+  ) => { stop: boolean; reason?: TurnKernelStopReason } | void;
   drainPendingMessages?: (state: TurnKernelIterationState) => Promise<void> | void;
   beforeIteration?: (state: TurnKernelIterationState) => Promise<void> | void;
   requestResponse: (
@@ -61,7 +75,8 @@ export interface TurnKernelOutcome {
   messages: LLMMessage[];
   iterations: number;
   emptyResponseCount: number;
-  stopReason?: string;
+  stopReason?: TurnKernelStopReason;
+  loopBudgetStopReason?: LoopBudgetStopReason;
 }
 
 export class TurnKernel {
@@ -78,9 +93,33 @@ export class TurnKernel {
       emptyResponseCount: 0,
       continueLoop: true,
     };
-    let stopReason: string | undefined;
+    let stopReason: TurnKernelStopReason | undefined;
+    let loopBudgetStopReason: LoopBudgetStopReason | undefined;
+    let llmCallCount = 0;
+    let recoveredResponseCount = 0;
+    let repeatedIterationCount = 0;
+    const maxLlmCalls =
+      typeof this.input.maxLlmCalls === "number" && Number.isFinite(this.input.maxLlmCalls)
+        ? Math.max(0, Math.floor(this.input.maxLlmCalls))
+        : Number.POSITIVE_INFINITY;
+    const maxRecoveredResponses =
+      typeof this.input.maxRecoveredResponses === "number" &&
+      Number.isFinite(this.input.maxRecoveredResponses)
+        ? Math.max(0, Math.floor(this.input.maxRecoveredResponses))
+        : this.input.maxIterations;
+    const maxRepeatedIterations =
+      typeof this.input.maxRepeatedIterations === "number" &&
+      Number.isFinite(this.input.maxRepeatedIterations)
+        ? Math.max(0, Math.floor(this.input.maxRepeatedIterations))
+        : this.input.maxIterations;
 
     while (state.continueLoop && state.iterationCount < this.input.maxIterations) {
+      if (llmCallCount >= maxLlmCalls) {
+        stopReason = "max_llm_calls";
+        loopBudgetStopReason = "max_llm_calls";
+        break;
+      }
+
       const stopBeforeIteration = this.policy.shouldStopBeforeIteration?.(state);
       if (stopBeforeIteration?.stop) {
         stopReason = stopBeforeIteration.reason;
@@ -97,6 +136,7 @@ export class TurnKernel {
       state.iterationCount += 1;
       await this.policy.beforeIteration?.(state);
 
+      llmCallCount += 1;
       const prepared = await this.policy.requestResponse(state);
       if (isTurnKernelStoppedResponse(prepared)) {
         state.messages = prepared.messages;
@@ -105,7 +145,13 @@ export class TurnKernel {
       }
       if (isTurnKernelRecoveredResponse(prepared)) {
         state.messages = prepared.messages;
+        recoveredResponseCount += 1;
         state.iterationCount -= 1;
+        if (recoveredResponseCount > maxRecoveredResponses) {
+          stopReason = "max_recovered_responses";
+          loopBudgetStopReason = "max_recovered_responses";
+          break;
+        }
         continue;
       }
 
@@ -126,7 +172,13 @@ export class TurnKernel {
         stopReason = decision.stopReason;
       }
       if (decision.repeatIteration) {
+        repeatedIterationCount += 1;
         state.iterationCount -= 1;
+        if (repeatedIterationCount > maxRepeatedIterations) {
+          stopReason = "max_repeated_iterations";
+          loopBudgetStopReason = "max_repeated_iterations";
+          break;
+        }
       }
 
       await this.policy.afterIteration?.(state);
@@ -137,6 +189,7 @@ export class TurnKernel {
       iterations: state.iterationCount,
       emptyResponseCount: state.emptyResponseCount,
       stopReason,
+      loopBudgetStopReason,
     };
   }
 }

--- a/src/electron/managed/__tests__/ManagedSessionService.helpers.test.ts
+++ b/src/electron/managed/__tests__/ManagedSessionService.helpers.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+  };
+});
+
 import { MCPSettingsManager } from "../../mcp/settings";
 import {
   resolveManagedAllowedMcpTools,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2370,15 +2370,7 @@ export interface Task {
   coreOutcome?: "ok" | "partial" | "failed";
   dependencyOutcome?: "healthy" | "degraded" | "down";
   failureDomains?: string[];
-  stopReasons?: Array<
-    | "completed"
-    | "max_turns"
-    | "tool_error"
-    | "contract_block"
-    | "verification_block"
-    | "awaiting_user_input"
-    | "dependency_unavailable"
-  >;
+  stopReasons?: TaskStopReason[];
   riskLevel?: TaskRiskLevel;
   evalCaseId?: string;
   evalRunId?: string;
@@ -2478,6 +2470,18 @@ export type StepFailureClass =
   | "provider_quota"
   | "user_blocker"
   | "unknown";
+
+export type TaskStopReason =
+  | "completed"
+  | "max_turns"
+  | "tool_error"
+  | "contract_block"
+  | "verification_block"
+  | "awaiting_user_input"
+  | "dependency_unavailable"
+  | "max_llm_calls"
+  | "max_recovered_responses"
+  | "max_repeated_iterations";
 
 // ============ Git Worktree Types ============
 

--- a/tests/tools/builtin-settings.test.ts
+++ b/tests/tools/builtin-settings.test.ts
@@ -455,10 +455,12 @@ describe('BuiltinToolsSettingsManager', () => {
       expect(defaults.categories.image.priority).toBe('normal');
     });
 
-    it('should have empty tool overrides by default', () => {
+    it('should keep x_search disabled by default for opt-in', () => {
       const defaults = BuiltinToolsSettingsManager.getDefaultSettings();
 
-      expect(defaults.toolOverrides).toEqual({});
+      expect(defaults.toolOverrides).toEqual({
+        x_search: { enabled: false },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add explicit step loop budgets for total LLM calls, recovered responses, and repeated iterations.
- Surface precise loop-budget stop reasons through executor failure state and telemetry.
- Prevent recovery paths from masking loop-budget stops.

## Validation
- npx vitest run src/electron/agent/runtime/__tests__/turn-kernel.test.ts src/electron/agent/__tests__/executor-entrypoints.test.ts
- npm run type-check
- git diff --check

AI assisted