### PR TITLE
Add task strategy snapshots for executor routing

### DIFF
--- a/src/electron/agent/__tests__/executor-routing-state-machine.test.ts
+++ b/src/electron/agent/__tests__/executor-routing-state-machine.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { TaskExecutor } from "../executor";
-import type { IntentRoute } from "../strategy/IntentRouter";
 import { TaskStrategyService } from "../strategy/TaskStrategyService";
 import type { TaskStrategySnapshot } from "../strategy/TaskStrategySnapshot";
+import { makeRoute } from "../strategy/__tests__/task-strategy-test-fixtures";
 
 vi.mock("electron", () => ({
   app: {
@@ -37,20 +37,9 @@ function createExecutorWithSnapshot(snapshot?: Partial<TaskStrategySnapshot>) {
   return executor;
 }
 
-function makeRoute(overrides: Partial<IntentRoute> = {}): IntentRoute {
-  return {
-    intent: "execution",
-    confidence: 0.8,
-    conversationMode: "task",
-    answerFirst: false,
-    signals: [],
-    complexity: "low",
-    domain: "code",
-    ...overrides,
-  };
-}
-
 describe("TaskExecutor routing state machine gates", () => {
+  // These assertions intentionally call private routing gates: the public executor
+  // flow is too expensive for this state-machine matrix.
   it("uses terminal quick-answer snapshots for answer-first LLM calls", () => {
     const executor = createExecutorWithSnapshot({
       directResponseMode: "terminal_quick_answer",
@@ -143,17 +132,17 @@ describe("agent loop routing matrix", () => {
     },
     {
       name: "simple image generation",
-      route: makeRoute({ intent: "execution", domain: "creative", signals: ["image-creation-intent"] }),
+      route: makeRoute({ intent: "execution", domain: "media", signals: ["image-creation-intent"] }),
       title: "Create image",
       prompt: "Create an image of a snow leopard wearing a small backpack.",
-      expected: { taskIntent: "execution", executionMode: "execute", taskDomain: "creative" },
+      expected: { taskIntent: "execution", executionMode: "execute", taskDomain: "media" },
     },
     {
       name: "document artifact task",
-      route: makeRoute({ intent: "execution", domain: "document", signals: ["artifact-creation-intent"] }),
+      route: makeRoute({ intent: "execution", domain: "writing", signals: ["artifact-creation-intent"] }),
       title: "Create PDF",
       prompt: "Create a PDF report from the attached notes and save it in the workspace.",
-      expected: { taskIntent: "execution", executionMode: "execute", taskDomain: "document" },
+      expected: { taskIntent: "execution", executionMode: "execute", taskDomain: "writing" },
     },
     {
       name: "code execution task",

--- a/src/electron/agent/__tests__/executor-routing-state-machine.test.ts
+++ b/src/electron/agent/__tests__/executor-routing-state-machine.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { TaskExecutor } from "../executor";
+import type { IntentRoute } from "../strategy/IntentRouter";
+import { TaskStrategyService } from "../strategy/TaskStrategyService";
 import type { TaskStrategySnapshot } from "../strategy/TaskStrategySnapshot";
 
 vi.mock("electron", () => ({
@@ -33,6 +35,19 @@ function createExecutorWithSnapshot(snapshot?: Partial<TaskStrategySnapshot>) {
       : {},
   };
   return executor;
+}
+
+function makeRoute(overrides: Partial<IntentRoute> = {}): IntentRoute {
+  return {
+    intent: "execution",
+    confidence: 0.8,
+    conversationMode: "task",
+    answerFirst: false,
+    signals: [],
+    complexity: "low",
+    domain: "code",
+    ...overrides,
+  };
 }
 
 describe("TaskExecutor routing state machine gates", () => {
@@ -72,5 +87,86 @@ describe("TaskExecutor routing state machine gates", () => {
     const executor = createExecutorWithSnapshot();
 
     expect((executor as Any).shouldEmitAnswerFirst()).toBe(true);
+  });
+});
+
+describe("agent loop routing matrix", () => {
+  const cases: Array<{
+    name: string;
+    route: IntentRoute;
+    title: string;
+    prompt: string;
+    expected: Partial<TaskStrategySnapshot>;
+  }> = [
+    {
+      name: "simple chat",
+      route: makeRoute({ intent: "chat", conversationMode: "chat", domain: "general" }),
+      title: "Quick check-in",
+      prompt: "Hey, how are you?",
+      expected: { taskIntent: "chat", directResponseMode: "companion", workflowMode: "none" },
+    },
+    {
+      name: "thinking-only prompt",
+      route: makeRoute({ intent: "thinking", conversationMode: "think", answerFirst: true, domain: "general" }),
+      title: "Think through tradeoffs",
+      prompt: "Think deeply about whether I should use SQLite or Postgres here.",
+      expected: { taskIntent: "thinking", directResponseMode: "companion", workflowMode: "none" },
+    },
+    {
+      name: "advice prompt",
+      route: makeRoute({ intent: "advice", conversationMode: "hybrid", answerFirst: true, domain: "general" }),
+      title: "Advice",
+      prompt: "Should I use pnpm or npm for this repo?",
+      expected: {
+        taskIntent: "advice",
+        executionMode: "plan",
+        directResponseMode: "terminal_quick_answer",
+      },
+    },
+    {
+      name: "mixed answer then execute",
+      route: makeRoute({ intent: "mixed", conversationMode: "hybrid", answerFirst: true, signals: ["path-or-command"] }),
+      title: "Explain then fix",
+      prompt: "Briefly explain the likely bug, then edit src/app.ts to fix it.",
+      expected: {
+        taskIntent: "mixed",
+        executionMode: "execute",
+        directResponseMode: "brief_status_then_execute",
+      },
+    },
+    {
+      name: "workflow task",
+      route: makeRoute({ intent: "workflow", conversationMode: "task", complexity: "high", domain: "code" }),
+      title: "Launch workflow",
+      prompt: "Run a multi-phase workflow to research, implement, test, and summarize the feature.",
+      expected: { taskIntent: "workflow", executionMode: "execute", workflowMode: "workflow" },
+    },
+    {
+      name: "simple image generation",
+      route: makeRoute({ intent: "execution", domain: "creative", signals: ["image-creation-intent"] }),
+      title: "Create image",
+      prompt: "Create an image of a snow leopard wearing a small backpack.",
+      expected: { taskIntent: "execution", executionMode: "execute", taskDomain: "creative" },
+    },
+    {
+      name: "document artifact task",
+      route: makeRoute({ intent: "execution", domain: "document", signals: ["artifact-creation-intent"] }),
+      title: "Create PDF",
+      prompt: "Create a PDF report from the attached notes and save it in the workspace.",
+      expected: { taskIntent: "execution", executionMode: "execute", taskDomain: "document" },
+    },
+    {
+      name: "code execution task",
+      route: makeRoute({ intent: "execution", domain: "code" }),
+      title: "Fix tests",
+      prompt: "Run the tests, fix the failing TypeScript code, and verify the result.",
+      expected: { taskIntent: "execution", executionMode: "execute", taskDomain: "code" },
+    },
+  ];
+
+  it.each(cases)("$name derives the expected canonical strategy", ({ route, title, prompt, expected }) => {
+    const strategy = TaskStrategyService.derive(route, undefined, { title, prompt });
+
+    expect(strategy.snapshot).toMatchObject(expected);
   });
 });

--- a/src/electron/agent/__tests__/executor-routing-state-machine.test.ts
+++ b/src/electron/agent/__tests__/executor-routing-state-machine.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { TaskExecutor } from "../executor";
+import type { TaskStrategySnapshot } from "../strategy/TaskStrategySnapshot";
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue("/tmp"),
+  },
+}));
+
+function createExecutorWithSnapshot(snapshot?: Partial<TaskStrategySnapshot>) {
+  const executor = Object.create(TaskExecutor.prototype) as Any;
+  executor.task = {
+    id: "task-1",
+    title: "Task",
+    prompt: snapshot ? "Task prompt" : "Task prompt\nanswer_first=true",
+    agentConfig: snapshot
+      ? {
+          taskStrategySnapshot: {
+            taskIntent: "mixed",
+            conversationMode: "hybrid",
+            executionMode: "execute",
+            taskDomain: "code",
+            directResponseMode: "none",
+            preflightGates: [],
+            workflowMode: "none",
+            confidence: 0.8,
+            overrides: [],
+            ...snapshot,
+          } satisfies TaskStrategySnapshot,
+        }
+      : {},
+  };
+  return executor;
+}
+
+describe("TaskExecutor routing state machine gates", () => {
+  it("uses terminal quick-answer snapshots for answer-first LLM calls", () => {
+    const executor = createExecutorWithSnapshot({
+      directResponseMode: "terminal_quick_answer",
+      executionMode: "plan",
+    });
+
+    expect((executor as Any).shouldEmitAnswerFirst()).toBe(true);
+  });
+
+  it("skips separate quick-answer LLM for answer-then-execute snapshots", () => {
+    const executor = createExecutorWithSnapshot({
+      directResponseMode: "brief_status_then_execute",
+      executionMode: "execute",
+    });
+
+    expect((executor as Any).shouldEmitAnswerFirst()).toBe(false);
+  });
+
+  it("uses explicit preflight snapshot gates when present", () => {
+    const withoutPreflight = createExecutorWithSnapshot({
+      directResponseMode: "brief_status_then_execute",
+      preflightGates: [],
+    });
+    const withPreflight = createExecutorWithSnapshot({
+      directResponseMode: "none",
+      preflightGates: ["preflight_framing"],
+    });
+
+    expect((withoutPreflight as Any).shouldEmitPreflight()).toBe(false);
+    expect((withPreflight as Any).shouldEmitPreflight()).toBe(true);
+  });
+
+  it("falls back to legacy answer_first prompt marker when no snapshot exists", () => {
+    const executor = createExecutorWithSnapshot();
+
+    expect((executor as Any).shouldEmitAnswerFirst()).toBe(true);
+  });
+});

--- a/src/electron/agent/daemon.ts
+++ b/src/electron/agent/daemon.ts
@@ -1073,11 +1073,17 @@ export class AgentDaemon extends EventEmitter {
     }
     if (runtimeStrategy.promptChanged || runtimeStrategy.agentConfigChanged) {
       this.logEvent(effectiveTask.id, "log", {
+        metric: "task_strategy_selected",
         message:
           `Execution strategy active: intent=${runtimeStrategy.route.intent}, ` +
           `domain=${runtimeStrategy.strategy.taskDomain}, convoMode=${runtimeStrategy.strategy.conversationMode}, ` +
           `execMode=${runtimeStrategy.strategy.executionMode}, answerFirst=${runtimeStrategy.strategy.answerFirst}, ` +
           `llmProfileHint=${runtimeStrategy.strategy.llmProfileHint}`,
+        routingConfidence: runtimeStrategy.route.confidence,
+        directResponseMode: runtimeStrategy.strategy.snapshot.directResponseMode,
+        preflightGates: runtimeStrategy.strategy.snapshot.preflightGates,
+        workflowMode: runtimeStrategy.strategy.snapshot.workflowMode,
+        llmProfileHint: runtimeStrategy.strategy.llmProfileHint,
       });
     }
 

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -22093,9 +22093,9 @@ You are continuing a previous conversation. The context from the previous conver
   }
 
   private getTaskStrategySnapshot(): TaskStrategySnapshot | undefined {
-    const snapshot = (this.task.agentConfig as Any)?.taskStrategySnapshot;
+    const snapshot = this.task.agentConfig?.taskStrategySnapshot;
     if (!snapshot || typeof snapshot !== "object") return undefined;
-    return snapshot as TaskStrategySnapshot;
+    return snapshot;
   }
 
   private hasDirectAnswerReady(): boolean {

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -93,6 +93,7 @@ import {
 } from "./runtime/SessionRuntime";
 import { defaultStepLoopBudget, type LoopBudgetStopReason } from "./runtime/LoopBudgetPolicy";
 import { createTerminalState, type TerminalState } from "./runtime/TerminalState";
+import type { TaskStrategySnapshot } from "./strategy/TaskStrategySnapshot";
 import type {
   TurnKernelIterationState,
   TurnKernelPolicy,
@@ -22071,6 +22072,11 @@ You are continuing a previous conversation. The context from the previous conver
   }
 
   private shouldEmitAnswerFirst(): boolean {
+    const directResponseMode = this.getTaskStrategySnapshot()?.directResponseMode;
+    if (directResponseMode === "terminal_quick_answer") return true;
+    if (directResponseMode === "brief_status_then_execute" || directResponseMode === "companion") {
+      return false;
+    }
     return /\banswer_first=true\b/i.test(String(this.task?.prompt || ""));
   }
 
@@ -22079,7 +22085,17 @@ You are continuing a previous conversation. The context from the previous conver
   }
 
   private shouldEmitPreflight(): boolean {
+    const snapshot = this.getTaskStrategySnapshot();
+    if (snapshot) {
+      return snapshot.preflightGates.includes("preflight_framing");
+    }
     return this.task.agentConfig?.preflightRequired === true;
+  }
+
+  private getTaskStrategySnapshot(): TaskStrategySnapshot | undefined {
+    const snapshot = (this.task.agentConfig as Any)?.taskStrategySnapshot;
+    if (!snapshot || typeof snapshot !== "object") return undefined;
+    return snapshot as TaskStrategySnapshot;
   }
 
   private hasDirectAnswerReady(): boolean {

--- a/src/electron/agent/strategy/IntentRouter.ts
+++ b/src/electron/agent/strategy/IntentRouter.ts
@@ -1,15 +1,6 @@
-import { ConversationMode, TaskDomain } from "../../../shared/types";
+import type { ConversationMode, TaskDomain, TaskStrategyIntent } from "../../../shared/types";
 
-export type RoutedIntent =
-  | "chat"
-  | "advice"
-  | "planning"
-  | "execution"
-  | "mixed"
-  | "thinking"
-  | "workflow"
-  | "deep_work"
-  | "redirect";
+export type RoutedIntent = TaskStrategyIntent;
 
 export type TaskComplexity = "low" | "medium" | "high";
 

--- a/src/electron/agent/strategy/TaskStrategyService.ts
+++ b/src/electron/agent/strategy/TaskStrategyService.ts
@@ -416,8 +416,7 @@ export class TaskStrategyService {
     strategy: DerivedTaskStrategy,
   ): AgentConfig {
     const next: AgentConfig = existing ? { ...existing } : {};
-    (next as AgentConfig & { taskStrategySnapshot?: TaskStrategySnapshot }).taskStrategySnapshot =
-      strategy.snapshot;
+    next.taskStrategySnapshot = strategy.snapshot;
     const existingExecutionMode = existing?.executionMode;
     const inferredExistingExecutionModeSource =
       existing?.executionModeSource ||

--- a/src/electron/agent/strategy/TaskStrategyService.ts
+++ b/src/electron/agent/strategy/TaskStrategyService.ts
@@ -6,6 +6,7 @@ import {
   TaskDomain,
 } from "../../../shared/types";
 import { IntentRoute } from "./IntentRouter";
+import type { DirectResponseMode, PreflightGate, TaskStrategySnapshot } from "./TaskStrategySnapshot";
 
 export interface DerivedTaskStrategy {
   conversationMode: ConversationMode;
@@ -25,6 +26,8 @@ export interface DerivedTaskStrategy {
   progressJournalEnabled: boolean;
   /** Strategy-derived model routing hint */
   llmProfileHint: LlmProfile;
+  /** Canonical strategy fields for downstream routing gates. */
+  snapshot: TaskStrategySnapshot;
 }
 
 export const STRATEGY_CONTEXT_OPEN = "[AGENT_STRATEGY_CONTEXT_V1]";
@@ -351,14 +354,32 @@ export class TaskStrategyService {
         previousWindowLowProgress)
         ? "strong"
         : baseLlmProfileHint;
+    const conversationMode =
+      existing?.conversationMode && existing.conversationMode !== "hybrid"
+        ? existing.conversationMode
+        : base.conversationMode;
+    const snapshot: TaskStrategySnapshot = {
+      taskIntent: route.intent,
+      conversationMode,
+      executionMode,
+      taskDomain,
+      directResponseMode: this.deriveDirectResponseMode({
+        intent: route.intent,
+        answerFirst: base.answerFirst,
+        executionMode,
+      }),
+      preflightGates: preflightRequired ? ["preflight_framing"] : [],
+      workflowMode:
+        route.intent === "workflow" || route.intent === "deep_work" ? route.intent : "none",
+      llmProfileHint,
+      confidence: route.confidence,
+      overrides: [],
+    };
     return {
       // Preserve explicit user-set modes (chat/task/think) but let intent-derived
       // strategy override the default "hybrid" so the daemon's IntentRouter decision
       // actually takes effect at execution time.
-      conversationMode:
-        existing?.conversationMode && existing.conversationMode !== "hybrid"
-          ? existing.conversationMode
-          : base.conversationMode,
+      conversationMode,
       executionMode,
       taskDomain,
       qualityPasses:
@@ -371,7 +392,22 @@ export class TaskStrategyService {
       autoReportEnabled: isWorkflowOrDeepWork,
       progressJournalEnabled: isDeepWork,
       llmProfileHint,
+      snapshot,
     };
+  }
+
+  private static deriveDirectResponseMode(params: {
+    intent: IntentRoute["intent"];
+    answerFirst: boolean;
+    executionMode: ExecutionMode;
+  }): DirectResponseMode {
+    if (params.intent === "chat" || params.intent === "thinking") {
+      return "companion";
+    }
+    if (!params.answerFirst) return "none";
+    return params.executionMode === "execute" || params.executionMode === "debug"
+      ? "brief_status_then_execute"
+      : "terminal_quick_answer";
   }
 
   static applyToAgentConfig(
@@ -379,6 +415,8 @@ export class TaskStrategyService {
     strategy: DerivedTaskStrategy,
   ): AgentConfig {
     const next: AgentConfig = existing ? { ...existing } : {};
+    (next as AgentConfig & { taskStrategySnapshot?: TaskStrategySnapshot }).taskStrategySnapshot =
+      strategy.snapshot;
     const existingExecutionMode = existing?.executionMode;
     const inferredExistingExecutionModeSource =
       existing?.executionModeSource ||

--- a/src/electron/agent/strategy/TaskStrategyService.ts
+++ b/src/electron/agent/strategy/TaskStrategyService.ts
@@ -185,6 +185,7 @@ export class TaskStrategyService {
         | "autoReportEnabled"
         | "progressJournalEnabled"
         | "llmProfileHint"
+        | "snapshot"
       >
     > = {
       chat: {

--- a/src/electron/agent/strategy/TaskStrategySnapshot.ts
+++ b/src/electron/agent/strategy/TaskStrategySnapshot.ts
@@ -1,32 +1,8 @@
-export type DirectResponseMode =
-  | "none"
-  | "companion"
-  | "terminal_quick_answer"
-  | "brief_status_then_execute";
-
-export type PreflightGate =
-  | "none"
-  | "preflight_framing"
-  | "workspace_selection"
-  | "artifact_presence";
-
-export interface StrategyOverride {
-  field: string;
-  from: unknown;
-  to: unknown;
-  reason: string;
-  phase: "daemon" | "startup" | "pre_planning" | "step";
-}
-
-export interface TaskStrategySnapshot {
-  taskIntent: string;
-  conversationMode: string;
-  executionMode: string;
-  taskDomain: string;
-  directResponseMode: DirectResponseMode;
-  preflightGates: PreflightGate[];
-  workflowMode: "none" | "workflow" | "deep_work";
-  llmProfileHint?: string;
-  confidence: number;
-  overrides: StrategyOverride[];
-}
+export type {
+  DirectResponseMode,
+  PreflightGate,
+  StrategyOverride,
+  TaskStrategyIntent,
+  TaskStrategySnapshot,
+  WorkflowMode,
+} from "../../../shared/types";

--- a/src/electron/agent/strategy/TaskStrategySnapshot.ts
+++ b/src/electron/agent/strategy/TaskStrategySnapshot.ts
@@ -1,0 +1,32 @@
+export type DirectResponseMode =
+  | "none"
+  | "companion"
+  | "terminal_quick_answer"
+  | "brief_status_then_execute";
+
+export type PreflightGate =
+  | "none"
+  | "preflight_framing"
+  | "workspace_selection"
+  | "artifact_presence";
+
+export interface StrategyOverride {
+  field: string;
+  from: unknown;
+  to: unknown;
+  reason: string;
+  phase: "daemon" | "startup" | "pre_planning" | "step";
+}
+
+export interface TaskStrategySnapshot {
+  taskIntent: string;
+  conversationMode: string;
+  executionMode: string;
+  taskDomain: string;
+  directResponseMode: DirectResponseMode;
+  preflightGates: PreflightGate[];
+  workflowMode: "none" | "workflow" | "deep_work";
+  llmProfileHint?: string;
+  confidence: number;
+  overrides: StrategyOverride[];
+}

--- a/src/electron/agent/strategy/__tests__/TaskStrategyService.test.ts
+++ b/src/electron/agent/strategy/__tests__/TaskStrategyService.test.ts
@@ -1,19 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { IntentRoute } from "../IntentRouter";
 import { TaskStrategyService } from "../TaskStrategyService";
-
-function makeRoute(overrides: Partial<IntentRoute> = {}): IntentRoute {
-  return {
-    intent: "execution",
-    confidence: 0.8,
-    conversationMode: "task",
-    answerFirst: false,
-    signals: [],
-    complexity: "low",
-    domain: "code",
-    ...overrides,
-  };
-}
+import { makeRoute } from "./task-strategy-test-fixtures";
 
 describe("TaskStrategyService deriveLlmProfile", () => {
   it("returns strong for planning intent", () => {
@@ -49,7 +36,7 @@ describe("TaskStrategyService deriveLlmProfile", () => {
 
   it("keeps simple image generation to one quality pass", () => {
     const strategy = TaskStrategyService.derive(
-      makeRoute({ intent: "execution", signals: ["image-creation-intent"], domain: "creative" }),
+      makeRoute({ intent: "execution", signals: ["image-creation-intent"], domain: "media" }),
       undefined,
       {
         title: "Create image",
@@ -62,7 +49,7 @@ describe("TaskStrategyService deriveLlmProfile", () => {
 
   it("keeps infographic image generation to one quality pass", () => {
     const strategy = TaskStrategyService.derive(
-      makeRoute({ intent: "execution", signals: ["image-creation-intent"], domain: "creative" }),
+      makeRoute({ intent: "execution", signals: ["image-creation-intent"], domain: "media" }),
       undefined,
       {
         title: "Create infographic",
@@ -75,7 +62,7 @@ describe("TaskStrategyService deriveLlmProfile", () => {
 
   it("keeps app avatar image generation to one quality pass", () => {
     const strategy = TaskStrategyService.derive(
-      makeRoute({ intent: "execution", signals: ["image-creation-intent"], domain: "creative" }),
+      makeRoute({ intent: "execution", signals: ["image-creation-intent"], domain: "media" }),
       undefined,
       {
         title: "Create avatar",
@@ -88,7 +75,7 @@ describe("TaskStrategyService deriveLlmProfile", () => {
 
   it("keeps grounded infographic image generation to one quality pass", () => {
     const strategy = TaskStrategyService.derive(
-      makeRoute({ intent: "execution", signals: ["image-creation-intent"], domain: "creative" }),
+      makeRoute({ intent: "execution", signals: ["image-creation-intent"], domain: "media" }),
       undefined,
       {
         title: "Create infographic",
@@ -144,7 +131,7 @@ describe("TaskStrategyService decoratePrompt", () => {
     const route = makeRoute({
       intent: "execution",
       signals: ["image-creation-intent"],
-      domain: "creative",
+      domain: "media",
     });
     const strategy = TaskStrategyService.derive(route, undefined, {
       title: "Create image",
@@ -166,7 +153,7 @@ describe("TaskStrategyService decoratePrompt", () => {
     const route = makeRoute({
       intent: "execution",
       signals: ["image-creation-intent"],
-      domain: "creative",
+      domain: "media",
     });
     const strategy = TaskStrategyService.derive(route, undefined, {
       title: "Create infographic",
@@ -194,7 +181,7 @@ image_generation_contract:
     const route = makeRoute({
       intent: "execution",
       signals: ["image-creation-intent"],
-      domain: "creative",
+      domain: "media",
     });
     const strategy = TaskStrategyService.derive(route, undefined, {
       title: "Create avatar",
@@ -209,7 +196,7 @@ image_generation_contract:
     const route = makeRoute({
       intent: "execution",
       signals: ["image-creation-intent"],
-      domain: "creative",
+      domain: "media",
     });
     const strategy = TaskStrategyService.derive(route, undefined, {
       title: "Create infographic",

--- a/src/electron/agent/strategy/__tests__/TaskStrategySnapshot.test.ts
+++ b/src/electron/agent/strategy/__tests__/TaskStrategySnapshot.test.ts
@@ -1,19 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { IntentRoute } from "../IntentRouter";
 import { TaskStrategyService } from "../TaskStrategyService";
-
-function makeRoute(overrides: Partial<IntentRoute> = {}): IntentRoute {
-  return {
-    intent: "execution",
-    confidence: 0.8,
-    conversationMode: "task",
-    answerFirst: false,
-    signals: [],
-    complexity: "low",
-    domain: "code",
-    ...overrides,
-  };
-}
+import { makeRoute } from "./task-strategy-test-fixtures";
 
 describe("TaskStrategySnapshot", () => {
   it("classifies chat and thinking as companion direct responses", () => {
@@ -61,9 +48,9 @@ describe("TaskStrategySnapshot", () => {
 
   it("persists the snapshot onto agent config", () => {
     const strategy = TaskStrategyService.derive(makeRoute({ intent: "planning", answerFirst: true }));
-    const config = TaskStrategyService.applyToAgentConfig({}, strategy) as Any;
+    const config = TaskStrategyService.applyToAgentConfig({}, strategy);
 
     expect(config.taskStrategySnapshot).toEqual(strategy.snapshot);
-    expect(config.taskStrategySnapshot.directResponseMode).toBe("terminal_quick_answer");
+    expect(config.taskStrategySnapshot?.directResponseMode).toBe("terminal_quick_answer");
   });
 });

--- a/src/electron/agent/strategy/__tests__/TaskStrategySnapshot.test.ts
+++ b/src/electron/agent/strategy/__tests__/TaskStrategySnapshot.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { IntentRoute } from "../IntentRouter";
+import { TaskStrategyService } from "../TaskStrategyService";
+
+function makeRoute(overrides: Partial<IntentRoute> = {}): IntentRoute {
+  return {
+    intent: "execution",
+    confidence: 0.8,
+    conversationMode: "task",
+    answerFirst: false,
+    signals: [],
+    complexity: "low",
+    domain: "code",
+    ...overrides,
+  };
+}
+
+describe("TaskStrategySnapshot", () => {
+  it("classifies chat and thinking as companion direct responses", () => {
+    const chat = TaskStrategyService.derive(makeRoute({ intent: "chat", conversationMode: "chat" }));
+    const thinking = TaskStrategyService.derive(
+      makeRoute({ intent: "thinking", conversationMode: "think", answerFirst: true }),
+    );
+
+    expect(chat.snapshot).toMatchObject({
+      taskIntent: "chat",
+      conversationMode: "chat",
+      directResponseMode: "companion",
+      workflowMode: "none",
+    });
+    expect(thinking.snapshot).toMatchObject({
+      taskIntent: "thinking",
+      conversationMode: "think",
+      directResponseMode: "companion",
+      workflowMode: "none",
+    });
+  });
+
+  it("distinguishes terminal quick answers from answer-then-execute work", () => {
+    const advice = TaskStrategyService.derive(makeRoute({ intent: "advice", answerFirst: true }));
+    const mixedExecute = TaskStrategyService.derive(
+      makeRoute({ intent: "mixed", answerFirst: true, signals: ["path-or-command"] }),
+    );
+
+    expect(advice.snapshot.directResponseMode).toBe("terminal_quick_answer");
+    expect(mixedExecute.snapshot.directResponseMode).toBe("brief_status_then_execute");
+  });
+
+  it("records workflow mode and preflight gates", () => {
+    const workflow = TaskStrategyService.derive(
+      makeRoute({ intent: "workflow", complexity: "high", confidence: 0.92 }),
+    );
+
+    expect(workflow.snapshot).toMatchObject({
+      taskIntent: "workflow",
+      workflowMode: "workflow",
+      preflightGates: ["preflight_framing"],
+      confidence: 0.92,
+    });
+  });
+
+  it("persists the snapshot onto agent config", () => {
+    const strategy = TaskStrategyService.derive(makeRoute({ intent: "planning", answerFirst: true }));
+    const config = TaskStrategyService.applyToAgentConfig({}, strategy) as Any;
+
+    expect(config.taskStrategySnapshot).toEqual(strategy.snapshot);
+    expect(config.taskStrategySnapshot.directResponseMode).toBe("terminal_quick_answer");
+  });
+});

--- a/src/electron/agent/strategy/__tests__/task-strategy-test-fixtures.ts
+++ b/src/electron/agent/strategy/__tests__/task-strategy-test-fixtures.ts
@@ -1,0 +1,14 @@
+import type { IntentRoute } from "../IntentRouter";
+
+export function makeRoute(overrides: Partial<IntentRoute> = {}): IntentRoute {
+  return {
+    intent: "execution",
+    confidence: 0.8,
+    conversationMode: "task",
+    answerFirst: false,
+    signals: [],
+    complexity: "low",
+    domain: "code",
+    ...overrides,
+  };
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1953,6 +1953,51 @@ export type ToolDecision = "allow" | "deny" | "ask";
 export type LlmProfile = "strong" | "cheap";
 export type ReviewPolicy = "off" | "balanced" | "strict";
 
+export type TaskStrategyIntent =
+  | "chat"
+  | "advice"
+  | "planning"
+  | "execution"
+  | "mixed"
+  | "thinking"
+  | "workflow"
+  | "deep_work"
+  | "redirect";
+
+export type DirectResponseMode =
+  | "none"
+  | "companion"
+  | "terminal_quick_answer"
+  | "brief_status_then_execute";
+
+export type PreflightGate =
+  | "preflight_framing"
+  | "workspace_selection"
+  | "artifact_presence";
+
+export type WorkflowMode = "none" | "workflow" | "deep_work";
+
+export interface StrategyOverride {
+  field: string;
+  from: unknown;
+  to: unknown;
+  reason: string;
+  phase: "daemon" | "startup" | "pre_planning" | "step";
+}
+
+export interface TaskStrategySnapshot {
+  taskIntent: TaskStrategyIntent;
+  conversationMode: ConversationMode;
+  executionMode: ExecutionMode;
+  taskDomain: TaskDomain;
+  directResponseMode: DirectResponseMode;
+  preflightGates: PreflightGate[];
+  workflowMode: WorkflowMode;
+  llmProfileHint?: LlmProfile;
+  confidence: number;
+  overrides: StrategyOverride[];
+}
+
 /**
  * Post-task repository entropy sweep: read-only audit for stale docs, contradictions, dead-code hints.
  * Defaults follow reviewPolicy when unset (see resolveEntropySweepPolicy).
@@ -2178,6 +2223,8 @@ export interface AgentConfig {
   stepDecompositionPolicy?: "off" | "balanced" | "strict";
   /** Whether to emit a pre-flight problem framing before execution (set by strategy service) */
   preflightRequired?: boolean;
+  /** Canonical routing decision snapshot produced by TaskStrategyService. */
+  taskStrategySnapshot?: TaskStrategySnapshot;
   /** Enable deep work mode: long-running autonomous execution with research-retry, journaling, auto-report */
   deepWorkMode?: boolean;
   /** Persistent `/goal` lifecycle metadata for long-running task objectives. */


### PR DESCRIPTION
## Summary
- Add a canonical task strategy snapshot for executor routing decisions.
- Use the snapshot for answer-first and preflight gates instead of prompt-string inference.
- Add route state-machine matrix coverage and emit task strategy selection telemetry.
- Align shared packaging type contracts for the new metadata.

## Validation
- npx vitest run src/electron/agent/strategy/__tests__/TaskStrategySnapshot.test.ts src/electron/agent/__tests__/executor-routing-state-machine.test.ts
- npm run type-check
- git diff --check

AI assisted