### PR TITLE
[codex] Fix x402 payment approval enforcement

### DIFF
--- a/docs/coinbase-agentic-signer.md
+++ b/docs/coinbase-agentic-signer.md
@@ -49,6 +49,10 @@ Most signer requests include:
 }
 ```
 
+- `paymentPolicy` (object, optional but strongly recommended): desktop-side
+  policy and any user-approved preflight requirement. If present, the signer must
+  enforce it before signing the real upstream payment challenge.
+
 ### Response
 
 ```json
@@ -138,6 +142,9 @@ Checks whether a URL requires x402 payment and returns payment metadata if requi
 `POST /x402/fetch`
 
 Performs the request with signing/payment flow handled server-side.
+The signer must treat any desktop preflight result as advisory only. The real
+upstream `402 Payment Required` response from this fetch is the authoritative
+payment challenge and must be checked against the policy envelope before signing.
 
 ### Request
 
@@ -150,7 +157,35 @@ Performs the request with signing/payment flow handled server-side.
     "accept": "application/json"
   },
   "accountId": "agent-wallet-prod",
-  "network": "base-mainnet"
+  "network": "base-mainnet",
+  "paymentPolicy": {
+    "policyVersion": 1,
+    "effectiveHardLimitUsd": 100,
+    "maxAutoApproveUsd": 1,
+    "requireApproval": true,
+    "allowedHosts": ["paid-api.example.com"],
+    "preflight": {
+      "requires402": true,
+      "url": "https://paid-api.example.com/data",
+      "paymentDetails": {
+        "scheme": "exact",
+        "payTo": "0xmerchant...",
+        "maxAmountRequired": "250000",
+        "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        "network": "eip155:8453",
+        "resource": "/data"
+      }
+    },
+    "approvedPaymentDetails": {
+      "scheme": "exact",
+      "payTo": "0xmerchant...",
+      "maxAmountRequired": "250000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "network": "eip155:8453",
+      "resource": "/data"
+    },
+    "approvedAt": "2026-06-01T10:00:00.000Z"
+  }
 }
 ```
 
@@ -164,7 +199,16 @@ Performs the request with signing/payment flow handled server-side.
     "content-type": "application/json"
   },
   "paymentMade": true,
-  "amountPaid": "0.25"
+  "amountPaid": "0.25",
+  "paymentPolicyEnforced": true,
+  "paymentDetails": {
+    "scheme": "exact",
+    "payTo": "0xmerchant...",
+    "maxAmountRequired": "250000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "network": "eip155:8453",
+    "resource": "/data"
+  }
 }
 ```
 
@@ -173,6 +217,10 @@ Performs the request with signing/payment flow handled server-side.
 - `headers` (object): flattened response headers.
 - `paymentMade` (boolean): whether payment/signature flow was used.
 - `amountPaid` (string, optional): decimal USDC amount.
+- `paymentPolicyEnforced` (boolean, required when `paymentMade=true`): signer
+  confirmed it enforced the supplied policy envelope before signing.
+- `paymentDetails` (object, required when `paymentMade=true`): exact upstream
+  challenge details that were signed.
 
 ## Error Handling
 
@@ -191,6 +239,7 @@ Performs the request with signing/payment flow handled server-side.
 Suggested codes:
 - `SIGNER_UNAUTHORIZED`
 - `SIGNER_POLICY_BLOCKED`
+- `X402_PAYMENT_REQUIREMENT_CHANGED`
 - `WALLET_NOT_READY`
 - `X402_PRECHECK_FAILED`
 - `X402_FETCH_FAILED`
@@ -202,18 +251,34 @@ Suggested codes:
    - mTLS, signed JWT, or short-lived bearer token.
 2. Enforce server-side policy independent of desktop settings:
    - host allowlist, per-request max, per-day budget, account scoping.
