### PR TITLE
[codex] fix Everyday Agent read-only toggle

### DIFF
--- a/src/renderer/components/EverydayAgentPanel.tsx
+++ b/src/renderer/components/EverydayAgentPanel.tsx
@@ -47,6 +47,11 @@ interface EverydayAgentPanelProps {
 type PauseKind = EverydayPauseScope["kind"];
 type PriorityTone = "danger" | "warn" | "quiet" | "success";
 type EverydayAgentStatus = "loading" | "enabled" | "paused" | "disabled" | "blocked";
+export type EverydayAgentTemporaryModes = {
+  noMemory: boolean;
+  disposableBrowser: boolean;
+  readOnly: boolean;
+};
 
 export interface EverydayAgentPriorityItem {
   id: string;
@@ -82,6 +87,17 @@ export interface EverydayAgentRecoveryItem {
   detail: string;
   actionLabel: string;
   tone: PriorityTone;
+}
+
+export function updateEverydayAgentTemporaryMode(
+  current: EverydayAgentTemporaryModes,
+  mode: keyof EverydayAgentTemporaryModes,
+  checked: boolean,
+): EverydayAgentTemporaryModes {
+  return {
+    ...current,
+    [mode]: checked,
+  };
 }
 
 interface EverydayAgentRecipe {
@@ -597,11 +613,14 @@ export function EverydayAgentPanel({
   const [preview, setPreview] = useState<EverydayActionPreview | null>(null);
   const [pauseKind, setPauseKind] = useState<PauseKind>("global");
   const [pauseTarget, setPauseTarget] = useState("");
-  const [temporaryModes, setTemporaryModes] = useState({
+  const [temporaryModes, setTemporaryModes] = useState<EverydayAgentTemporaryModes>({
     noMemory: false,
     disposableBrowser: true,
     readOnly: false,
   });
+  const updateTemporaryMode = (mode: keyof EverydayAgentTemporaryModes, checked: boolean) => {
+    setTemporaryModes((current) => updateEverydayAgentTemporaryMode(current, mode, checked));
+  };
   const [previewForm, setPreviewForm] = useState({
     title: "Triage inbox follow-ups",
     action: "Draft replies and stage follow-up tasks",
@@ -1235,10 +1254,7 @@ export function EverydayAgentPanel({
                   type="checkbox"
                   checked={temporaryModes.noMemory}
                   onChange={(event) =>
-                    setTemporaryModes((current) => ({
-                      ...current,
-                      noMemory: event.currentTarget.checked,
-                    }))
+                    updateTemporaryMode("noMemory", event.currentTarget.checked)
                   }
                 />
                 <span>
@@ -1251,10 +1267,7 @@ export function EverydayAgentPanel({
                   type="checkbox"
                   checked={temporaryModes.disposableBrowser}
                   onChange={(event) =>
-                    setTemporaryModes((current) => ({
-                      ...current,
-                      disposableBrowser: event.currentTarget.checked,
-                    }))
+                    updateTemporaryMode("disposableBrowser", event.currentTarget.checked)
                   }
                 />
                 <span>
@@ -1267,10 +1280,7 @@ export function EverydayAgentPanel({
                   type="checkbox"
                   checked={temporaryModes.readOnly}
                   onChange={(event) =>
-                    setTemporaryModes((current) => ({
-                      ...current,
-                      readOnly: event.currentTarget.checked,
-                    }))
+                    updateTemporaryMode("readOnly", event.currentTarget.checked)
                   }
                 />
                 <span>

--- a/src/renderer/components/__tests__/EverydayAgentPanel.test.ts
+++ b/src/renderer/components/__tests__/EverydayAgentPanel.test.ts
@@ -6,6 +6,7 @@ import {
   getEverydayAgentStatus,
   isEverydayAgentConsentRequired,
   isEverydayAgentUuid,
+  updateEverydayAgentTemporaryMode,
 } from "../EverydayAgentPanel";
 import {
   EVERYDAY_AGENT_CAPABILITY_BUNDLES,
@@ -216,6 +217,24 @@ describe("EverydayAgentPanel console state", () => {
 
     expect(isEverydayAgentConsentRequired(declined)).toBe(false);
     expect(isEverydayAgentConsentRequired(missingDecision)).toBe(true);
+  });
+
+  it("updates a temporary run mode without changing sibling modes", () => {
+    expect(
+      updateEverydayAgentTemporaryMode(
+        {
+          noMemory: false,
+          disposableBrowser: true,
+          readOnly: false,
+        },
+        "readOnly",
+        true,
+      ),
+    ).toEqual({
+      noMemory: false,
+      disposableBrowser: true,
+      readOnly: true,
+    });
   });
 
   it("classifies recoverable auth failures into connector repair actions", () => {


### PR DESCRIPTION
## Summary

Fixes #151 by updating the Everyday Agent Run Defaults checkbox handlers so they no longer read `event.currentTarget.checked` inside a deferred React state updater.

## Root Cause

React sets `event.currentTarget` back to `null` after dispatch. The previous functional updater closed over the event and later attempted to read `currentTarget.checked`, which could crash the renderer when toggling "Read-only until approved".

## Changes

- Added a typed temporary-mode update helper.
- Updated all three Run Defaults checkboxes to pass a captured boolean into state updates.
- Added a focused regression test for updating one temporary mode without changing sibling modes.

## Validation

- `npx vitest run src/renderer/components/__tests__/EverydayAgentPanel.test.ts`
- `npm run build:react`
