### PR TITLE
Preserve runtime approval metadata in tool policy

### DIFF
--- a/src/electron/agent/__tests__/tool-policy-pipeline.test.ts
+++ b/src/electron/agent/__tests__/tool-policy-pipeline.test.ts
@@ -9,6 +9,7 @@ vi.mock("../../security/monty-tool-policy", () => ({
 }));
 
 import { evaluateToolPolicyPipeline } from "../runtime/ToolPolicyPipeline";
+import { PermissionEngine } from "../runtime/PermissionEngine";
 
 describe("ToolPolicyPipeline", () => {
   const workspace = {
@@ -71,5 +72,162 @@ describe("ToolPolicyPipeline", () => {
     expect(result.decision).toBe("require_approval");
     expect(result.trace.finalDecision).toBe("require_approval");
     expect(result.trace.entries.some((entry) => entry.stage === "permissions")).toBe(true);
+  });
+
+  it("requires approval for runtime metadata approval when permissions are unavailable", async () => {
+    const result = await evaluateToolPolicyPipeline({
+      workspace,
+      toolName: "custom_sensitive_tool",
+      toolInput: { target: "external-system" },
+      approvalRequired: true,
+    });
+
+    expect(result.decision).toBe("require_approval");
+    expect(result.reason).toBe("approval required by runtime metadata");
+    expect(result.trace.finalDecision).toBe("require_approval");
+    expect(result.trace.entries).toContainEqual(
+      expect.objectContaining({
+        stage: "approval",
+        decision: "require_approval",
+        reason: "approval required by runtime metadata",
+      }),
+    );
+  });
+
+  it("preserves runtime data_export approval semantics for custom tools", async () => {
+    const permissionEvaluation = vi.fn(async (opts?: { approvalType?: string | null }) => ({
+      decision: opts?.approvalType === "data_export" ? ("ask" as const) : ("allow" as const),
+      reason:
+        opts?.approvalType === "data_export"
+          ? {
+              type: "mode" as const,
+              mode: "dont_ask",
+              summary: "Data export always requires an explicit prompt, even in bypass modes.",
+            }
+          : {
+              type: "mode" as const,
+              mode: "dont_ask",
+              summary: "Mode allows the action unless a higher-precedence hard policy blocks it.",
+            },
+      suggestions: [],
+      scopePreview: "custom_data_export_tool",
+    }));
+
+    const result = await evaluateToolPolicyPipeline({
+      workspace,
+      toolName: "custom_data_export_tool",
+      toolInput: { target: "external-system" },
+      approvalRequired: true,
+      runtimeApprovalType: "data_export",
+      permissionApprovalType: "data_export",
+      permissionEvaluation,
+    });
+
+    expect(result.decision).toBe("require_approval");
+    expect(result.reason).toBe(
+      "Data export always requires an explicit prompt, even in bypass modes.",
+    );
+    expect(result.trace.finalDecision).toBe("require_approval");
+    expect(permissionEvaluation).toHaveBeenCalledWith({ approvalType: "data_export" });
+  });
+
+  it("preserves destructive runtime approval semantics for custom tools", async () => {
+    const permissionEvaluation = vi.fn(async (opts?: { approvalType?: string | null }) =>
+      PermissionEngine.evaluate({
+        workspace,
+        toolName: "custom_destructive_tool",
+        toolInput: { target: "external-system" },
+        mode: "default",
+        rules: [],
+        approvalType: opts?.approvalType as Any,
+      }),
+    );
+
+    const result = await evaluateToolPolicyPipeline({
+      workspace,
+      toolName: "custom_destructive_tool",
+      toolInput: { target: "external-system" },
+      approvalRequired: true,
+      runtimeApprovalType: "delete_file",
+      permissionApprovalType: "delete_file",
+      permissionEvaluation,
+    });
+
+    expect(result.decision).toBe("require_approval");
+    expect(result.reason).toBe("Default mode prompts for writes, deletes, shell, and external effects.");
+    expect(result.trace.finalDecision).toBe("require_approval");
+    expect(result.trace.entries).toContainEqual(
+      expect.objectContaining({
+        stage: "permissions",
+        decision: "require_approval",
+        reason: "Default mode prompts for writes, deletes, shell, and external effects.",
+      }),
+    );
+    expect(permissionEvaluation).toHaveBeenCalledWith({ approvalType: "delete_file" });
+  });
+
+  it("does not force runtime approval for ordinary permission approval types", async () => {
+    const permissionEvaluation = vi.fn(async () => ({
+      decision: "allow" as const,
+      reason: {
+        type: "mode" as const,
+        mode: "default",
+        summary: "Allowed by explicit test permission.",
+      },
+      suggestions: [],
+      scopePreview: "web_fetch",
+    }));
+
+    const result = await evaluateToolPolicyPipeline({
+      workspace,
+      toolName: "web_fetch",
+      toolInput: { url: "https://example.com" },
+      approvalRequired: false,
+      permissionApprovalType: "network_access",
+      permissionEvaluation,
+    });
+
+    expect(result.decision).toBe("allow");
+    expect(result.trace.finalDecision).toBe("allow");
+    expect(result.trace.entries).toContainEqual(
+      expect.objectContaining({
+        stage: "approval",
+        decision: "allow",
+      }),
+    );
+    expect(permissionEvaluation).toHaveBeenCalledWith({ approvalType: "network_access" });
+  });
+
+  it("requires runtime metadata approval after permissive permission evaluation", async () => {
+    const permissionEvaluation = vi.fn(async () => ({
+      decision: "allow" as const,
+      reason: {
+        type: "mode" as const,
+        mode: "default",
+        summary: "Allowed by explicit test permission.",
+      },
+      suggestions: [],
+      scopePreview: "custom_sensitive_tool",
+    }));
+
+    const result = await evaluateToolPolicyPipeline({
+      workspace,
+      toolName: "custom_sensitive_tool",
+      toolInput: { target: "external-system" },
+      approvalRequired: true,
+      permissionEvaluation,
+    });
+
+    expect(result.decision).toBe("require_approval");
+    expect(result.reason).toBe("approval required by runtime metadata");
+    expect(result.trace.finalDecision).toBe("require_approval");
+    expect(result.trace.entries).toContainEqual(
+      expect.objectContaining({
+        stage: "approval",
+        decision: "require_approval",
+        reason: "approval required by runtime metadata",
+      }),
+    );
+    expect(permissionEvaluation).toHaveBeenCalled();
   });
 });

--- a/src/electron/agent/__tests__/tool-policy-pipeline.test.ts
+++ b/src/electron/agent/__tests__/tool-policy-pipeline.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ApprovalType } from "../../../shared/types";
 
 vi.mock("../../security/policy-manager", () => ({
   isToolAllowedQuick: vi.fn(() => true),
@@ -8,6 +9,7 @@ vi.mock("../../security/monty-tool-policy", () => ({
   evaluateMontyToolPolicy: vi.fn(async () => ({ decision: "pass", reason: null })),
 }));
 
+import { evaluateMontyToolPolicy } from "../../security/monty-tool-policy";
 import { evaluateToolPolicyPipeline } from "../runtime/ToolPolicyPipeline";
 import { PermissionEngine } from "../runtime/PermissionEngine";
 
@@ -128,18 +130,28 @@ describe("ToolPolicyPipeline", () => {
       "Data export always requires an explicit prompt, even in bypass modes.",
     );
     expect(result.trace.finalDecision).toBe("require_approval");
+    expect(result.trace.entries).toContainEqual(
+      expect.objectContaining({
+        stage: "permissions",
+        metadata: expect.objectContaining({
+          runtimeApprovalType: "data_export",
+          requestedPermissionApprovalType: "data_export",
+          resolvedPermissionApprovalType: "data_export",
+        }),
+      }),
+    );
     expect(permissionEvaluation).toHaveBeenCalledWith({ approvalType: "data_export" });
   });
 
   it("preserves destructive runtime approval semantics for custom tools", async () => {
-    const permissionEvaluation = vi.fn(async (opts?: { approvalType?: string | null }) =>
+    const permissionEvaluation = vi.fn(async (opts?: { approvalType?: ApprovalType | null }) =>
       PermissionEngine.evaluate({
         workspace,
         toolName: "custom_destructive_tool",
         toolInput: { target: "external-system" },
         mode: "default",
         rules: [],
-        approvalType: opts?.approvalType as Any,
+        approvalType: opts?.approvalType ?? undefined,
       }),
     );
 
@@ -229,5 +241,50 @@ describe("ToolPolicyPipeline", () => {
       }),
     );
     expect(permissionEvaluation).toHaveBeenCalled();
+  });
+
+  it("keeps runtime approval required after permissive workspace policy", async () => {
+    vi.mocked(evaluateMontyToolPolicy).mockResolvedValueOnce({
+      decision: "allow",
+      reason: "workspace policy allows this tool",
+    });
+    const permissionEvaluation = vi.fn(async () => ({
+      decision: "allow" as const,
+      reason: {
+        type: "mode" as const,
+        mode: "dont_ask",
+        summary: "Permission mode allows this tool.",
+      },
+      suggestions: [],
+      scopePreview: "custom_data_export_tool",
+    }));
+
+    const result = await evaluateToolPolicyPipeline({
+      workspace,
+      toolName: "custom_data_export_tool",
+      toolInput: { target: "external-system" },
+      approvalRequired: true,
+      runtimeApprovalType: "data_export",
+      permissionEvaluation,
+    });
+
+    expect(result.decision).toBe("require_approval");
+    expect(result.reason).toBe("approval required by runtime metadata");
+    expect(result.trace.finalDecision).toBe("require_approval");
+    expect(result.trace.entries).toContainEqual(
+      expect.objectContaining({
+        stage: "workspace_script",
+        decision: "allow",
+        reason: "workspace policy allows this tool",
+      }),
+    );
+    expect(result.trace.entries).toContainEqual(
+      expect.objectContaining({
+        stage: "approval",
+        decision: "require_approval",
+        reason: "approval required by runtime metadata",
+      }),
+    );
+    expect(permissionEvaluation).toHaveBeenCalledWith({ approvalType: "data_export" });
   });
 });