-3. Never expose private keys over API.
-4. Log and audit all signing/payment actions with correlation IDs.
-5. Add replay protection and strict request timeouts.
+3. Enforce the desktop `paymentPolicy` envelope before signing:
+   - reject missing or unsupported `policyVersion`
+   - reject if the real upstream payment amount exceeds `effectiveHardLimitUsd`
+   - reject unsupported asset/currency/network combinations. Supported USDC
+     assets are Base mainnet `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+     and Base Sepolia `0x036CbD53842c5426634e7929541eC2318f3dCF7e`
+   - reject resources that do not match the requested URL
+   - when `approvedPaymentDetails` is present, reject if the real upstream
+     challenge differs in `scheme`, `payTo`, `amount`, `maxAmountRequired`,
+     `asset`, `currency`, `network`, `resource`, or `expires`
+   - when `requireApproval` is true and no exact approved payment details are
+     present, reject instead of signing silently
+4. Never expose private keys over API.
+5. Log and audit all signing/payment actions with correlation IDs.
+6. Add replay protection and strict request timeouts.
 
 ## CoWork OS Policy Interaction
 
-Desktop-side policy is enforced before `x402/fetch`:
+Desktop-side policy is enforced at two points:
 - Optional host allowlist (`payments.allowedHosts`)
-- Hard payment limit (`payments.hardLimitUsd`)
-- Approval gate (`payments.requireApproval`, `maxAutoApproveUsd`)
+- Advisory preflight estimate (`/x402/check`), when available
+- Final policy/approval gate on the real upstream `402` challenge
+  (`payments.hardLimitUsd`, `payments.requireApproval`, `maxAutoApproveUsd`)
 
-Signer-side policy should be stricter or equal. Do not rely only on desktop checks.
+The final signer-side check is mandatory because HEAD preflight is not
+authoritative. If `/x402/check` returns no payment but `/x402/fetch` receives a
+real upstream `402`, the signer must still apply the policy envelope before
+signing.
 
 ## Quick Smoke Test
 

--- a/src/electron/infra/__tests__/infra-tools-payments.test.ts
+++ b/src/electron/infra/__tests__/infra-tools-payments.test.ts
@@ -52,6 +52,14 @@ describe("InfraTools x402 payment policy", () => {
 
   const workspace = { id: "w1", path: "/tmp", permissions: {} } as Any;
 
+  const paymentDetails = {
+    payTo: "0x000000000000000000000000000000000000dEaD",
+    amount: "1.25",
+    currency: "USDC",
+    network: "base",
+    resource: "/data",
+  };
+
   beforeEach(() => {
     vi.restoreAllMocks();
     daemonMock.logEvent.mockReset();
@@ -141,6 +149,237 @@ describe("InfraTools x402 payment policy", () => {
     expect(result.error).toBeUndefined();
     expect(daemonMock.requestApproval).not.toHaveBeenCalled();
     expect(managerMock.x402Fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks when the real x402 challenge exceeds the hard limit after a cheap preflight", async () => {
+    const settings = cloneInfraSettings();
+    settings.payments.requireApproval = false;
+    settings.payments.maxAutoApproveUsd = 10;
+    settings.payments.hardLimitUsd = 20;
+    settings.payments.allowedHosts = ["trusted.example"];
+
+    vi.spyOn(InfraSettingsManager, "loadSettings").mockReturnValue(settings);
+    managerMock.x402Check.mockResolvedValue({
+      requires402: true,
+      paymentDetails: { ...paymentDetails, amount: "0.01" },
+      url: "https://trusted.example/data",
+    });
+    managerMock.x402Fetch.mockImplementation(async (_url, opts) => {
+      await opts.approvePayment({
+        url: "https://trusted.example/data",
+        method: "GET",
+        paymentDetails: { ...paymentDetails, amount: "50" },
+      });
+      return {
+        status: 200,
+        body: "ok",
+        headers: {},
+        paymentMade: true,
+        amountPaid: "50",
+      };
+    });
+
+    const tools = new InfraTools(workspace, daemonMock as Any, "task-real-limit");
+    const result = await tools.executeTool("x402_fetch", {
+      url: "https://trusted.example/data",
+    });
+
+    expect(result.error).toMatch(/exceeds configured hard limit/i);
+    expect(daemonMock.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it("requires approval for a real x402 challenge even when HEAD preflight is free", async () => {
+    const settings = cloneInfraSettings();
+    settings.payments.requireApproval = true;
+    settings.payments.allowedHosts = ["trusted.example"];
+
+    vi.spyOn(InfraSettingsManager, "loadSettings").mockReturnValue(settings);
+    managerMock.x402Check.mockResolvedValue({
+      requires402: false,
+      url: "https://trusted.example/data",
+    });
+    managerMock.x402Fetch.mockImplementation(async (_url, opts) => {
+      const approved = await opts.approvePayment({
+        url: "https://trusted.example/data",
+        method: "GET",
+        paymentDetails,
+      });
+      expect(approved).toBe(true);
+      return {
+        status: 200,
+        body: "ok",
+        headers: {},
+        paymentMade: true,
+        amountPaid: paymentDetails.amount,
+      };
+    });
+
+    const tools = new InfraTools(workspace, daemonMock as Any, "task-real-approval");
+    const result = await tools.executeTool("x402_fetch", {
+      url: "https://trusted.example/data",
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(daemonMock.requestApproval).toHaveBeenCalledTimes(1);
+    expect(daemonMock.requestApproval.mock.calls[0][2]).toMatch(/Amount: 1.25 USDC/);
+  });
+
+  it("refuses to sign when the real challenge differs from an approved preflight", async () => {
+    const settings = cloneInfraSettings();
+    settings.payments.requireApproval = true;
+    settings.payments.allowedHosts = ["trusted.example"];
+
+    vi.spyOn(InfraSettingsManager, "loadSettings").mockReturnValue(settings);
+    managerMock.x402Check.mockResolvedValue({
+      requires402: true,
+      paymentDetails,
+      url: "https://trusted.example/data",
+    });
+    managerMock.x402Fetch.mockImplementation(async (_url, opts) => {
+      await opts.approvePayment({
+        url: "https://trusted.example/data",
+        method: "GET",
+        paymentDetails: { ...paymentDetails, amount: "1.50" },
+      });
+      return {
+        status: 200,
+        body: "ok",
+        headers: {},
+        paymentMade: true,
+        amountPaid: "1.50",
+      };
+    });
+
+    const tools = new InfraTools(workspace, daemonMock as Any, "task-mismatch");
+    const result = await tools.executeTool("x402_fetch", {
+      url: "https://trusted.example/data",
+    });
+
+    expect(result.error).toMatch(/requirement changed after preflight/i);
+    expect(daemonMock.requestApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses real challenge mismatch even when the changed payment is under auto-approve cap", async () => {
+    const settings = cloneInfraSettings();
+    settings.payments.requireApproval = false;
+    settings.payments.maxAutoApproveUsd = 5;
+    settings.payments.hardLimitUsd = 50;
+    settings.payments.allowedHosts = ["trusted.example"];
+
+    vi.spyOn(InfraSettingsManager, "loadSettings").mockReturnValue(settings);
+    managerMock.x402Check.mockResolvedValue({
+      requires402: true,
+      paymentDetails: { ...paymentDetails, amount: "0.01" },
+      url: "https://trusted.example/data",
+    });
+    managerMock.x402Fetch.mockImplementation(async (_url, opts) => {
+      await opts.approvePayment({
+        url: "https://trusted.example/data",
+        method: "GET",
+        paymentDetails: {
+          ...paymentDetails,
+          amount: "0.99",
+          payTo: "0x000000000000000000000000000000000000bEEF",
+        },
+      });
+      return {
+        status: 200,
+        body: "ok",
+        headers: {},
+        paymentMade: true,
+        amountPaid: "0.99",
+      };
+    });
+
+    const tools = new InfraTools(workspace, daemonMock as Any, "task-auto-mismatch");
+    const result = await tools.executeTool("x402_fetch", {
+      url: "https://trusted.example/data",
+    });
+
+    expect(result.error).toMatch(/requirement changed after preflight/i);
+    expect(daemonMock.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it("includes exact payment details in the real challenge approval prompt", async () => {
+    const settings = cloneInfraSettings();
+    settings.payments.requireApproval = true;
+    settings.payments.allowedHosts = ["trusted.example"];
+
+    vi.spyOn(InfraSettingsManager, "loadSettings").mockReturnValue(settings);
+    managerMock.x402Check.mockResolvedValue({
+      requires402: false,
+      url: "https://trusted.example/data",
+    });
+    managerMock.x402Fetch.mockImplementation(async (_url, opts) => {
+      await opts.approvePayment({
+        url: "https://trusted.example/data",
+        method: "GET",
+        paymentDetails,
+      });
+      return {
+        status: 200,
+        body: "ok",
+        headers: {},
+        paymentMade: true,
+        amountPaid: paymentDetails.amount,
+      };
+    });
+
+    const tools = new InfraTools(workspace, daemonMock as Any, "task-prompt-details");
+    await tools.executeTool("x402_fetch", {
+      url: "https://trusted.example/data",
+    });
+
+    const approvalMessage = daemonMock.requestApproval.mock.calls[0][2];
+    expect(approvalMessage).toContain(paymentDetails.payTo);
+    expect(approvalMessage).toContain(paymentDetails.resource);
+    expect(approvalMessage).toContain(paymentDetails.network);
+  });
+
+  it("accepts official x402 atomic USDC amount and Base asset fields", async () => {
+    const settings = cloneInfraSettings();
+    settings.payments.requireApproval = false;
+    settings.payments.maxAutoApproveUsd = 2;
+    settings.payments.hardLimitUsd = 50;
+    settings.payments.allowedHosts = ["trusted.example"];
+
+    const officialPaymentDetails = {
+      scheme: "exact",
+      payTo: "0x000000000000000000000000000000000000dEaD",
+      maxAmountRequired: "1250000",
+      asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      network: "eip155:8453",
+      resource: "/data",
+    };
+
+    vi.spyOn(InfraSettingsManager, "loadSettings").mockReturnValue(settings);
+    managerMock.x402Check.mockResolvedValue({
+      requires402: false,
+      url: "https://trusted.example/data",
+    });
+    managerMock.x402Fetch.mockImplementation(async (_url, opts) => {
+      const approved = await opts.approvePayment({
+        url: "https://trusted.example/data",
+        method: "GET",
+        paymentDetails: officialPaymentDetails,
+      });
+      expect(approved).toBe(true);
+      return {
+        status: 200,
+        body: "ok",
+        headers: {},
+        paymentMade: true,
+        amountPaid: "1.25",
+      };
+    });
+
+    const tools = new InfraTools(workspace, daemonMock as Any, "task-official-fields");
+    const result = await tools.executeTool("x402_fetch", {
+      url: "https://trusted.example/data",
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(daemonMock.requestApproval).not.toHaveBeenCalled();
   });
 
   it("blocks x402 requests to hosts outside allowlist", async () => {

--- a/src/electron/infra/infra-manager.ts
+++ b/src/electron/infra/infra-manager.ts
@@ -13,7 +13,12 @@ import { E2BSandboxProvider } from "./providers/e2b-sandbox";
 import { NamecheapDomainsProvider } from "./providers/namecheap-domains";
 import { LocalWalletProvider } from "./providers/local-wallet-provider";
 import { CoinbaseAgenticWalletProvider } from "./providers/coinbase-agentic-wallet-provider";
-import { WalletProvider, WalletProviderKind } from "./providers/wallet-provider";
+import {
+  WalletProvider,
+  WalletProviderKind,
+  X402PaymentApprovalHandler,
+  X402PaymentPolicyEnvelope,
+} from "./providers/wallet-provider";
 
 export class InfraManager {
   private static instance: InfraManager | null = null;
@@ -284,12 +289,23 @@ export class InfraManager {
     return this.walletProvider.x402Check(url);
   }
 
-  async x402Fetch(url: string, opts?: { method?: string; body?: string; headers?: Record<string, string> }) {
+  async x402Fetch(
+    url: string,
+    opts?: {
+      method?: string;
+      body?: string;
+      headers?: Record<string, string>;
+      paymentPolicy?: X402PaymentPolicyEnvelope;
+      approvePayment?: X402PaymentApprovalHandler;
+    },
+  ) {
     return this.walletProvider.x402Fetch({
       url,
       method: opts?.method,
       body: opts?.body,
       headers: opts?.headers,
+      paymentPolicy: opts?.paymentPolicy,
+      approvePayment: opts?.approvePayment,
     });
   }
 

--- a/src/electron/infra/infra-tools.ts
+++ b/src/electron/infra/infra-tools.ts
@@ -10,6 +10,12 @@ import { AgentDaemon } from "../agent/daemon";
 import { LLMTool } from "../agent/llm/types";
 import { InfraManager } from "./infra-manager";
 import { InfraSettingsManager } from "./infra-settings";
+import type {
+  X402CheckResult,
+  X402PaymentChallenge,
+  X402PaymentDetails,
+  X402PaymentPolicyEnvelope,
+} from "./providers/wallet-provider";
 
 export class InfraTools {
   constructor(
@@ -435,6 +441,9 @@ export class InfraTools {
             amount === null ||
             amount > settings.payments.maxAutoApproveUsd;
 
+          let approvedPaymentDetails: X402PaymentDetails | undefined;
+          let preflightApprovedWithoutExactDetails = false;
+
           if (preflight.requires402 && shouldRequireApproval) {
             const payApproved = await this.daemon.requestApproval(
               this.taskId,
@@ -455,12 +464,28 @@ export class InfraTools {
               result = { error: "x402 payment was not approved by the user." };
               break;
             }
+            if (preflight.paymentDetails) {
+              approvedPaymentDetails = preflight.paymentDetails;
+            } else {
+              preflightApprovedWithoutExactDetails = true;
+            }
           }
 
           result = await manager.x402Fetch(args.url, {
             method: args.method,
             body: args.body,
             headers: args.headers,
+            paymentPolicy: this.createX402PaymentPolicy(settings, preflight, {
+              approvedPaymentDetails,
+              effectiveHardLimit,
+            }),
+            approvePayment: async (challenge) =>
+              this.approveX402PaymentChallenge(challenge, settings, {
+                effectiveHardLimit,
+                preflightPaymentDetails: preflight.paymentDetails,
+                approvedPaymentDetails,
+                preflightApprovedWithoutExactDetails,
+              }),
           });
           break;
         }
@@ -519,6 +544,225 @@ export class InfraTools {
       return safeConfiguredLimit;
     }
     return safeConfiguredLimit > 0 ? Math.min(safeConfiguredLimit, envLimit) : envLimit;
+  }
+
+  private createX402PaymentPolicy(
+    settings: InfraSettings,
+    preflight: X402CheckResult,
+    opts: {
+      approvedPaymentDetails?: X402PaymentDetails;
+      effectiveHardLimit: number;
+    },
+  ): X402PaymentPolicyEnvelope {
+    return {
+      policyVersion: 1,
+      effectiveHardLimitUsd: opts.effectiveHardLimit,
+      maxAutoApproveUsd: settings.payments.maxAutoApproveUsd,
+      requireApproval: settings.payments.requireApproval,
+      allowedHosts: [...(settings.payments.allowedHosts || [])],
+      preflight,
+      ...(opts.approvedPaymentDetails
+        ? {
+            approvedPaymentDetails: opts.approvedPaymentDetails,
+            approvedAt: new Date().toISOString(),
+          }
+        : {}),
+    };
+  }
+
+  private async approveX402PaymentChallenge(
+    challenge: X402PaymentChallenge,
+    settings: InfraSettings,
+    opts: {
+      effectiveHardLimit: number;
+      preflightPaymentDetails?: X402PaymentDetails;
+      approvedPaymentDetails?: X402PaymentDetails;
+      preflightApprovedWithoutExactDetails: boolean;
+    },
+  ): Promise<boolean> {
+    this.validateX402PaymentChallenge(challenge, settings, opts.effectiveHardLimit);
+
+    if (opts.preflightPaymentDetails) {
+      const mismatch = this.getPaymentDetailsMismatch(opts.preflightPaymentDetails, challenge.paymentDetails);
+      if (mismatch) {
+        throw new Error(`x402 payment requirement changed after preflight (${mismatch}); refusing to sign.`);
+      }
+    }
+
+    if (opts.approvedPaymentDetails) {
+      const mismatch = this.getPaymentDetailsMismatch(opts.approvedPaymentDetails, challenge.paymentDetails);
+      if (mismatch) {
+        throw new Error(`x402 payment requirement changed after approval (${mismatch}); refusing to sign.`);
+      }
+      return true;
+    }
+
+    const amount = this.extractPaymentDetailsAmount(challenge.paymentDetails);
+    const shouldRequireApproval =
+      settings.payments.requireApproval ||
+      opts.preflightApprovedWithoutExactDetails ||
+      amount === null ||
+      amount > settings.payments.maxAutoApproveUsd;
+
+    if (!shouldRequireApproval) {
+      return true;
+    }
+
+    return await this.daemon.requestApproval(
+      this.taskId,
+      "external_service",
+      this.formatPaymentApprovalMessage(challenge, amount),
+      {
+        tool: "x402_fetch",
+        params: {
+          url: challenge.url,
+          method: challenge.method,
+          paymentDetails: challenge.paymentDetails,
+        },
+        reason: amount !== null ? `x402 payment operation (${amount} USDC)` : "x402 payment operation",
+      },
+      { allowAutoApprove: false },
+    );
+  }
+
+  private validateX402PaymentChallenge(
+    challenge: X402PaymentChallenge,
+    settings: InfraSettings,
+    effectiveHardLimit: number,
+  ): void {
+    const hostError = this.getHostAllowlistError(challenge.url, settings);
+    if (hostError) throw new Error(hostError);
+
+    const details = challenge.paymentDetails;
+    const amount = this.extractPaymentDetailsAmount(details);
+    if (amount === null) {
+      throw new Error("x402 payment amount is missing or invalid; refusing to sign.");
+    }
+    if (amount > effectiveHardLimit) {
+      throw new Error(
+        `x402 payment amount (${amount} USDC) exceeds configured hard limit (${effectiveHardLimit} USDC).`,
+      );
+    }
+    if (!/^0x[a-fA-F0-9]{40}$/.test(String(details.payTo || ""))) {
+      throw new Error("x402 payment recipient is missing or invalid; refusing to sign.");
+    }
+    const currency = String(details.currency || "").toUpperCase();
+    if (currency && currency !== "USDC") {
+      throw new Error(`Unsupported x402 payment currency: ${details.currency || "unknown"}.`);
+    }
+    if (!currency && !details.asset) {
+      throw new Error("x402 payment asset/currency is missing; refusing to sign.");
+    }
+    if (!this.isAllowedPaymentAsset(String(details.asset || ""), settings)) {
+      throw new Error(`Unsupported x402 payment asset: ${details.asset || "unknown"}.`);
+    }
+    if (!this.isAllowedPaymentNetwork(String(details.network || ""), settings)) {
+      throw new Error(`Unsupported x402 payment network: ${details.network || "unknown"}.`);
+    }
+    if (!this.isPaymentResourceAllowed(String(details.resource || ""), challenge.url)) {
+      throw new Error("x402 payment resource does not match the requested URL; refusing to sign.");
+    }
+    if (typeof details.expires === "number" && details.expires <= Math.floor(Date.now() / 1000)) {
+      throw new Error("x402 payment requirement is expired; refusing to sign.");
+    }
+  }
+
+  private extractPaymentDetailsAmount(details: X402PaymentDetails | undefined): number | null {
+    const amount =
+      details?.amount !== undefined
+        ? Number(details.amount)
+        : this.extractAtomicUsdcAmount(details?.maxAmountRequired);
+    if (!Number.isFinite(amount) || amount < 0) return null;
+    return amount;
+  }
+
+  private extractAtomicUsdcAmount(rawAmount: unknown): number {
+    if (typeof rawAmount !== "string" || !/^\d+$/.test(rawAmount)) return Number.NaN;
+    return Number(rawAmount) / 1_000_000;
+  }
+
+  private getPaymentDetailsMismatch(
+    approved: X402PaymentDetails,
+    actual: X402PaymentDetails,
+  ): string | null {
+    const fields: Array<keyof X402PaymentDetails> = [
+      "scheme",
+      "payTo",
+      "amount",
+      "maxAmountRequired",
+      "currency",
+      "asset",
+      "network",
+      "resource",
+      "expires",
+    ];
+    for (const field of fields) {
+      const approvedValue = approved[field];
+      const actualValue = actual[field];
+      if (String(approvedValue ?? "") !== String(actualValue ?? "")) {
+        return `${field} mismatch`;
+      }
+    }
+    return null;
+  }
+
+  private formatPaymentApprovalMessage(challenge: X402PaymentChallenge, amount: number | null): string {
+    const details = challenge.paymentDetails;
+    const displayAmount = amount !== null ? `${amount} USDC` : "unknown amount";
+    return (
+      `Make an x402 payment request to "${challenge.url}"? ` +
+      `Amount: ${displayAmount}. ` +
+      `Recipient: ${details.payTo || "unknown"}. ` +
+      `Resource: ${details.resource || "unknown"}. ` +
+      `Network: ${details.network || "unknown"}. ` +
+      `Currency: ${details.currency || "USDC"}. ` +
+      `Asset: ${details.asset || "legacy currency field"}.`
+    );
+  }
+
+  private isAllowedPaymentNetwork(network: string, settings: InfraSettings): boolean {
+    const normalized = network.trim().toLowerCase();
+    if (settings.wallet.provider === "coinbase_agentic") {
+      const configured = settings.wallet.coinbase.network;
+      return (
+        normalized === "base" ||
+        normalized === configured ||
+        (configured === "base-mainnet" && normalized === "eip155:8453") ||
+        (configured === "base-sepolia" && normalized === "eip155:84532")
+      );
+    }
+    return normalized === "base" || normalized === "base-mainnet" || normalized === "eip155:8453";
+  }
+
+  private isAllowedPaymentAsset(asset: string, settings: InfraSettings): boolean {
+    if (!asset) return true;
+    const normalized = asset.trim().toLowerCase();
+    const mainnetUsdc = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+    const sepoliaUsdc = "0x036cbd53842c5426634e7929541ec2318f3dcf7e";
+    if (settings.wallet.provider === "coinbase_agentic") {
+      return settings.wallet.coinbase.network === "base-sepolia"
+        ? normalized === sepoliaUsdc
+        : normalized === mainnetUsdc;
+    }
+    return normalized === mainnetUsdc;
+  }
+
+  private isPaymentResourceAllowed(resource: string, requestUrl: string): boolean {
+    if (!resource) return false;
+    let parsedRequest: URL;
+    try {
+      parsedRequest = new URL(requestUrl);
+    } catch {
+      return false;
+    }
+
+    try {
+      const parsedResource = new URL(resource);
+      return parsedResource.origin === parsedRequest.origin && parsedResource.href === parsedRequest.href;
+    } catch {
+      const pathWithSearch = `${parsedRequest.pathname}${parsedRequest.search}`;
+      return resource === parsedRequest.pathname || resource === pathWithSearch;
+    }
   }
 
   private getHostAllowlistError(url: string, settings: InfraSettings): string | null {

--- a/src/electron/infra/providers/__tests__/coinbase-agentic-wallet-provider.test.ts
+++ b/src/electron/infra/providers/__tests__/coinbase-agentic-wallet-provider.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_INFRA_SETTINGS, InfraSettings } from "../../../../shared/types";
+import { CoinbaseAgenticWalletProvider } from "../coinbase-agentic-wallet-provider";
+
+function cloneInfraSettings(): InfraSettings {
+  return {
+    ...DEFAULT_INFRA_SETTINGS,
+    e2b: { ...DEFAULT_INFRA_SETTINGS.e2b },
+    domains: { ...DEFAULT_INFRA_SETTINGS.domains },
+    wallet: {
+      ...DEFAULT_INFRA_SETTINGS.wallet,
+      provider: "coinbase_agentic",
+      coinbase: {
+        ...DEFAULT_INFRA_SETTINGS.wallet.coinbase,
+        enabled: true,
+        signerEndpoint: "https://signer.example",
+      },
+    },
+    payments: {
+      ...DEFAULT_INFRA_SETTINGS.payments,
+      allowedHosts: [...DEFAULT_INFRA_SETTINGS.payments.allowedHosts],
+    },
+    enabledCategories: { ...DEFAULT_INFRA_SETTINGS.enabledCategories },
+  };
+}
+
+describe("CoinbaseAgenticWalletProvider", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards the x402 payment policy envelope to the remote signer", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new CoinbaseAgenticWalletProvider();
+    await provider.applySettings(cloneInfraSettings());
+
+    const paymentPolicy = {
+      policyVersion: 1 as const,
+      effectiveHardLimitUsd: 100,
+      maxAutoApproveUsd: 1,
+      requireApproval: true,
+      allowedHosts: ["paid.example"],
+      preflight: {
+        requires402: true,
+        url: "https://paid.example/data",
+      },
+    };
+
+    await provider.x402Fetch({
+      url: "https://paid.example/data",
+      paymentPolicy,
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.paymentPolicy).toEqual(paymentPolicy);
+  });
+
+  it("rejects paid signer responses that do not confirm policy enforcement", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            status: 200,
+            body: "ok",
+            headers: {},
+            paymentMade: true,
+            amountPaid: "1",
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new CoinbaseAgenticWalletProvider();
+    await provider.applySettings(cloneInfraSettings());
+
+    await expect(
+      provider.x402Fetch({
+        url: "https://paid.example/data",
+        paymentPolicy: {
+          policyVersion: 1,
+          effectiveHardLimitUsd: 100,
+          maxAutoApproveUsd: 1,
+          requireApproval: false,
+          allowedHosts: ["paid.example"],
+        },
+      }),
+    ).rejects.toThrow(/did not confirm x402 payment policy enforcement/i);
+  });
+
+  it("accepts paid signer responses only when returned details match the policy", async () => {
+    const paymentDetails = {
+      payTo: "0x000000000000000000000000000000000000dEaD",
+      amount: "1",
+      currency: "USDC",
+      network: "base",
+      resource: "/data",
+    };
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            status: 200,
+            body: "ok",
+            headers: {},
+            paymentMade: true,
+            amountPaid: "1",
+            paymentPolicyEnforced: true,
+            paymentDetails,
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new CoinbaseAgenticWalletProvider();
+    await provider.applySettings(cloneInfraSettings());
+
+    await expect(
+      provider.x402Fetch({
+        url: "https://paid.example/data",
+        paymentPolicy: {
+          policyVersion: 1,
+          effectiveHardLimitUsd: 100,
+          maxAutoApproveUsd: 1,
+          requireApproval: true,
+          allowedHosts: ["paid.example"],
+          approvedPaymentDetails: paymentDetails,
+        },
+      }),
+    ).resolves.toMatchObject({ paymentMade: true, paymentPolicyEnforced: true });
+  });
+});

--- a/src/electron/infra/providers/__tests__/local-wallet-provider.test.ts
+++ b/src/electron/infra/providers/__tests__/local-wallet-provider.test.ts
@@ -85,10 +85,13 @@ describe("LocalWalletProvider", () => {
       headers: { "x-test": "1" },
     });
 
-    expect(hoisted.x402Client.fetchWithPayment).toHaveBeenCalledWith("https://paid.example/data", {
-      method: "POST",
-      body: "{\"q\":1}",
-      headers: { "x-test": "1" },
-    });
+    expect(hoisted.x402Client.fetchWithPayment).toHaveBeenCalledWith(
+      "https://paid.example/data",
+      expect.objectContaining({
+        method: "POST",
+        body: "{\"q\":1}",
+        headers: { "x-test": "1" },
+      }),
+    );
   });
 });

--- a/src/electron/infra/providers/__tests__/x402-client.test.ts
+++ b/src/electron/infra/providers/__tests__/x402-client.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { X402Client } from "../x402-client";
+
+function paymentHeader(amount: string): string {
+  return Buffer.from(
+    JSON.stringify({
+      payTo: "0x000000000000000000000000000000000000dEaD",
+      amount,
+      currency: "USDC",
+      network: "base",
+      resource: "/paid",
+    }),
+  ).toString("base64");
+}
+
+describe("X402Client", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requires approval of the real payment challenge before signing and retrying", async () => {
+    const client = new X402Client();
+    client.setWallet(
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "0x0000000000000000000000000000000000000001",
+    );
+
+    const fetchMock = vi.fn(async () => {
+      return new Response("", {
+        status: 402,
+        headers: { "payment-required": paymentHeader("10") },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      client.fetchWithPayment("https://trusted.example/paid", {
+        approvePayment: () => false,
+      }),
+    ).rejects.toThrow(/not approved by policy/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses paid signing when no approval handler is provided", async () => {
+    const client = new X402Client();
+    client.setWallet(
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "0x0000000000000000000000000000000000000001",
+    );
+
+    const fetchMock = vi.fn(async () => {
+      return new Response("", {
+        status: 402,
+        headers: { "payment-required": paymentHeader("10") },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(client.fetchWithPayment("https://trusted.example/paid")).rejects.toThrow(
+      /approval handler is required/i,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not require an approval handler when no payment is requested", async () => {
+    const client = new X402Client();
+    client.setWallet(
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "0x0000000000000000000000000000000000000001",
+    );
+
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("free", { status: 200 })));
+
+    await expect(client.fetchWithPayment("https://trusted.example/free")).resolves.toMatchObject({
+      paymentMade: false,
+      body: "free",
+    });
+  });
+
+  it("signs the actual challenge amount after approval", async () => {
+    const client = new X402Client();
+    client.setWallet(
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "0x0000000000000000000000000000000000000001",
+    );
+
+    const seenSignatures: string[] = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const signature = init?.headers && (init.headers as Record<string, string>)["payment-signature"];
+      if (!signature) {
+        return new Response("", {
+          status: 402,
+          headers: { "payment-required": paymentHeader("2") },
+        });
+      }
+      seenSignatures.push(signature);
+      return new Response("ok", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await client.fetchWithPayment("https://trusted.example/paid", {
+      approvePayment: ({ paymentDetails }) => paymentDetails.amount === "2",
+    });
+
+    expect(result.paymentMade).toBe(true);
+    expect(result.amountPaid).toBe("2");
+    const signedPayload = JSON.parse(Buffer.from(seenSignatures[0], "base64").toString("utf8"));
+    expect(signedPayload.amount).toBe("2000000");
+  });
+});

--- a/src/electron/infra/providers/coinbase-agentic-wallet-provider.ts
+++ b/src/electron/infra/providers/coinbase-agentic-wallet-provider.ts
@@ -6,6 +6,8 @@ import {
   X402CheckResult,
   X402FetchRequest,
   X402FetchResult,
+  X402PaymentDetails,
+  X402PaymentPolicyEnvelope,
 } from "./wallet-provider";
 
 interface CoinbaseWalletStatusResponse {
@@ -97,7 +99,11 @@ export class CoinbaseAgenticWalletProvider implements WalletProvider {
 
   async x402Fetch(req: X402FetchRequest): Promise<X402FetchResult> {
     this.ensureConfigured();
-    return this.callJson<X402FetchResult>("/x402/fetch", {
+    if (!req.paymentPolicy) {
+      throw new Error("Coinbase x402 fetch requires a payment policy envelope");
+    }
+
+    const result = await this.callJson<X402FetchResult>("/x402/fetch", {
       method: "POST",
       body: {
         url: req.url,
@@ -106,8 +112,11 @@ export class CoinbaseAgenticWalletProvider implements WalletProvider {
         headers: req.headers,
         accountId: this.accountId,
         network: this.network,
+        paymentPolicy: req.paymentPolicy,
       },
     });
+    this.validateSignerPaymentResult(result, req.paymentPolicy);
+    return result;
   }
 
   private async fetchRemoteStatus(): Promise<CoinbaseWalletStatusResponse> {
@@ -159,5 +168,101 @@ export class CoinbaseAgenticWalletProvider implements WalletProvider {
     }
 
     return (await response.json()) as T;
+  }
+
+  private validateSignerPaymentResult(
+    result: X402FetchResult,
+    policy: X402PaymentPolicyEnvelope,
+  ): void {
+    if (!result.paymentMade) return;
+
+    if (result.paymentPolicyEnforced !== true) {
+      throw new Error("Coinbase signer did not confirm x402 payment policy enforcement");
+    }
+    if (!result.paymentDetails) {
+      throw new Error("Coinbase signer did not return signed x402 payment details");
+    }
+
+    const amount = this.extractPaymentAmount(result.paymentDetails);
+    if (amount === null) {
+      throw new Error("Coinbase signer returned invalid x402 payment amount");
+    }
+    if (amount > policy.effectiveHardLimitUsd) {
+      throw new Error(
+        `Coinbase signer payment amount (${amount} USDC) exceeds policy hard limit (${policy.effectiveHardLimitUsd} USDC)`,
+      );
+    }
+    if (!this.isAllowedPaymentNetwork(String(result.paymentDetails.network || ""))) {
+      throw new Error(`Coinbase signer returned unsupported x402 network: ${result.paymentDetails.network}`);
+    }
+    if (!this.isAllowedPaymentAsset(result.paymentDetails)) {
+      throw new Error(`Coinbase signer returned unsupported x402 asset: ${result.paymentDetails.asset || "unknown"}`);
+    }
+    if (policy.requireApproval && !policy.approvedPaymentDetails) {
+      throw new Error("Coinbase signer made an x402 payment without exact approved payment details");
+    }
+
+    const expected = policy.approvedPaymentDetails || policy.preflight?.paymentDetails;
+    if (expected) {
+      const mismatch = this.getPaymentDetailsMismatch(expected, result.paymentDetails);
+      if (mismatch) {
+        throw new Error(`Coinbase signer payment details do not match approved policy (${mismatch})`);
+      }
+    }
+  }
+
+  private extractPaymentAmount(details: X402PaymentDetails): number | null {
+    const amount =
+      details.amount !== undefined
+        ? Number(details.amount)
+        : typeof details.maxAmountRequired === "string" && /^\d+$/.test(details.maxAmountRequired)
+          ? Number(details.maxAmountRequired) / 1_000_000
+          : Number.NaN;
+    return Number.isFinite(amount) && amount >= 0 ? amount : null;
+  }
+
+  private isAllowedPaymentNetwork(network: string): boolean {
+    const normalized = network.trim().toLowerCase();
+    return (
+      normalized === "base" ||
+      normalized === this.network ||
+      (this.network === "base-mainnet" && normalized === "eip155:8453") ||
+      (this.network === "base-sepolia" && normalized === "eip155:84532")
+    );
+  }
+
+  private isAllowedPaymentAsset(details: X402PaymentDetails): boolean {
+    const currency = String(details.currency || "").toUpperCase();
+    if (currency && currency !== "USDC") return false;
+    if (!currency && !details.asset) return false;
+    if (!details.asset) return true;
+
+    const normalized = String(details.asset).trim().toLowerCase();
+    const mainnetUsdc = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+    const sepoliaUsdc = "0x036cbd53842c5426634e7929541ec2318f3dcf7e";
+    return this.network === "base-sepolia" ? normalized === sepoliaUsdc : normalized === mainnetUsdc;
+  }
+
+  private getPaymentDetailsMismatch(
+    expected: X402PaymentDetails,
+    actual: X402PaymentDetails,
+  ): string | null {
+    const fields: Array<keyof X402PaymentDetails> = [
+      "scheme",
+      "payTo",
+      "amount",
+      "maxAmountRequired",
+      "currency",
+      "asset",
+      "network",
+      "resource",
+      "expires",
+    ];
+    for (const field of fields) {
+      if (String(expected[field] ?? "") !== String(actual[field] ?? "")) {
+        return `${field} mismatch`;
+      }
+    }
+    return null;
   }
 }

--- a/src/electron/infra/providers/local-wallet-provider.ts
+++ b/src/electron/infra/providers/local-wallet-provider.ts
@@ -80,6 +80,11 @@ export class LocalWalletProvider implements WalletProvider {
       method: req.method,
       body: req.body,
       headers: req.headers,
+      approvePayment:
+        req.approvePayment ??
+        (() => {
+          throw new Error("x402 payment policy approval handler is required before signing.");
+        }),
     });
   }
 

--- a/src/electron/infra/providers/wallet-provider.ts
+++ b/src/electron/infra/providers/wallet-provider.ts
@@ -3,13 +3,18 @@ import { InfraSettings } from "../../../shared/types";
 export type WalletProviderKind = "local" | "coinbase_agentic";
 
 export interface X402PaymentDetails {
+  scheme?: string;
   payTo: string;
-  amount: string;
-  currency: string;
+  amount?: string;
+  maxAmountRequired?: string;
+  currency?: string;
+  asset?: string;
   network: string;
   resource: string;
   description?: string;
+  mimeType?: string;
   expires?: number;
+  [key: string]: unknown;
 }
 
 export interface X402CheckResult {
@@ -23,6 +28,8 @@ export interface X402FetchRequest {
   method?: string;
   body?: string;
   headers?: Record<string, string>;
+  paymentPolicy?: X402PaymentPolicyEnvelope;
+  approvePayment?: X402PaymentApprovalHandler;
 }
 
 export interface X402FetchResult {
@@ -31,7 +38,30 @@ export interface X402FetchResult {
   headers: Record<string, string>;
   paymentMade: boolean;
   amountPaid?: string;
+  paymentDetails?: X402PaymentDetails;
+  paymentPolicyEnforced?: boolean;
 }
+
+export interface X402PaymentPolicyEnvelope {
+  policyVersion: 1;
+  effectiveHardLimitUsd: number;
+  maxAutoApproveUsd: number;
+  requireApproval: boolean;
+  allowedHosts: string[];
+  preflight?: X402CheckResult;
+  approvedPaymentDetails?: X402PaymentDetails;
+  approvedAt?: string;
+}
+
+export interface X402PaymentChallenge {
+  url: string;
+  method: string;
+  paymentDetails: X402PaymentDetails;
+}
+
+export type X402PaymentApprovalHandler = (
+  challenge: X402PaymentChallenge,
+) => Promise<boolean> | boolean;
 
 export interface WalletProviderStatus {
   kind: WalletProviderKind;

--- a/src/electron/infra/providers/x402-client.ts
+++ b/src/electron/infra/providers/x402-client.ts
@@ -9,29 +9,18 @@
 
 import * as crypto from "crypto";
 import { ethers } from "ethers";
+import type {
+  X402FetchResult,
+  X402PaymentApprovalHandler,
+  X402PaymentDetails,
+  X402CheckResult,
+} from "./wallet-provider";
 
-interface PaymentDetails {
-  payTo: string;
-  amount: string;
-  currency: string;
-  network: string;
-  resource: string;
-  description?: string;
-  expires?: number;
-}
-
-interface X402CheckResult {
-  requires402: boolean;
-  paymentDetails?: PaymentDetails;
-  url: string;
-}
-
-interface X402FetchResult {
-  status: number;
-  body: string;
-  headers: Record<string, string>;
-  paymentMade: boolean;
-  amountPaid?: string;
+interface X402FetchWithPaymentOptions {
+  method?: string;
+  body?: string;
+  headers?: Record<string, string>;
+  approvePayment?: X402PaymentApprovalHandler;
 }
 
 // EIP-712 domain for x402 payment signing
@@ -91,14 +80,14 @@ export class X402Client {
    */
   async fetchWithPayment(
     url: string,
-    opts?: { method?: string; body?: string; headers?: Record<string, string> },
+    opts?: X402FetchWithPaymentOptions,
   ): Promise<X402FetchResult> {
     if (!this.privateKey || !this.address) {
       throw new Error("Wallet not configured for x402 payments");
     }
 
     const method = opts?.method || "GET";
-    const headers: Record<string, string> = { ...opts?.headers };
+    const headers: Record<string, string> = this.sanitizeRequestHeaders(opts?.headers);
 
     // First request
     const initialResponse = await fetch(url, { method, headers, body: opts?.body });
@@ -125,6 +114,14 @@ export class X402Client {
       throw new Error("Failed to parse PAYMENT-REQUIRED header");
     }
 
+    if (!opts?.approvePayment) {
+      throw new Error("x402 payment policy approval handler is required before signing.");
+    }
+    const approved = await opts.approvePayment({ url, method, paymentDetails });
+    if (!approved) {
+      throw new Error("x402 payment was not approved by policy.");
+    }
+
     // Sign the payment intent
     const signature = await this.signPaymentIntent(paymentDetails);
 
@@ -141,6 +138,8 @@ export class X402Client {
       headers: this.responseHeadersToRecord(paidResponse.headers),
       paymentMade: true,
       amountPaid: paymentDetails.amount,
+      paymentDetails,
+      paymentPolicyEnforced: true,
     };
   }
 
@@ -165,29 +164,33 @@ export class X402Client {
 
   // --- Private helpers ---
 
-  private parsePaymentHeader(header: string): PaymentDetails | undefined {
+  private parsePaymentHeader(header: string): X402PaymentDetails | undefined {
     try {
       // x402 header is base64-encoded JSON
       const decoded = Buffer.from(header, "base64").toString("utf-8");
-      return JSON.parse(decoded) as PaymentDetails;
+      return JSON.parse(decoded) as X402PaymentDetails;
     } catch {
       try {
         // Try parsing as plain JSON
-        return JSON.parse(header) as PaymentDetails;
+        return JSON.parse(header) as X402PaymentDetails;
       } catch {
         return undefined;
       }
     }
   }
 
-  private async signPaymentIntent(details: PaymentDetails): Promise<string> {
+  private async signPaymentIntent(details: X402PaymentDetails): Promise<string> {
     if (!this.privateKey) throw new Error("No private key for signing");
 
     const wallet = new ethers.Wallet(this.privateKey);
+    const amount = this.getDecimalAmount(details);
+    if (amount === null) {
+      throw new Error("x402 payment amount is missing or invalid; refusing to sign.");
+    }
 
     const value = {
       payTo: details.payTo,
-      amount: ethers.parseUnits(details.amount, 6).toString(), // USDC 6 decimals
+      amount: ethers.parseUnits(amount, 6).toString(), // USDC 6 decimals
       resource: details.resource,
       nonce: Date.now() * 1000 + crypto.randomInt(1000),
       expires: details.expires || Math.floor(Date.now() / 1000) + 300, // 5 min
@@ -206,5 +209,30 @@ export class X402Client {
       record[key] = value;
     });
     return record;
+  }
+
+  private sanitizeRequestHeaders(headers?: Record<string, string>): Record<string, string> {
+    const sanitized: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers || {})) {
+      const normalized = key.toLowerCase();
+      if (normalized === "payment-signature" || normalized === "payment-address") {
+        continue;
+      }
+      sanitized[key] = value;
+    }
+    return sanitized;
+  }
+
+  private getDecimalAmount(details: X402PaymentDetails): string | null {
+    if (typeof details.amount === "string" && Number.isFinite(Number(details.amount))) {
+      return details.amount;
+    }
+    if (
+      typeof details.maxAmountRequired === "string" &&
+      /^\d+$/.test(details.maxAmountRequired)
+    ) {
+      return ethers.formatUnits(details.maxAmountRequired, 6);
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

Fixes the x402 payment approval bypass reported in #146 by treating HEAD preflight as advisory and enforcing policy on the real 402 payment challenge before signing.

## What changed

- Adds a payment approval callback at the local x402 signing boundary.
- Validates amount, hard limit, recipient, network, asset/currency, resource, expiry, and preflight/approval mismatches before signing.
- Requires exact real/preflight payment detail matching whenever preflight details exist, including auto-approved flows.
- Fails closed when the exported local x402 client is asked to sign a paid challenge without a policy handler.
- Sends a versioned `paymentPolicy` envelope to Coinbase remote signers and rejects paid responses unless the signer confirms enforcement and returns exact signed payment details.
- Updates Coinbase signer contract docs for the new policy and response requirements.
- Adds focused regression coverage for cheap/no HEAD preflight, real challenge approval, mismatch rejection, local client signing, and remote signer enforcement confirmation.

## Root Cause

The previous flow enforced user approval and hard limits against a HEAD preflight result, but the wallet signed payment details parsed from a separate real GET/POST 402 response. A server could therefore return a cheap or empty HEAD requirement and a different real payment requirement.

## Validation

- `npx vitest run src/electron/infra/__tests__/infra-tools-payments.test.ts src/electron/infra/providers/__tests__/local-wallet-provider.test.ts src/electron/infra/providers/__tests__/x402-client.test.ts src/electron/infra/providers/__tests__/coinbase-agentic-wallet-provider.test.ts`
- `npm run build:electron`
- `git diff --check -- docs/coinbase-agentic-signer.md src/electron/infra src/electron/infra/providers`
