### PR TITLE
Preserve explicit agent terminal states

### DIFF
--- a/src/electron/agent/__tests__/daemon-complete-task.test.ts
+++ b/src/electron/agent/__tests__/daemon-complete-task.test.ts
@@ -649,6 +649,92 @@ describe("AgentDaemon.completeTask", () => {
     );
   });
 
+  it("does not downgrade explicit failed terminal metadata when completion gates fail", () => {
+    const daemonLike = createDaemonLike();
+    daemonLike.taskRepo.findById.mockReturnValue({
+      id: "task-1",
+      title: "Task 1",
+      prompt: "Verify required output evidence",
+      status: "executing",
+      workspaceId: "workspace-1",
+      parentTaskId: "parent-task",
+      agentType: "sub",
+      agentConfig: {
+        reviewPolicy: "strict",
+      },
+    });
+    daemonLike.getUnresolvedFailedSteps.mockReturnValue([]);
+    daemonLike.runQuickQualityPass.mockReturnValue({
+      passed: false,
+      issues: ["strict_mode_requires_more_complete_summary"],
+    });
+    daemonLike.hasEvidenceForKeyClaims.mockReturnValue({
+      passed: false,
+      keyClaims: ["The required verification passed."],
+    });
+
+    AgentDaemon.prototype.completeTask.call(daemonLike, "task-1", "Cannot verify required evidence.", {
+      terminalStatus: "failed",
+      terminalKind: "failed",
+      failureClass: "required_verification",
+      failedStepIds: ["step:verify"],
+      terminalStatusReason: "Task missing required verification evidence.",
+      outputSummary: {
+        outputCount: 1,
+        textOutputCount: 1,
+      },
+    });
+
+    expect(daemonLike.taskRepo.update).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "failed",
+        terminalStatus: "failed",
+        failureClass: "required_verification",
+      }),
+    );
+    expect(daemonLike.taskRepo.update).not.toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "completed",
+        terminalStatus: "partial_success",
+        failureClass: "contract_error",
+      }),
+    );
+    const terminalPayload = (daemonLike.logEvent as Any).mock.calls.find(
+      (call: unknown[]) => call[1] === "task_status",
+    )?.[2];
+    expect(terminalPayload).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        terminalStatus: "failed",
+        terminalKind: "failed",
+        failureClass: "required_verification",
+        failedStepIds: ["step:verify"],
+      }),
+    );
+  });
+
+  it("treats terminalKind failed as an explicit failed terminal outcome", () => {
+    const daemonLike = createDaemonLike();
+    daemonLike.getUnresolvedFailedSteps.mockReturnValue([]);
+
+    AgentDaemon.prototype.completeTask.call(daemonLike, "task-1", "Cannot verify required evidence.", {
+      terminalStatus: "ok",
+      terminalKind: "failed",
+      failureClass: "required_verification",
+    });
+
+    expect(daemonLike.taskRepo.update).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "failed",
+        terminalStatus: "failed",
+        failureClass: "required_verification",
+      }),
+    );
+  });
+
   it("keeps timeline_error step IDs out of unresolved plan-step gate", () => {
     const daemonLike = createDaemonLike();
     daemonLike.getUnresolvedFailedSteps.mockReturnValue([]);

--- a/src/electron/agent/__tests__/daemon-complete-task.test.ts
+++ b/src/electron/agent/__tests__/daemon-complete-task.test.ts
@@ -4,6 +4,12 @@ import { AgentDaemon } from "../daemon";
 import type { TaskOutputSummary } from "../../../shared/types";
 import { PersonalityManager } from "../../settings/personality-manager";
 
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue("/tmp"),
+  },
+}));
+
 vi.spyOn(PersonalityManager, "recordTaskCompleted").mockImplementation(() => {});
 
 function createDaemonLike() {
@@ -595,6 +601,51 @@ describe("AgentDaemon.completeTask", () => {
     expect(daemonLike.taskRepo.update).not.toHaveBeenCalledWith(
       "task-1",
       expect.objectContaining({ status: "failed" }),
+    );
+  });
+
+  it("preserves explicit failed terminal metadata from executor finalization", () => {
+    const daemonLike = createDaemonLike();
+    daemonLike.getUnresolvedFailedSteps.mockReturnValue([]);
+
+    AgentDaemon.prototype.completeTask.call(daemonLike, "task-1", "Cannot verify required evidence.", {
+      terminalStatus: "failed",
+      terminalKind: "failed",
+      failureClass: "required_verification",
+      failedStepIds: ["step:verify"],
+      terminalStatusReason: "Task missing required verification evidence.",
+      outputSummary: {
+        outputCount: 1,
+        textOutputCount: 1,
+      },
+    });
+
+    expect(daemonLike.taskRepo.update).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "failed",
+        terminalStatus: "failed",
+        failureClass: "required_verification",
+      }),
+    );
+    expect(daemonLike.taskRepo.update).not.toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "completed",
+        terminalStatus: "ok",
+      }),
+    );
+    const terminalPayload = (daemonLike.logEvent as Any).mock.calls.find(
+      (call: unknown[]) => call[1] === "task_status",
+    )?.[2];
+    expect(terminalPayload).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        terminalStatus: "failed",
+        terminalKind: "failed",
+        failureClass: "required_verification",
+        failedStepIds: ["step:verify"],
+      }),
     );
   });
 