--- a/src/electron/agent/runtime/ToolPolicyPipeline.ts
+++ b/src/electron/agent/runtime/ToolPolicyPipeline.ts
@@ -54,7 +54,9 @@ export async function evaluateToolPolicyPipeline(
   opts: ToolPolicyPipelineOptions,
 ): Promise<ToolPolicyPipelineResult> {
   const trace = new ToolPolicyTraceBuilder(opts.toolName);
-  const permissionApprovalType = opts.permissionApprovalType ?? opts.runtimeApprovalType ?? null;
+  const requestedPermissionApprovalType = opts.permissionApprovalType ?? null;
+  const resolvedPermissionApprovalType =
+    requestedPermissionApprovalType ?? opts.runtimeApprovalType ?? null;
 
   if (opts.deniedTools?.has(opts.toolName)) {
     trace.add("task_restrictions", "deny", "tool denied by task restrictions");
@@ -148,6 +150,8 @@ export async function evaluateToolPolicyPipeline(
         trace: trace.build("require_approval"),
       };
     }
+    // Workspace allow/pass does not discharge runtime approval metadata; it is
+    // still evaluated by the permission engine or final runtime fallback below.
   } catch (error) {
     if (process.env.COWORK_FAIL_CLOSED_TOOL_POLICY === "1") {
       trace.add("workspace_script", "deny", "workspace policy evaluation failed", {
@@ -175,12 +179,13 @@ export async function evaluateToolPolicyPipeline(
 
   if (opts.permissionEvaluation) {
     const permission = await opts.permissionEvaluation({
-      approvalType: permissionApprovalType,
+      approvalType: resolvedPermissionApprovalType,
     });
     trace.add("permissions", toStageDecision(permission.decision), permission.reason.summary, {
       reasonType: permission.reason.type,
       runtimeApprovalType: opts.runtimeApprovalType,
-      permissionApprovalType,
+      requestedPermissionApprovalType,
+      resolvedPermissionApprovalType,
       scopePreview: permission.scopePreview,
       matchedRuleSource: permission.matchedRule?.source,
       matchedScopeKind: permission.matchedRule?.scope?.kind,

--- a/src/electron/agent/runtime/ToolPolicyPipeline.ts
+++ b/src/electron/agent/runtime/ToolPolicyPipeline.ts
@@ -1,4 +1,5 @@
 import type {
+  ApprovalType,
   GatewayContextType,
   PermissionEvaluationResult,
   Workspace,
@@ -23,7 +24,11 @@ export interface ToolPolicyPipelineOptions {
   deniedTools?: Set<string>;
   allowedTools?: Set<string>;
   approvalRequired?: boolean;
-  permissionEvaluation?: () => Promise<PermissionEvaluationResult>;
+  runtimeApprovalType?: ApprovalType | null;
+  permissionApprovalType?: ApprovalType | null;
+  permissionEvaluation?: (opts?: {
+    approvalType?: ApprovalType | null;
+  }) => Promise<PermissionEvaluationResult>;
 }
 
 export interface ToolPolicyPipelineResult {
@@ -49,6 +54,7 @@ export async function evaluateToolPolicyPipeline(
   opts: ToolPolicyPipelineOptions,
 ): Promise<ToolPolicyPipelineResult> {
   const trace = new ToolPolicyTraceBuilder(opts.toolName);
+  const permissionApprovalType = opts.permissionApprovalType ?? opts.runtimeApprovalType ?? null;
 
   if (opts.deniedTools?.has(opts.toolName)) {
     trace.add("task_restrictions", "deny", "tool denied by task restrictions");
@@ -132,11 +138,13 @@ export async function evaluateToolPolicyPipeline(
         trace: trace.build("deny"),
       };
     }
-    if (workspacePolicy.decision === "require_approval" || opts.approvalRequired) {
-      trace.add("approval", "require_approval", workspacePolicy.reason);
+    if (workspacePolicy.decision === "require_approval") {
+      const approvalReason =
+        workspacePolicy.reason || "approval required by workspace policy";
+      trace.add("approval", "require_approval", approvalReason);
       return {
         decision: "require_approval",
-        reason: workspacePolicy.reason,
+        reason: approvalReason,
         trace: trace.build("require_approval"),
       };
     }
@@ -156,7 +164,7 @@ export async function evaluateToolPolicyPipeline(
     });
   }
 
-  if (opts.approvalRequired) {
+  if (opts.approvalRequired && !opts.permissionEvaluation) {
     trace.add("approval", "require_approval", "approval required by runtime metadata");
     return {
       decision: "require_approval",
@@ -166,9 +174,13 @@ export async function evaluateToolPolicyPipeline(
   }
 
   if (opts.permissionEvaluation) {
-    const permission = await opts.permissionEvaluation();
+    const permission = await opts.permissionEvaluation({
+      approvalType: permissionApprovalType,
+    });
     trace.add("permissions", toStageDecision(permission.decision), permission.reason.summary, {
       reasonType: permission.reason.type,
+      runtimeApprovalType: opts.runtimeApprovalType,
+      permissionApprovalType,
       scopePreview: permission.scopePreview,
       matchedRuleSource: permission.matchedRule?.source,
       matchedScopeKind: permission.matchedRule?.scope?.kind,
@@ -189,6 +201,15 @@ export async function evaluateToolPolicyPipeline(
     }
   } else {
     trace.add("permissions", "skip");
+  }
+
+  if (opts.approvalRequired) {
+    trace.add("approval", "require_approval", "approval required by runtime metadata");
+    return {
+      decision: "require_approval",
+      reason: "approval required by runtime metadata",
+      trace: trace.build("require_approval"),
+    };
   }
 
   trace.add("approval", "allow");

--- a/src/electron/agent/tools/registry.ts
+++ b/src/electron/agent/tools/registry.ts
@@ -1596,9 +1596,11 @@ export class ToolRegistry {
         context.request.input,
       );
       const runtimeApprovalType = getApprovalTypeForRuntimeKind(runtime.approvalKind);
+      // Prefer tool/input-derived approval types because they are more specific
+      // than broad runtime metadata kinds for the same tool call.
       const effectiveApprovalType = browserUseApproval
         ? "network_access"
-        : approvalType || runtimeApprovalType;
+        : approvalType ?? runtimeApprovalType;
       const permissionEvaluation = (this.daemon as Any)?.evaluateToolPermission;
       const serverName = this.getMcpServerName(context.request.name);
       const approvalDetails = {
@@ -1620,14 +1622,14 @@ export class ToolRegistry {
         permissionApprovalType: effectiveApprovalType,
         permissionEvaluation:
           typeof permissionEvaluation === "function"
-            ? (policy) =>
-                permissionEvaluation.call(this.daemon, this.taskId, {
-                  ...(policy?.approvalType || effectiveApprovalType
-                    ? { approvalType: policy?.approvalType || effectiveApprovalType }
-                    : {}),
+            ? (policy) => {
+                const approvalTypeForPermission = policy?.approvalType ?? effectiveApprovalType;
+                return permissionEvaluation.call(this.daemon, this.taskId, {
+                  ...(approvalTypeForPermission ? { approvalType: approvalTypeForPermission } : {}),
                   toolName: context.request.name,
                   details: approvalDetails,
-                })
+                });
+              }
             : undefined,
       });
 

--- a/src/electron/agent/tools/registry.ts
+++ b/src/electron/agent/tools/registry.ts
@@ -16,6 +16,7 @@ import {
   TaskEvent,
   TOOL_GROUPS,
   ToolGroupName,
+  RuntimeToolApprovalKind,
   WorkspacePathAliasPolicy,
   WorkerRoleKind,
 } from "../../../shared/types";
@@ -193,6 +194,23 @@ const MCP_PAYMENT_AMOUNT_PATHS = [
   ["request", "maxAmount"],
 ];
 const MCP_PAYMENT_MAX_AMOUNT_USD = 100;
+
+function getApprovalTypeForRuntimeKind(
+  approvalKind: RuntimeToolApprovalKind | undefined,
+): ApprovalType | null {
+  switch (approvalKind) {
+    case "external_service":
+      return "external_service";
+    case "data_export":
+      return "data_export";
+    case "destructive":
+      return "delete_file";
+    case "shell_sensitive":
+      return "run_command";
+    default:
+      return null;
+  }
+}
 
 const MCP_PAYMENT_AMOUNT_TYPES = new Set(["number", "integer", "string"]);
 
@@ -1577,7 +1595,10 @@ export class ToolRegistry {
         context.request.name,
         context.request.input,
       );
-      const effectiveApprovalType = browserUseApproval ? "network_access" : approvalType;
+      const runtimeApprovalType = getApprovalTypeForRuntimeKind(runtime.approvalKind);
+      const effectiveApprovalType = browserUseApproval
+        ? "network_access"
+        : approvalType || runtimeApprovalType;
       const permissionEvaluation = (this.daemon as Any)?.evaluateToolPermission;
       const serverName = this.getMcpServerName(context.request.name);
       const approvalDetails = {
@@ -1586,20 +1607,24 @@ export class ToolRegistry {
         ...(serverName ? { serverName } : {}),
         ...browserUseApproval,
       };
+      const runtimeApprovalRequired =
+        runtime.approvalKind !== "none" && runtime.approvalKind !== "workspace_policy";
       const pipeline = await evaluateToolPolicyPipeline({
         workspace: this.workspace,
         toolName: context.request.name,
         toolInput: context.request.input,
         gatewayContext: this.gatewayContext,
         policyContext: context.request.runtime?.toolPolicyContext as Any,
-        approvalRequired: runtime.approvalKind !== "none" && runtime.approvalKind !== "workspace_policy"
-          ? false
-          : false,
+        approvalRequired: runtimeApprovalRequired,
+        runtimeApprovalType: runtimeApprovalRequired ? runtimeApprovalType : null,
+        permissionApprovalType: effectiveApprovalType,
         permissionEvaluation:
           typeof permissionEvaluation === "function"
-            ? () =>
+            ? (policy) =>
                 permissionEvaluation.call(this.daemon, this.taskId, {
-                  ...(effectiveApprovalType ? { approvalType: effectiveApprovalType } : {}),
+                  ...(policy?.approvalType || effectiveApprovalType
+                    ? { approvalType: policy?.approvalType || effectiveApprovalType }
+                    : {}),
                   toolName: context.request.name,
                   details: approvalDetails,
                 })


### PR DESCRIPTION
## Summary
- Thread runtime approval metadata through the tool policy pipeline.
- Preserve permission approval semantics while applying runtime metadata approvals after permissive permission evaluation.
- Map runtime approval kinds to the existing approval type model for external service, data export, destructive, and shell-sensitive tools.

## Validation
- npx vitest run src/electron/agent/__tests__/tool-policy-pipeline.test.ts
- npm run type-check
- git diff --check