### PR TITLE
[codex] fix OpenCode Go Qwen 3.7 Max routing

### DIFF
--- a/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
+++ b/src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts
@@ -344,6 +344,211 @@ describe("LLMProviderFactory custom provider config resolution", () => {
     );
   });
 
+  it("routes OpenCode Go Qwen 3.7 Max through the Anthropic Messages API", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+      }),
+    } as Response);
+
+    const provider = LLMProviderFactory.createProviderFromConfig({
+      type: "opencode",
+      model: "opencode-go/qwen3.7-max",
+      providerApiKey: "opencode-go-key",
+      providerBaseUrl: "https://opencode.ai/zen/go/v1/chat/completions",
+    } as Any);
+
+    await expect(
+      provider.createMessage({
+        model: "opencode-go/qwen3.7-max",
+        system: "Use tools when useful.",
+        maxTokens: 4096,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text: "ok" }],
+      stopReason: "end_turn",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://opencode.ai/zen/go/v1/messages",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "anthropic-version": "2023-06-01",
+          "x-api-key": "opencode-go-key",
+          Authorization: "Bearer opencode-go-key",
+        }),
+      }),
+    );
+
+    const body = JSON.parse(
+      String(fetchSpy.mock.calls[0]?.[1]?.body || "{}"),
+    );
+    expect(body).toMatchObject({
+      model: "qwen3.7-max",
+      max_tokens: 4096,
+      system: "Use tools when useful.",
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    expect(body.max_completion_tokens).toBeUndefined();
+  });
+
+  it("routes bare OpenCode Go Qwen 3.7 Max connection tests through the Anthropic Messages API", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+      }),
+    } as Response);
+
+    const provider = LLMProviderFactory.createProviderFromConfig({
+      type: "opencode",
+      model: "qwen3.7-max",
+      providerApiKey: "opencode-go-key",
+      providerBaseUrl: "https://opencode.ai/zen/go/v1/chat/completions",
+    } as Any);
+
+    await expect(provider.testConnection()).resolves.toEqual({
+      success: true,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://opencode.ai/zen/go/v1/messages",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-api-key": "opencode-go-key",
+        }),
+      }),
+    );
+
+    const body = JSON.parse(
+      String(fetchSpy.mock.calls[0]?.[1]?.body || "{}"),
+    );
+    expect(body).toMatchObject({
+      model: "qwen3.7-max",
+      max_tokens: 10,
+      messages: [{ role: "user", content: "Hi" }],
+    });
+  });
+
+  it("routes generic OpenAI-compatible OpenCode Go Qwen 3.7 Max through Anthropic Messages", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+      }),
+    } as Response);
+
+    const provider = LLMProviderFactory.createProviderFromConfig({
+      type: "openai-compatible",
+      model: "opencode-go/qwen3.7-max",
+      openaiCompatibleApiKey: "opencode-go-key",
+      openaiCompatibleBaseUrl: "https://opencode.ai/zen/go/v1/chat/completions",
+    } as Any);
+
+    await expect(
+      provider.createMessage({
+        model: "opencode-go/qwen3.7-max",
+        system: "Use tools when useful.",
+        maxTokens: 4096,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://opencode.ai/zen/go/v1/messages",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-api-key": "opencode-go-key",
+        }),
+      }),
+    );
+  });
+
+  it("routes OpenCode Go request model overrides through the matching API surface", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+      }),
+    } as Response);
+
+    const kimiDefaultProvider = LLMProviderFactory.createProviderFromConfig({
+      type: "opencode",
+      model: "opencode-go/kimi-k2.6",
+      providerApiKey: "opencode-go-key",
+      providerBaseUrl: "https://opencode.ai/zen/go/v1/chat/completions",
+    } as Any);
+
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+      }),
+    } as Response);
+
+    await expect(
+      kimiDefaultProvider.createMessage({
+        model: "opencode-go/qwen3.7-max",
+        system: "Use tools when useful.",
+        maxTokens: 4096,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://opencode.ai/zen/go/v1/messages",
+    );
+    expect(
+      JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body || "{}")),
+    ).toMatchObject({ model: "qwen3.7-max" });
+
+    fetchSpy.mockClear();
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+      }),
+    } as Response);
+
+    const qwenDefaultProvider = LLMProviderFactory.createProviderFromConfig({
+      type: "opencode",
+      model: "opencode-go/qwen3.7-max",
+      providerApiKey: "opencode-go-key",
+      providerBaseUrl: "https://opencode.ai/zen/go/v1/chat/completions",
+    } as Any);
+
+    await expect(
+      qwenDefaultProvider.createMessage({
+        model: "opencode-go/kimi-k2.6",
+        system: "Use tools when useful.",
+        maxTokens: 4096,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://opencode.ai/zen/go/v1/chat/completions",
+    );
+    expect(
+      JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body || "{}")),
+    ).toMatchObject({ model: "kimi-k2.6" });
+  });
+
   it("adapts OpenCode Go Kimi tool turns to the raw chat completions API", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,

--- a/src/electron/agent/llm/anthropic-compatible-provider.ts
+++ b/src/electron/agent/llm/anthropic-compatible-provider.ts
@@ -17,6 +17,10 @@ import {
   isPromptCacheAutoUnsupportedError,
   normalizeSystemBlocks,
 } from "./prompt-cache";
+import {
+  isOpenCodeGoBaseUrl,
+  normalizeOpenCodeGoModelId,
+} from "./opencode-go-routing";
 
 const ANTHROPIC_VERSION = "2023-06-01";
 
@@ -101,9 +105,22 @@ export class AnthropicCompatibleProvider implements LLMProvider {
     this.managedPromptCacheSupported = !isNanoGptBaseUrl(options.baseUrl);
   }
 
+  private normalizeModelForEndpoint(model: string): string {
+    const trimmed = model.trim();
+    if (
+      isOpenCodeGoBaseUrl(this.baseUrl) &&
+      trimmed.toLowerCase().startsWith("opencode-go/")
+    ) {
+      return normalizeOpenCodeGoModelId(trimmed);
+    }
+    return trimmed;
+  }
+
   async createMessage(request: LLMRequest): Promise<LLMResponse> {
     const tools = request.tools ? this.convertTools(request.tools) : undefined;
-    const model = request.model || this.defaultModel;
+    const model = this.normalizeModelForEndpoint(
+      request.model || this.defaultModel,
+    );
     const normalizedMessages = assertNormalizedTurnTranscript(
       request.messages,
       (message) => console.warn(`[${this.providerName}] ${message}`),
@@ -142,6 +159,7 @@ export class AnthropicCompatibleProvider implements LLMProvider {
 
   async testConnection(): Promise<{ success: boolean; error?: string }> {
     try {
+      const model = this.normalizeModelForEndpoint(this.defaultModel);
       const response = await fetch(this.messagesUrl, {
         method: "POST",
         headers: {
@@ -155,7 +173,7 @@ export class AnthropicCompatibleProvider implements LLMProvider {
             : {}),
         },
         body: JSON.stringify({
-          model: this.defaultModel,
+          model,
           max_tokens: 10,
           messages: [{ role: "user", content: "Hi" }],
         }),

--- a/src/electron/agent/llm/opencode-go-provider.ts
+++ b/src/electron/agent/llm/opencode-go-provider.ts
@@ -1,0 +1,58 @@
+import { AnthropicCompatibleProvider } from "./anthropic-compatible-provider";
+import { OpenAICompatibleProvider } from "./openai-compatible-provider";
+import {
+  LLMProvider,
+  LLMProviderType,
+  LLMRequest,
+  LLMResponse,
+} from "./types";
+import {
+  isOpenCodeGoAnthropicMessagesModel,
+  normalizeOpenCodeGoAnthropicBaseUrl,
+  normalizeOpenCodeGoModelId,
+} from "./opencode-go-routing";
+
+export interface OpenCodeGoProviderOptions {
+  type: LLMProviderType;
+  providerName: string;
+  apiKey: string;
+  baseUrl: string;
+  defaultModel: string;
+}
+
+export class OpenCodeGoProvider implements LLMProvider {
+  readonly type: LLMProviderType;
+  private defaultModel: string;
+  private openaiProvider: OpenAICompatibleProvider;
+  private anthropicProvider: AnthropicCompatibleProvider;
+
+  constructor(options: OpenCodeGoProviderOptions) {
+    this.type = options.type;
+    this.defaultModel = options.defaultModel;
+    this.openaiProvider = new OpenAICompatibleProvider(options);
+    this.anthropicProvider = new AnthropicCompatibleProvider({
+      ...options,
+      baseUrl: normalizeOpenCodeGoAnthropicBaseUrl(options.baseUrl),
+      defaultModel: normalizeOpenCodeGoModelId(options.defaultModel),
+    });
+  }
+
+  async createMessage(request: LLMRequest): Promise<LLMResponse> {
+    const model = request.model || this.defaultModel;
+    if (!isOpenCodeGoAnthropicMessagesModel(model)) {
+      return this.openaiProvider.createMessage(request);
+    }
+
+    return this.anthropicProvider.createMessage({
+      ...request,
+      model: normalizeOpenCodeGoModelId(model),
+    });
+  }
+
+  async testConnection(): Promise<{ success: boolean; error?: string }> {
+    if (isOpenCodeGoAnthropicMessagesModel(this.defaultModel)) {
+      return this.anthropicProvider.testConnection();
+    }
+    return this.openaiProvider.testConnection();
+  }
+}

--- a/src/electron/agent/llm/opencode-go-routing.ts
+++ b/src/electron/agent/llm/opencode-go-routing.ts
@@ -1,0 +1,41 @@
+export function isOpenCodeGoBaseUrl(baseUrl: string): boolean {
+  const trimmed = baseUrl.trim();
+  try {
+    const url = new URL(trimmed);
+    return (
+      url.hostname.toLowerCase() === "opencode.ai" &&
+      /\/zen\/go(?:\/|$)/i.test(url.pathname)
+    );
+  } catch {
+    return trimmed.toLowerCase().includes("opencode.ai/zen/go/");
+  }
+}
+
+export function normalizeOpenCodeGoModelId(model: string): string {
+  const trimmed = model.trim();
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("opencode-go/")) {
+    return trimmed.slice("opencode-go/".length);
+  }
+  return trimmed;
+}
+
+export function isOpenCodeGoAnthropicMessagesModel(model: string): boolean {
+  const normalized = normalizeOpenCodeGoModelId(model).toLowerCase();
+  const withoutVariant = normalized.includes(":")
+    ? normalized.slice(0, normalized.indexOf(":"))
+    : normalized;
+  return withoutVariant === "qwen3.7-max";
+}
+
+export function normalizeOpenCodeGoAnthropicBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, "");
+  const lower = trimmed.toLowerCase();
+  if (lower.endsWith("/chat/completions")) {
+    return trimmed.slice(0, -"/chat/completions".length);
+  }
+  if (lower.endsWith("/models")) {
+    return trimmed.slice(0, -"/models".length);
+  }
+  return trimmed;
+}

--- a/src/electron/agent/llm/provider-factory.ts
+++ b/src/electron/agent/llm/provider-factory.ts
@@ -38,7 +38,9 @@ import { DeepSeekProvider } from "./deepseek-provider";
 import { PiProvider } from "./pi-provider";
 import { AnthropicCompatibleProvider } from "./anthropic-compatible-provider";
 import { OpenAICompatibleProvider } from "./openai-compatible-provider";
+import { OpenCodeGoProvider } from "./opencode-go-provider";
 import { GitHubCopilotProvider } from "./github-copilot-provider";
+import { isOpenCodeGoBaseUrl } from "./opencode-go-routing";
 import { SecureSettingsRepository } from "../../database/SecureSettingsRepository";
 import {
   CUSTOM_PROVIDER_CATALOG,
@@ -505,6 +507,16 @@ function createCustomProvider(
     throw new Error(
       `${entry.name} model is required. Configure it in Settings.`,
     );
+  }
+
+  if (resolvedType === "opencode" && isOpenCodeGoBaseUrl(baseUrl)) {
+    return new OpenCodeGoProvider({
+      type: resolvedType,
+      providerName: entry.name,
+      apiKey,
+      baseUrl,
+      defaultModel: model,
+    });
   }
 
   if (entry.compatibility === "openai") {
@@ -2257,15 +2269,21 @@ export class LLMProviderFactory {
       case "pi":
         provider = new PiProvider(config);
         break;
-      case "openai-compatible":
-        provider = new OpenAICompatibleProvider({
+      case "openai-compatible": {
+        const baseUrl =
+          config.openaiCompatibleBaseUrl || "http://localhost:1234/v1";
+        const ProviderClass = isOpenCodeGoBaseUrl(baseUrl)
+          ? OpenCodeGoProvider
+          : OpenAICompatibleProvider;
+        provider = new ProviderClass({
           type: "openai-compatible",
           providerName: "OpenAI-Compatible",
           apiKey: config.openaiCompatibleApiKey || "",
-          baseUrl: config.openaiCompatibleBaseUrl || "http://localhost:1234/v1",
+          baseUrl,
           defaultModel: config.model,
         });
         break;
+      }
       default:
         throw new Error(`Unknown provider type: ${config.type}`);
     }

--- a/src/shared/llm-provider-catalog.ts
+++ b/src/shared/llm-provider-catalog.ts
@@ -26,7 +26,8 @@ export const CUSTOM_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     apiKeyLabel: "API Key / Token",
     apiKeyPlaceholder: "Enter token",
     requiresBaseUrl: true,
-    description: "OpenAI-compatible endpoint required.",
+    description:
+      "OpenCode endpoint required. OpenCode Go uses model-specific API surfaces.",
   },
   {
     id: "google-vertex",


### PR DESCRIPTION
## Summary

Fixes OpenCode Go routing for `qwen3.7-max`, which rejects OpenAI-compatible `oa-compat` chat-completions requests and must use the Anthropic Messages surface.

## Root Cause

CoWork treated OpenCode Zen/OpenCode Go as a single OpenAI-compatible provider. That sent `qwen3.7-max` to `/chat/completions`, producing:

`401 Unauthorized - Model qwen3.7-max is not supported for format oa-compat`

## Changes

- Add an OpenCode Go routing provider that chooses the API surface per request model.
- Route `qwen3.7-max` and `opencode-go/qwen3.7-max` through `/v1/messages`.
- Keep Kimi and other OpenCode Go models on `/v1/chat/completions`.
- Support both the named `opencode` provider and generic `openai-compatible` configs pointed at `opencode.ai/zen/go`.
- Add regression coverage for bare model IDs, connection tests, generic compatible config, and per-request model overrides.

## Validation

- `npx vitest run src/electron/agent/llm/__tests__/provider-factory-custom-config.test.ts`
- `npm run type-check`