--- a/src/electron/agent/__tests__/daemon-complete-task.test.ts
+++ b/src/electron/agent/__tests__/daemon-complete-task.test.ts
@@ -645,6 +645,7 @@ describe("AgentDaemon.completeTask", () => {
         terminalKind: "failed",
         failureClass: "required_verification",
         failedStepIds: ["step:verify"],
+        message: "Task failed",
       }),
     );
   });
@@ -711,6 +712,7 @@ describe("AgentDaemon.completeTask", () => {
         terminalKind: "failed",
         failureClass: "required_verification",
         failedStepIds: ["step:verify"],
+        message: "Task failed",
       }),
     );
   });
@@ -732,6 +734,89 @@ describe("AgentDaemon.completeTask", () => {
         terminalStatus: "failed",
         failureClass: "required_verification",
       }),
+    );
+    const terminalPayload = (daemonLike.logEvent as Any).mock.calls.find(
+      (call: unknown[]) => call[1] === "task_status",
+    )?.[2];
+    expect(terminalPayload).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        terminalStatus: "failed",
+        message: "Task failed",
+      }),
+    );
+  });
+
+  it("does not run completion-only side effects for explicit failed terminal outcomes", async () => {
+    const daemonLike = createDaemonLike();
+    const onTaskCompleted = vi.fn().mockResolvedValue(undefined);
+    daemonLike.comparisonService = { onTaskCompleted };
+    daemonLike.taskRepo.findById.mockReturnValue({
+      id: "task-1",
+      title: "Task 1",
+      prompt: "Run tests, edit files, deploy production changes, verify security, and publish release",
+      status: "executing",
+      workspaceId: "workspace-1",
+      agentType: "main",
+      worktreeStatus: "active",
+      worktreePath: "/tmp/task-1",
+      comparisonSessionId: "comparison-1",
+      agentConfig: {
+        reviewPolicy: "strict",
+        entropySweepPolicy: "strict",
+      },
+    });
+    daemonLike.worktreeManager.getSettings.mockReturnValue({
+      autoCommitOnComplete: true,
+      commitMessagePrefix: "task: ",
+    });
+    daemonLike.getUnresolvedFailedSteps.mockReturnValue([]);
+    daemonLike.eventRepo.findByTaskId.mockReturnValue([
+      {
+        id: "e1",
+        taskId: "task-1",
+        timestamp: Date.now(),
+        type: "tool_call",
+        payload: { tool: "run_command", input: { command: "npm test" } },
+      },
+    ]);
+
+    AgentDaemon.prototype.completeTask.call(daemonLike, "task-1", "Cannot verify required evidence.", {
+      terminalStatus: "failed",
+      terminalKind: "failed",
+      failureClass: "required_verification",
+      failedStepIds: ["step:verify"],
+      outputSummary: {
+        outputCount: 1,
+        textOutputCount: 1,
+        created: ["artifacts/report.md"],
+        primaryOutputPath: "artifacts/report.md",
+      },
+    });
+    await Promise.resolve();
+
+    expect(daemonLike.taskRepo.update).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "failed",
+        terminalStatus: "failed",
+        failureClass: "required_verification",
+      }),
+    );
+    expect(daemonLike.runPostCompletionVerification).not.toHaveBeenCalled();
+    expect(daemonLike.runPostTaskEntropySweep).not.toHaveBeenCalled();
+    expect(daemonLike.worktreeManager.commitTaskChanges).not.toHaveBeenCalled();
+    expect(onTaskCompleted).not.toHaveBeenCalled();
+    expect(PersonalityManager.recordTaskCompleted).not.toHaveBeenCalled();
+    expect(daemonLike.logEvent).not.toHaveBeenCalledWith(
+      "task-1",
+      "verification_started",
+      expect.anything(),
+    );
+    expect(daemonLike.logEvent).not.toHaveBeenCalledWith(
+      "task-1",
+      "entropy_sweep_started",
+      expect.anything(),
     );
   });
 

--- a/src/electron/agent/__tests__/executor-finalization-state.test.ts
+++ b/src/electron/agent/__tests__/executor-finalization-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { TaskExecutor } from "../executor";
+import { decideTaskOutcome } from "../outcome-policy";
 import { createTerminalState } from "../runtime/TerminalState";
 
 vi.mock("electron", () => ({
@@ -90,6 +91,25 @@ function createExecutorForFinalization(overrides: Partial<Any> = {}): Any {
 }
 
 describe("TaskExecutor terminal finalization state", () => {
+  it("preserves explicit failed terminal status through completed daemon outcome normalization", () => {
+    const outcome = decideTaskOutcome({
+      requestedStatus: "completed",
+      terminalStatus: "failed",
+      failureClass: "required_verification",
+      resultSummary: "Cannot verify required evidence.",
+      outputSummary: {
+        outputCount: 1,
+        textOutputCount: 1,
+      },
+    });
+
+    expect(outcome).toEqual({
+      status: "failed",
+      terminalStatus: "failed",
+      failureClass: "required_verification",
+    });
+  });
+
   it("maps soft timeout to partial timed_out terminal state instead of ordinary ok completion", () => {
     const executor = createExecutorForFinalization({
       softDeadlineTriggered: true,

--- a/src/electron/agent/__tests__/executor-finalization-state.test.ts
+++ b/src/electron/agent/__tests__/executor-finalization-state.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi } from "vitest";
+import { TaskExecutor } from "../executor";
+import { createTerminalState } from "../runtime/TerminalState";
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue("/tmp"),
+  },
+}));
+
+function createExecutorForFinalization(overrides: Partial<Any> = {}): Any {
+  const executor = Object.create(TaskExecutor.prototype) as Any;
+  executor.task = {
+    id: "task-terminal-state",
+    title: "Terminal state task",
+    prompt: "Do the work",
+    status: "executing",
+    createdAt: Date.now(),
+    agentConfig: { executionMode: "execute" },
+  };
+  executor.daemon = { completeTask: vi.fn(), updateTask: vi.fn() };
+  executor.plan = {
+    description: "Plan",
+    steps: [
+      {
+        id: "step-1",
+        description: "Collect evidence",
+        status: "failed",
+        error: "Step soft-deadline reached after 54s",
+        completedAt: Date.now(),
+        kind: "primary",
+      },
+      {
+        id: "step-2",
+        description: "Finish remaining work",
+        status: "pending",
+        kind: "primary",
+      },
+    ],
+  };
+  executor.verificationOutcomeV2Enabled = false;
+  executor.softDeadlineTriggered = false;
+  executor.wrapUpRequested = false;
+  executor.terminalStatus = "ok";
+  executor.failureClass = undefined;
+  executor.taskFailureDomains = new Set();
+  executor.stepStopReasons = new Set();
+  executor.stopProgressJournal = vi.fn();
+  executor.saveConversationSnapshot = vi.fn();
+  executor.endDebugRuntimeSessionIfNeeded = vi.fn();
+  executor.getWaivableFailedStepIdsAtCompletion = vi.fn().mockReturnValue([]);
+  executor.getNonBlockingFailedStepIdsAtCompletion = vi.fn().mockReturnValue([]);
+  executor.getFailedMutationRequiredStepIdsAtCompletion = vi.fn().mockReturnValue([]);
+  executor.getVerificationStepIds = vi.fn().mockReturnValue([]);
+  executor.applyRuntimeTaskProjectionToTask = vi.fn().mockReturnValue({});
+  executor.applyVerificationOutcomeToTerminalStatus = vi
+    .fn()
+    .mockImplementation((terminalStatus: string, failureClass?: string) => ({
+      terminalStatus,
+      failureClass,
+    }));
+  executor.computeReliabilityOutcomes = vi.fn().mockImplementation((terminalStatus: string) => ({
+    coreOutcome: terminalStatus === "failed" ? "failed" : terminalStatus === "ok" ? "ok" : "partial",
+    dependencyOutcome: "healthy",
+    failureDomains: [],
+    stopReasons: [],
+  }));
+  executor.buildTaskOutputSummary = vi.fn().mockReturnValue({
+    outputCount: 1,
+    textOutputCount: 1,
+  });
+  executor.persistBestKnownOutcome = vi.fn();
+  executor.applyGoalTerminalState = vi.fn().mockReturnValue(undefined);
+  executor.emitEvent = vi.fn();
+  executor.emitRunSummary = vi.fn();
+  executor.closeAcpxRuntimeSession = vi.fn().mockResolvedValue(undefined);
+  executor.getCompletionProjectionFields = vi.fn().mockReturnValue({});
+  executor.getVerificationState = vi.fn().mockReturnValue({ verificationEvidenceEntries: [] });
+  executor.buildResultSummary = vi.fn().mockReturnValue("Partial result gathered before stop.");
+  executor.getContentFallback = vi.fn().mockReturnValue("");
+  executor.hasSubstantivePartialSuccessEvidence = vi.fn().mockReturnValue(true);
+  executor.classifyFailure = vi.fn().mockReturnValue("contract_error");
+  executor.isBudgetExhaustionError = vi.fn().mockReturnValue(false);
+  executor.isSourceValidationGuardError = vi.fn().mockReturnValue(false);
+  executor.emitRunSummary = vi.fn();
+  executor.capturePlaybookOutcome = vi.fn();
+  executor.autoGenerateReport = vi.fn().mockResolvedValue(undefined);
+
+  return Object.assign(executor, overrides);
+}
+
+describe("TaskExecutor terminal finalization state", () => {
+  it("maps soft timeout to partial timed_out terminal state instead of ordinary ok completion", () => {
+    const executor = createExecutorForFinalization({
+      softDeadlineTriggered: true,
+      stepStopReasons: new Set(["max_turns"]),
+    });
+    const terminalState = createTerminalState("timed_out", {
+      reason: "Soft deadline reached during execution. Finalizing with best-effort answer.",
+      failedStepIds: ["step-1"],
+    });
+
+    (TaskExecutor as Any).prototype.finalizeTaskBestEffort.call(
+      executor,
+      "Partial result gathered before stop.",
+      terminalState.reason,
+      terminalState,
+    );
+
+    expect(executor.task.terminalStatus).toBe("partial_success");
+    expect(executor.task.failureClass).toBe("budget_exhausted");
+    expect(executor.task.coreOutcome).toBe("partial");
+    expect(executor.daemon.completeTask).toHaveBeenCalledWith(
+      "task-terminal-state",
+      "Partial result gathered before stop.",
+      expect.objectContaining({
+        terminalStatus: "partial_success",
+        failureClass: "budget_exhausted",
+        terminalKind: "timed_out",
+        terminalStatusReason:
+          "Soft deadline reached during execution. Finalizing with best-effort answer.",
+        failedStepIds: ["step-1"],
+      }),
+    );
+  });
+
+  it("maps user input pause to needs_user_action terminal state", () => {
+    const executor = createExecutorForFinalization();
+    const terminalState = createTerminalState("needs_user_action", {
+      reason: "Task paused pending user approval or input.",
+    });
+
+    (TaskExecutor as Any).prototype.finalizeTaskBestEffort.call(
+      executor,
+      "Current answer is blocked on approval.",
+      terminalState.reason,
+      terminalState,
+    );
+
+    expect(executor.task.terminalStatus).toBe("needs_user_action");
+    expect(executor.task.failureClass).toBeUndefined();
+    expect(executor.daemon.completeTask).toHaveBeenCalledWith(
+      "task-terminal-state",
+      "Current answer is blocked on approval.",
+      expect.objectContaining({
+        terminalKind: "needs_user_action",
+        terminalStatus: "needs_user_action",
+        failureClass: undefined,
+      }),
+    );
+  });
+
+  it("maps failed required evidence to failed rather than best-effort completed", () => {
+    const executor = createExecutorForFinalization();
+    const terminalState = createTerminalState("failed", {
+      reason: "Task missing required verification evidence.",
+      failureClass: "required_verification",
+      failedStepIds: ["step-1"],
+    });
+
+    (TaskExecutor as Any).prototype.finalizeTaskBestEffort.call(
+      executor,
+      "Cannot verify required evidence.",
+      terminalState.reason,
+      terminalState,
+    );
+
+    expect(executor.task.terminalStatus).toBe("failed");
+    expect(executor.task.failureClass).toBe("required_verification");
+    expect(executor.daemon.completeTask).toHaveBeenCalledWith(
+      "task-terminal-state",
+      "Cannot verify required evidence.",
+      expect.objectContaining({
+        terminalKind: "failed",
+        terminalStatus: "failed",
+        failureClass: "required_verification",
+        failedStepIds: ["step-1"],
+      }),
+    );
+  });
+
+  it.todo(
+    "covers ACP external completion once an executor-local ACP completion harness exists; current ACP tests exercise runtime routing, not finalizer projection.",
+  );
+
+  it.todo(
+    "covers deterministic handled completion once deterministic slash-command finalization is exposed without running full execute().",
+  );
+});

--- a/src/electron/agent/daemon.ts
+++ b/src/electron/agent/daemon.ts
@@ -7845,6 +7845,10 @@ export class AgentDaemon extends EventEmitter {
 
     let terminalStatus: NonNullable<Task["terminalStatus"]> = metadata?.terminalStatus || "ok";
     let failureClass: Task["failureClass"] | undefined = metadata?.failureClass || undefined;
+    if (metadata?.terminalKind === "failed" && terminalStatus !== "failed") {
+      terminalStatus = "failed";
+    }
+    const explicitFailedTerminalStatus = terminalStatus === "failed";
     if (this.verificationOutcomeV2Enabled && metadata?.verificationOutcome === "pending_user_action") {
       if (terminalStatus === "ok") {
         terminalStatus = "needs_user_action";
@@ -7874,8 +7878,12 @@ export class AgentDaemon extends EventEmitter {
         verificationEvidenceBundle: metadata?.verificationEvidenceBundle,
       });
       if (!quality.passed && reviewDecision.strictCompletionContract) {
-        terminalStatus = "partial_success";
-        failureClass = "contract_error";
+        if (!explicitFailedTerminalStatus) {
+          terminalStatus = "partial_success";
+          failureClass = "contract_error";
+        } else if (!failureClass) {
+          failureClass = "unknown";
+        }
       }
     }
 
@@ -7886,8 +7894,12 @@ export class AgentDaemon extends EventEmitter {
     );
     if (!evidenceCheck.passed) {
       this.timelineMetrics.evidenceGateFails += 1;
-      terminalStatus = "partial_success";
-      failureClass = "contract_error";
+      if (!explicitFailedTerminalStatus) {
+        terminalStatus = "partial_success";
+        failureClass = "contract_error";
+      } else if (!failureClass) {
+        failureClass = "unknown";
+      }
       this.logEvent(taskId, "timeline_step_updated", {
         stepId: "evidence_gate:key_claims",
         status: "blocked",

--- a/src/electron/agent/daemon.ts
+++ b/src/electron/agent/daemon.ts
@@ -7944,6 +7944,7 @@ export class AgentDaemon extends EventEmitter {
       ...this.computeTimelineTelemetryFromEvents(this.getTaskEventsForReplay(taskId)),
       telemetry_source: "runtime_v2",
     };
+    const isCompletedOutcome = resolvedOutcome.status === "completed";
 
     const updates: Partial<Task> = {
       status: resolvedOutcome.status,
@@ -7982,13 +7983,16 @@ export class AgentDaemon extends EventEmitter {
         : terminalStatus === "partial_success"
           ? "Task completed with partial results"
           : "Task completed successfully";
-    this.logEvent(taskId, resolvedOutcome.status === "completed" ? "task_completed" : "task_status", {
-      message:
-        resolvedOutcome.status === "completed"
-          ? completionMessage
+    const terminalStatusMessage =
+      resolvedOutcome.status === "completed"
+        ? completionMessage
+        : resolvedOutcome.status === "failed"
+          ? "Task failed"
           : resolvedOutcome.status === "interrupted"
             ? "Task interrupted - resume available"
-            : "Task is waiting for approval or further input",
+            : "Task is waiting for approval or further input";
+    this.logEvent(taskId, isCompletedOutcome ? "task_completed" : "task_status", {
+      message: terminalStatusMessage,
       ...(updates.resultSummary ? { resultSummary: updates.resultSummary } : {}),
       ...(resolvedOutcome.status !== "completed" ? { status: resolvedOutcome.status } : {}),
       terminalStatus,
@@ -8040,7 +8044,7 @@ export class AgentDaemon extends EventEmitter {
       telemetry: completionTelemetry,
     });
 
-    if (this.activeTimelineStageByTask.get(taskId) === "DELIVER") {
+    if (isCompletedOutcome && this.activeTimelineStageByTask.get(taskId) === "DELIVER") {
       const timeline = createTimelineEmitter(taskId, (eventType, payload) => {
         this.logEvent(taskId, eventType, payload);
       });
@@ -8060,7 +8064,7 @@ export class AgentDaemon extends EventEmitter {
       });
     }
 
-    if (reviewDecision.runVerificationAgent) {
+    if (isCompletedOutcome && reviewDecision.runVerificationAgent) {
       this.logEvent(taskId, "verification_started", {
         source: "post_completion_review_gate",
         policy: reviewPolicy,
@@ -8086,7 +8090,7 @@ export class AgentDaemon extends EventEmitter {
         inferMutationFromSummary(metadata?.outputSummary) || risk.signals.changedFileCount > 0,
       deepWorkMode: existingTask.agentConfig?.deepWorkMode === true,
     });
-    if (entropyDecision.runEntropySweep) {
+    if (isCompletedOutcome && entropyDecision.runEntropySweep) {
       this.logEvent(taskId, "entropy_sweep_started", {
         source: "post_completion_entropy_sweep",
         policy: entropyPolicy,
@@ -8103,7 +8107,7 @@ export class AgentDaemon extends EventEmitter {
 
     // === WORKTREE AUTO-COMMIT ===
     // If the task has an active worktree, auto-commit changes on completion.
-    if (existingTask?.worktreeStatus === "active" && existingTask.worktreePath) {
+    if (isCompletedOutcome && existingTask?.worktreeStatus === "active" && existingTask.worktreePath) {
       const worktreeSettings = this.worktreeManager.getSettings();
       if (worktreeSettings.autoCommitOnComplete) {
         void (async () => {
@@ -8135,7 +8139,7 @@ export class AgentDaemon extends EventEmitter {
     // Notify the comparison service when a task in a comparison session completes.
     // This must be outside the auto-commit block so it fires regardless of worktree settings.
     const comparisonSvc = this.comparisonService;
-    if (existingTask?.comparisonSessionId && comparisonSvc) {
+    if (isCompletedOutcome && existingTask?.comparisonSessionId && comparisonSvc) {
       void (async () => {
         try {
           await comparisonSvc.onTaskCompleted(taskId);
@@ -8148,7 +8152,7 @@ export class AgentDaemon extends EventEmitter {
     try {
       const isTopLevelTask =
         existingTask && !existingTask.parentTaskId && (existingTask.agentType ?? "main") === "main";
-      if (isTopLevelTask) {
+      if (isCompletedOutcome && isTopLevelTask) {
         const workspaceName = this.workspaceRepo.findById(existingTask.workspaceId)?.name;
         PersonalityManager.recordTaskCompleted(workspaceName);
         const gatewayContext = existingTask.agentConfig?.gatewayContext ?? "private";

--- a/src/electron/agent/daemon.ts
+++ b/src/electron/agent/daemon.ts
@@ -96,6 +96,7 @@ import { deriveCanonicalTaskStatus, isTerminalTaskStatus } from "../../shared/ta
 import { createTimelineEmitter } from "./timeline-emitter";
 import { TaskExecutor } from "./executor";
 import { TaskQueueManager } from "./queue-manager";
+import type { TerminalKind } from "./runtime/TerminalState";
 import { BuiltinToolsSettingsManager } from "./tools/builtin-settings";
 import { loadPolicies } from "../admin/policies";
 import { ComputerUseSessionManager } from "../computer-use/session-manager";
@@ -7304,6 +7305,9 @@ export class AgentDaemon extends EventEmitter {
       waiveFailedStepIds?: string[];
       failedMutationRequiredStepIds?: string[];
       waivedVerificationStepIds?: string[];
+      failedStepIds?: string[];
+      incompleteStepIds?: string[];
+      terminalKind?: TerminalKind;
       terminalStatusReason?: string;
       nonBlockingFailedStepIds?: string[];
       bestKnownOutcome?: Task["bestKnownOutcome"];
@@ -7737,7 +7741,8 @@ export class AgentDaemon extends EventEmitter {
     ];
     const terminalStatusReason = metadata?.terminalStatusReason ?? "";
     const isBestEffortFinalization =
-      bestEffortReasons.some((r) => terminalStatusReason.includes(r)) &&
+      (metadata?.terminalKind === "timed_out" ||
+        bestEffortReasons.some((r) => terminalStatusReason.includes(r))) &&
       (metadata?.terminalStatus === "ok" || metadata?.terminalStatus === "partial_success");
     if (isBestEffortFinalization && blockingFailedSteps.length > 0) {
       const nonMutationBlockers = blockingFailedSteps.filter((id) => {
@@ -8002,6 +8007,13 @@ export class AgentDaemon extends EventEmitter {
       ...(Array.isArray(metadata?.waivedVerificationStepIds) &&
       metadata.waivedVerificationStepIds.length > 0
         ? { waivedVerificationStepIds: metadata.waivedVerificationStepIds }
+        : {}),
+      ...(metadata?.terminalKind ? { terminalKind: metadata.terminalKind } : {}),
+      ...(Array.isArray(metadata?.failedStepIds) && metadata.failedStepIds.length > 0
+        ? { failedStepIds: metadata.failedStepIds }
+        : {}),
+      ...(Array.isArray(metadata?.incompleteStepIds) && metadata.incompleteStepIds.length > 0
+        ? { incompleteStepIds: metadata.incompleteStepIds }
         : {}),
       ...(metadata?.terminalStatusReason ? { terminalStatusReason: metadata.terminalStatusReason } : {}),
       ...(timelineErrorStepIds.length > 0 ? { timelineErrorStepIds } : {}),

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -92,6 +92,7 @@ import {
   type SessionRuntimeTaskProjection,
 } from "./runtime/SessionRuntime";
 import { defaultStepLoopBudget, type LoopBudgetStopReason } from "./runtime/LoopBudgetPolicy";
+import { createTerminalState, type TerminalState } from "./runtime/TerminalState";
 import type {
   TurnKernelIterationState,
   TurnKernelPolicy,
@@ -8040,10 +8041,10 @@ ${transcript}
       "Task is waiting for your approval or input before it can continue.";
     this.terminalStatus = "needs_user_action";
     this.failureClass = undefined;
-    this.finalizeTaskBestEffort(summary, "Task paused pending user approval or input.", {
-      terminalStatus: "needs_user_action",
-      failureClass: undefined,
+    const terminalState = createTerminalState("needs_user_action", {
+      reason: "Task paused pending user approval or input.",
     });
+    this.finalizeTaskBestEffort(summary, terminalState.reason, terminalState);
     return true;
   }
 
@@ -8061,10 +8062,11 @@ ${transcript}
         this.emitEvent("log", { metric: "agent_turn_limit_exceeded_total", value: 1 });
       }
     }
-    this.finalizeTaskBestEffort(partialText, this.getPartialSuccessReason(error), {
-      terminalStatus: "partial_success",
+    const terminalState = createTerminalState("partial_success", {
+      reason: this.getPartialSuccessReason(error),
       failureClass,
     });
+    this.finalizeTaskBestEffort(partialText, terminalState.reason, terminalState);
     return true;
   }
 
@@ -8076,6 +8078,22 @@ ${transcript}
       if (this.maybeFinalizeAsPartialSuccess(error)) return;
       throw error;
     }
+  }
+
+  private buildTerminalStepState(): Pick<TerminalState, "failedStepIds" | "incompleteStepIds"> {
+    const steps = this.plan?.steps || [];
+    const failedStepIds = steps
+      .filter((step) => step.status === "failed")
+      .map((step) => String(step.id || "").trim())
+      .filter(Boolean);
+    const incompleteStepIds = steps
+      .filter((step) => step.status === "pending" || step.status === "in_progress")
+      .map((step) => String(step.id || "").trim())
+      .filter(Boolean);
+    return {
+      ...(failedStepIds.length > 0 ? { failedStepIds } : {}),
+      ...(incompleteStepIds.length > 0 ? { incompleteStepIds } : {}),
+    };
   }
 
   private classifyFailure(error: unknown): NonNullable<Task["failureClass"]> {
@@ -11798,7 +11816,7 @@ ${transcript}
     metadata?: {
       terminalStatus?: Task["terminalStatus"];
       failureClass?: Task["failureClass"];
-    },
+    } & Partial<TerminalState>,
   ): void {
     if (this.getEffectiveExecutionMode() === "chat") {
       this.finalizeChatTurn(reason);
@@ -11825,6 +11843,15 @@ ${transcript}
         : this.resolveWaiverFailureClass(waivableFailedStepIds) || "contract_error";
     const implicitExecutorStatus =
       this.terminalStatus && this.terminalStatus !== "ok" ? this.terminalStatus : undefined;
+    const explicitTerminalState = metadata?.terminalKind
+      ? createTerminalState(metadata.terminalKind, {
+          terminalStatus: metadata.terminalStatus,
+          failureClass: metadata.failureClass,
+          reason: metadata.reason || reason,
+          failedStepIds: metadata.failedStepIds,
+          incompleteStepIds: metadata.incompleteStepIds,
+        })
+      : undefined;
     let computedTerminalStatus: NonNullable<Task["terminalStatus"]> =
       metadata?.terminalStatus || implicitExecutorStatus || fallbackTerminalStatus;
     let computedFailureClass: Task["failureClass"] | undefined =
@@ -11835,9 +11862,14 @@ ${transcript}
         : fallbackFailureClass || "contract_error");
     const runtimeProjection = this.applyRuntimeTaskProjectionToTask();
     const hasExplicitBestEffortOutcome =
+      explicitTerminalState !== undefined ||
       metadata?.terminalStatus !== undefined ||
       metadata?.failureClass !== undefined ||
       implicitExecutorStatus !== undefined;
+    if (explicitTerminalState) {
+      computedTerminalStatus = explicitTerminalState.terminalStatus;
+      computedFailureClass = explicitTerminalState.failureClass;
+    }
     if (!hasExplicitBestEffortOutcome) {
       const statusWithVerification = this.applyVerificationOutcomeToTerminalStatus(
         computedTerminalStatus,
@@ -11873,9 +11905,35 @@ ${transcript}
     if (reason) {
       this.emitEvent("log", { message: reason });
     }
+    if (explicitTerminalState?.terminalKind === "timed_out") {
+      const completedSteps = this.plan?.steps?.filter((step) => step.status === "completed").length || 0;
+      const totalSteps = this.plan?.steps?.length || 0;
+      this.emitEvent("progress_update", {
+        phase: "execution",
+        completedSteps,
+        totalSteps,
+        progress: totalSteps > 0 ? Math.min(99, Math.round((completedSteps / totalSteps) * 100)) : 0,
+        message: "Stopped at soft deadline; finalized with partial results.",
+        terminalKind: explicitTerminalState.terminalKind,
+        terminalStatus: this.task.terminalStatus,
+        incompleteStepIds: explicitTerminalState.incompleteStepIds,
+        failedStepIds: explicitTerminalState.failedStepIds,
+      });
+    }
     this.daemon.completeTask(this.task.id, summary, {
       terminalStatus: this.task.terminalStatus,
       failureClass: this.task.failureClass,
+      ...(explicitTerminalState
+        ? {
+            terminalKind: explicitTerminalState.terminalKind,
+            ...(explicitTerminalState.failedStepIds
+              ? { failedStepIds: explicitTerminalState.failedStepIds }
+              : {}),
+            ...(explicitTerminalState.incompleteStepIds
+              ? { incompleteStepIds: explicitTerminalState.incompleteStepIds }
+              : {}),
+          }
+        : {}),
       ...(goalAgentConfig ? { agentConfig: goalAgentConfig } : {}),
       ...runtimeProjection,
       outputSummary,
@@ -11883,7 +11941,7 @@ ${transcript}
       waiveFailedStepIds: waivableFailedStepIds,
       failedMutationRequiredStepIds,
       waivedVerificationStepIds,
-      terminalStatusReason: reason || "executor_best_effort_finalized",
+      terminalStatusReason: explicitTerminalState?.reason || reason || "executor_best_effort_finalized",
       ...(this.verificationOutcomeV2Enabled && nonBlockingFailedStepIds.length > 0
         ? { nonBlockingFailedStepIds }
         : {}),
@@ -22003,15 +22061,12 @@ You are continuing a previous conversation. The context from the previous conver
     this.lastAssistantOutput = finalText;
     this.lastNonVerificationOutput = finalText;
     this.lastAssistantText = finalText;
-    try {
-      this.finalizeTask(finalText);
-    } catch (guardError) {
-      logger.warn(
-        `${this.logTag} Timeout recovery guard blocked strict completion, using best-effort finalization:`,
-        guardError,
-      );
-      this.finalizeTaskBestEffort(finalText, "Timeout recovery finalized with best-effort answer.");
-    }
+    const terminalState = createTerminalState("timed_out", {
+      reason: "Timeout recovery finalized with best-effort answer.",
+      failureClass: "budget_exhausted",
+      ...this.buildTerminalStepState(),
+    });
+    this.finalizeTaskBestEffort(finalText, terminalState.reason, terminalState);
     return true;
   }
 
@@ -22653,7 +22708,15 @@ You are continuing a previous conversation. The context from the previous conver
         const reason = this.wrapUpRequested
           ? "Wrap-up requested. Finalizing with best-effort answer."
           : "Soft deadline reached during execution. Finalizing with best-effort answer.";
-        this.finalizeTaskBestEffort(this.buildResultSummary(), reason);
+        const terminalState = createTerminalState(
+          this.softDeadlineTriggered && !this.wrapUpRequested ? "timed_out" : "partial_success",
+          {
+            reason,
+            failureClass: this.softDeadlineTriggered && !this.wrapUpRequested ? "budget_exhausted" : "contract_error",
+            ...this.buildTerminalStepState(),
+          },
+        );
+        this.finalizeTaskBestEffort(this.buildResultSummary(), terminalState.reason, terminalState);
       } else {
         this.finalizeTaskWithFallback(this.buildResultSummary());
       }
@@ -22669,6 +22732,11 @@ You are continuing a previous conversation. The context from the previous conver
         this.finalizeTaskBestEffort(
           this.buildResultSummary() || "Task wrapped up before producing results.",
           "Wrap-up requested by user.",
+          createTerminalState("partial_success", {
+            reason: "Wrap-up requested by user.",
+            failureClass: "contract_error",
+            ...this.buildTerminalStepState(),
+          }),
         );
         return;
       }

--- a/src/electron/agent/outcome-policy.ts
+++ b/src/electron/agent/outcome-policy.ts
@@ -154,6 +154,13 @@ export function decideTaskOutcome(input: OutcomeDecisionInput): OutcomeDecision 
   }
 
   if (input.requestedStatus === "completed") {
+    if (requestedTerminalStatus === "failed") {
+      return {
+        status: "failed",
+        terminalStatus: "failed",
+        failureClass: failureClass || "unknown",
+      };
+    }
     if (requestedTerminalStatus === "partial_success") {
       return {
         status: "completed",

--- a/src/electron/agent/runtime/TerminalState.ts
+++ b/src/electron/agent/runtime/TerminalState.ts
@@ -1,0 +1,92 @@
+import type { Task } from "../../../shared/types";
+
+export type TerminalKind =
+  | "success"
+  | "partial_success"
+  | "timed_out"
+  | "needs_user_action"
+  | "cancelled"
+  | "external_completed"
+  | "deterministic_handled"
+  | "failed";
+
+export interface TerminalState {
+  terminalKind: TerminalKind;
+  terminalStatus: NonNullable<Task["terminalStatus"]>;
+  failureClass?: Task["failureClass"];
+  reason?: string;
+  failedStepIds?: string[];
+  incompleteStepIds?: string[];
+}
+
+export type TerminalStateInput = Partial<Omit<TerminalState, "terminalKind" | "terminalStatus">> & {
+  terminalStatus?: Task["terminalStatus"];
+};
+
+export function createTerminalState(
+  terminalKind: TerminalKind,
+  input: TerminalStateInput = {},
+): TerminalState {
+  const terminalStatus = resolveTerminalStatus(terminalKind, input.terminalStatus);
+  const failureClass = resolveFailureClass(terminalKind, terminalStatus, input.failureClass);
+  return {
+    terminalKind,
+    terminalStatus,
+    ...(failureClass ? { failureClass } : {}),
+    ...(input.reason ? { reason: input.reason } : {}),
+    ...(input.failedStepIds?.length ? { failedStepIds: input.failedStepIds } : {}),
+    ...(input.incompleteStepIds?.length ? { incompleteStepIds: input.incompleteStepIds } : {}),
+  };
+}
+
+export function projectTerminalState(
+  terminalState?: TerminalState,
+): Pick<TerminalState, "terminalKind" | "terminalStatus" | "failureClass"> | undefined {
+  if (!terminalState) return undefined;
+  return {
+    terminalKind: terminalState.terminalKind,
+    terminalStatus: terminalState.terminalStatus,
+    ...(terminalState.failureClass ? { failureClass: terminalState.failureClass } : {}),
+  };
+}
+
+function resolveTerminalStatus(
+  terminalKind: TerminalKind,
+  override?: Task["terminalStatus"],
+): NonNullable<Task["terminalStatus"]> {
+  if (override) return override;
+  switch (terminalKind) {
+    case "success":
+    case "external_completed":
+    case "deterministic_handled":
+      return "ok";
+    case "partial_success":
+    case "timed_out":
+    case "cancelled":
+      return "partial_success";
+    case "needs_user_action":
+      return "needs_user_action";
+    case "failed":
+      return "failed";
+  }
+}
+
+function resolveFailureClass(
+  terminalKind: TerminalKind,
+  terminalStatus: Task["terminalStatus"],
+  override?: Task["failureClass"],
+): Task["failureClass"] | undefined {
+  if (terminalStatus === "ok" || terminalStatus === "needs_user_action") return undefined;
+  if (override) return override;
+  switch (terminalKind) {
+    case "timed_out":
+    case "cancelled":
+      return "budget_exhausted";
+    case "failed":
+      return "unknown";
+    case "partial_success":
+      return "contract_error";
+    default:
+      return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce a normalized agent terminal-state helper for executor finalization.
- Preserve explicit failed terminal metadata through daemon completion handling.
- Keep quality and evidence gates from downgrading explicit failed terminal outcomes to partial success.

## Validation
- npx vitest run src/electron/agent/__tests__/executor-finalization-state.test.ts src/electron/agent/__tests__/daemon-complete-task.test.ts
- npm run type-check
- git diff --check

AI assisted