### PR TITLE
Fix sluggish desktop startup

### DIFF
--- a/src/electron/database/__tests__/schema-legacy-type-migration.test.ts
+++ b/src/electron/database/__tests__/schema-legacy-type-migration.test.ts
@@ -79,4 +79,51 @@ describeWithSqlite("DatabaseManager legacy_type migration", () => {
 
     manager.close();
   });
+
+  it("defers oversized task event payload cleanup until post-startup maintenance", async () => {
+    const dbPath = path.join(tmpDir, "cowork-os.db");
+    const oversizedPayload = JSON.stringify({
+      message: "x".repeat(300_000),
+      nested: { value: "y".repeat(300_000) },
+    });
+    const seedDb = new Database(dbPath);
+    seedDb
+      .prepare(
+        `
+          INSERT INTO task_events (id, task_id, timestamp, type, payload)
+          VALUES (?, ?, ?, ?, ?)
+        `,
+      )
+      .run("event-1", "task-1", Date.now(), "tool_result", oversizedPayload);
+    seedDb.close();
+
+    const { DatabaseManager } = await import("../schema");
+    const manager = new DatabaseManager();
+    const db = manager.getDatabase();
+
+    const beforeMaintenance = db
+      .prepare("SELECT LENGTH(payload) AS payload_bytes FROM task_events WHERE id = ?")
+      .get("event-1") as { payload_bytes: number };
+    expect(beforeMaintenance.payload_bytes).toBe(oversizedPayload.length);
+
+    await manager.runPostStartupMaintenance();
+
+    const afterMaintenance = db
+      .prepare(
+        `
+          SELECT LENGTH(payload) AS payload_bytes
+          FROM task_events
+          WHERE id = ?
+        `,
+      )
+      .get("event-1") as { payload_bytes: number };
+    const maintenanceState = db
+      .prepare("SELECT value FROM maintenance_state WHERE key = ?")
+      .get("task_event_payload_sanitizer_v1_completed") as { value?: string } | undefined;
+
+    expect(afterMaintenance.payload_bytes).toBeLessThanOrEqual(256 * 1024);
+    expect(maintenanceState?.value).toBe("1");
+
+    manager.close();
+  });
 });

--- a/src/electron/database/schema.ts
+++ b/src/electron/database/schema.ts
@@ -10,30 +10,120 @@ import {
 } from "../agent/timeline-payload-sanitizer";
 
 const schemaLogger = createLogger("DatabaseManager");
+const STARTUP_PHASE_WARN_MS = 250;
+const TASK_EVENT_PAYLOAD_SANITIZER_STATE_KEY =
+  "task_event_payload_sanitizer_v1_completed";
 
 export class DatabaseManager {
   private static instance: DatabaseManager | null = null;
   private db: Database.Database;
 
   constructor() {
+    const constructorStartedAt = Date.now();
+    const logStartupPhase = (name: string, startedAt: number): void => {
+      const durationMs = Date.now() - startedAt;
+      const message = `[DatabaseManager] Startup phase "${name}" completed in ${durationMs} ms`;
+      if (durationMs >= STARTUP_PHASE_WARN_MS) {
+        schemaLogger.warn(message);
+      } else {
+        schemaLogger.debug(message);
+      }
+    };
+
+    let phaseStartedAt = Date.now();
     const userDataPath = getUserDataDir();
     this.ensureRestrictedDirectory(userDataPath);
+    logStartupPhase("restrict-user-data-directory", phaseStartedAt);
 
     // Run migration from old cowork-oss directory before opening database
+    phaseStartedAt = Date.now();
     this.migrateFromLegacyDirectory(userDataPath);
+    logStartupPhase("legacy-directory-migration-check", phaseStartedAt);
 
+    phaseStartedAt = Date.now();
     const dbPath = path.join(userDataPath, "cowork-os.db");
     this.db = new Database(dbPath);
     this.db.pragma("journal_mode = WAL");
     this.db.pragma("busy_timeout = 5000");
     this.ensureRestrictedFile(dbPath);
+    logStartupPhase("open-database", phaseStartedAt);
+
+    phaseStartedAt = Date.now();
+    this.ensureMaintenanceStateTable();
+    logStartupPhase("maintenance-state-schema", phaseStartedAt);
+
+    phaseStartedAt = Date.now();
     this.initializeSchema();
+    logStartupPhase("initialize-schema", phaseStartedAt);
+
+    phaseStartedAt = Date.now();
     this.repairLegacyHeartbeatRunReferences();
-    this.repairControlPlaneForeignKeyOrphans();
+    logStartupPhase("repair-legacy-heartbeat-references", phaseStartedAt);
+
+    phaseStartedAt = Date.now();
     this.db.pragma("foreign_keys = ON");
+    logStartupPhase("enable-foreign-keys", phaseStartedAt);
 
     // Store as singleton instance
     DatabaseManager.instance = this;
+    logStartupPhase("constructor-total", constructorStartedAt);
+  }
+
+  async runPostStartupMaintenance(): Promise<void> {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    const runMaintenanceStep = (name: string, step: () => void): void => {
+      const startedAt = Date.now();
+      try {
+        step();
+        schemaLogger.info(
+          `[DatabaseManager] Maintenance step "${name}" completed in ${Date.now() - startedAt} ms`,
+        );
+      } catch (error) {
+        schemaLogger.warn(`${name} failed:`, error);
+      }
+    };
+
+    runMaintenanceStep("backfillTaskLastRunDurations", () =>
+      this.backfillTaskLastRunDurations(),
+    );
+    runMaintenanceStep("sanitizeLargeTaskEventPayloads", () =>
+      this.sanitizeLargeTaskEventPayloads(),
+    );
+    runMaintenanceStep("repairControlPlaneForeignKeyOrphans", () =>
+      this.repairControlPlaneForeignKeyOrphans(),
+    );
+  }
+
+  private ensureMaintenanceStateTable(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS maintenance_state (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+  }
+
+  private getMaintenanceState(key: string): string | null {
+    const row = this.db
+      .prepare("SELECT value FROM maintenance_state WHERE key = ?")
+      .get(key) as { value?: string } | undefined;
+    return typeof row?.value === "string" ? row.value : null;
+  }
+
+  private setMaintenanceState(key: string, value: string): void {
+    this.db
+      .prepare(
+        `
+          INSERT INTO maintenance_state (key, value, updated_at)
+          VALUES (?, ?, ?)
+          ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_at = excluded.updated_at
+        `,
+      )
+      .run(key, value, Date.now());
   }
 
   private repairLegacyHeartbeatRunReferences(): void {
@@ -554,6 +644,10 @@ export class DatabaseManager {
   }
 
   private sanitizeLargeTaskEventPayloads(): void {
+    if (this.getMaintenanceState(TASK_EVENT_PAYLOAD_SANITIZER_STATE_KEY) === "1") {
+      return;
+    }
+
     const rows = this.db
       .prepare(
         `
@@ -566,7 +660,10 @@ export class DatabaseManager {
         `,
       )
       .all(TIMELINE_PAYLOAD_STORAGE_BYTE_LIMIT) as Array<{ id: string; payload: string }>;
-    if (rows.length === 0) return;
+    if (rows.length === 0) {
+      this.setMaintenanceState(TASK_EVENT_PAYLOAD_SANITIZER_STATE_KEY, "1");
+      return;
+    }
 
     const updateStmt = this.db.prepare("UPDATE task_events SET payload = ? WHERE id = ?");
     let updated = 0;
@@ -594,9 +691,10 @@ export class DatabaseManager {
 
     if (updated > 0) {
       schemaLogger.info(
-        `[DatabaseManager] Sanitized ${updated} oversized task_event payload(s) during startup hygiene`,
+        `[DatabaseManager] Sanitized ${updated} oversized task_event payload(s) during maintenance`,
       );
     }
+    this.setMaintenanceState(TASK_EVENT_PAYLOAD_SANITIZER_STATE_KEY, "1");
   }
 
   // Migration version - increment this to force re-migration for users with partial migrations
@@ -2681,18 +2779,6 @@ export class DatabaseManager {
       } catch {
         // Column already exists, ignore
       }
-    }
-
-    try {
-      this.backfillTaskLastRunDurations();
-    } catch (err) {
-      schemaLogger.warn("backfillTaskLastRunDurations failed:", err);
-    }
-
-    try {
-      this.sanitizeLargeTaskEventPayloads();
-    } catch (err) {
-      schemaLogger.warn("sanitizeLargeTaskEventPayloads failed:", err);
     }
 
     try {

--- a/src/electron/gateway/__tests__/router-connect-all.test.ts
+++ b/src/electron/gateway/__tests__/router-connect-all.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      exec: vi.fn(),
+      prepare: vi.fn().mockReturnValue({
+        run: vi.fn().mockReturnValue({ changes: 1 }),
+        get: vi.fn(),
+        all: vi.fn().mockReturnValue([]),
+      }),
+      close: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue("/tmp/test-cowork"),
+  },
+  BrowserWindow: {
+    getAllWindows: vi.fn().mockReturnValue([]),
+  },
+}));
+
+import { MessageRouter } from "../router";
+
+type Any = any;
+
+function createMockDb() {
+  return {
+    prepare: vi.fn().mockReturnValue({
+      run: vi.fn().mockReturnValue({ changes: 1 }),
+      get: vi.fn(),
+      all: vi.fn().mockReturnValue([]),
+    }),
+    transaction: vi.fn((fn: Any) => fn),
+  } as Any;
+}
+
+describe("MessageRouter connectAll", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not block other channels when one adapter connect times out", async () => {
+    vi.useFakeTimers();
+    const router = new MessageRouter(createMockDb(), {}, undefined);
+    const slowAdapter = {
+      type: "whatsapp",
+      status: "disconnected",
+      connect: vi.fn(() => new Promise<void>(() => {})),
+    };
+    const fastAdapter = {
+      type: "discord",
+      status: "disconnected",
+      connect: vi.fn(async () => {
+        fastAdapter.status = "connected";
+      }),
+    };
+
+    (router as Any).channelRepo.findEnabled = vi.fn().mockReturnValue([
+      { id: "whatsapp-1", type: "whatsapp" },
+      { id: "discord-1", type: "discord" },
+    ]);
+    (router as Any).adaptersByChannelId.set("whatsapp-1", slowAdapter);
+    (router as Any).adaptersByChannelId.set("discord-1", fastAdapter);
+    (router as Any).sessionRepo.findActiveByChannelId = vi.fn().mockReturnValue([]);
+
+    const connectPromise = router.connectAll({ timeoutMs: 100 });
+    await vi.advanceTimersByTimeAsync(100);
+    await connectPromise;
+
+    expect(slowAdapter.connect).toHaveBeenCalledOnce();
+    expect(fastAdapter.connect).toHaveBeenCalledOnce();
+    expect(fastAdapter.status).toBe("connected");
+  });
+});

--- a/src/electron/gateway/index.ts
+++ b/src/electron/gateway/index.ts
@@ -99,6 +99,28 @@ const DEFAULT_CONFIG: GatewayConfig = {
 const IDLE_SESSION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const logger = createLogger("ChannelGateway");
 
+export interface ChannelConnectOptions {
+  timeoutMs?: number;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number | undefined,
+  message: string,
+): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) return promise;
+  let timer: NodeJS.Timeout | undefined;
+  return new Promise<T>((resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(message));
+    }, timeoutMs);
+    timer.unref?.();
+    promise.then(resolve, reject).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+  });
+}
+
 /**
  * Channel Gateway - Main class for managing multi-channel messaging
  */
@@ -610,8 +632,15 @@ export class ChannelGateway {
 
     // Auto-connect if configured
     if (this.config.autoConnect) {
-      await this.connectMicrosoftEmailGraphChannels();
-      await this.router.connectAll();
+      const results = await Promise.allSettled([
+        this.connectMicrosoftEmailGraphChannels(),
+        this.router.connectAll(),
+      ]);
+      for (const result of results) {
+        if (result.status === "rejected") {
+          logger.warn("Enabled channel connect group failed:", result.reason);
+        }
+      }
     }
 
     this.startPendingCleanup();
@@ -626,12 +655,19 @@ export class ChannelGateway {
    * Connect enabled channel adapters after the gateway has loaded them.
    * Used by desktop startup to keep network handshakes off the first-window path.
    */
-  async connectEnabledChannels(): Promise<void> {
+  async connectEnabledChannels(options: ChannelConnectOptions = {}): Promise<void> {
     if (!this.initialized) {
       await this.initialize();
     }
-    await this.connectMicrosoftEmailGraphChannels();
-    await this.router.connectAll();
+    const results = await Promise.allSettled([
+      this.connectMicrosoftEmailGraphChannels(options),
+      this.router.connectAll(options),
+    ]);
+    for (const result of results) {
+      if (result.status === "rejected") {
+        logger.warn("Enabled channel connect group failed:", result.reason);
+      }
+    }
   }
 
   /**
@@ -1966,26 +2002,37 @@ export class ChannelGateway {
     return email?.trim() || undefined;
   }
 
-  private async connectMicrosoftEmailGraphChannels(): Promise<void> {
+  private async connectMicrosoftEmailGraphChannels(
+    options: ChannelConnectOptions = {},
+  ): Promise<void> {
     const channels = this.channelRepo
       .findEnabled()
       .filter((channel) => this.isMicrosoftEmailOAuthChannel(channel));
 
-    for (const channel of channels) {
-      try {
-        await this.connectMicrosoftEmailGraphChannel(channel);
-      } catch (error) {
-        console.error("Failed to connect Microsoft Outlook email channel:", error);
-      }
-    }
+    await Promise.all(
+      channels.map(async (channel) => {
+        try {
+          await withTimeout(
+            this.connectMicrosoftEmailGraphChannel(channel, options),
+            options.timeoutMs,
+            `Timed out connecting Microsoft Outlook email channel ${channel.id}`,
+          );
+        } catch (error) {
+          console.error("Failed to connect Microsoft Outlook email channel:", error);
+        }
+      }),
+    );
   }
 
-  private async connectMicrosoftEmailGraphChannel(channel: Channel): Promise<void> {
+  private async connectMicrosoftEmailGraphChannel(
+    channel: Channel,
+    options: ChannelConnectOptions = {},
+  ): Promise<void> {
     this.router.unregisterAdapter(channel.id);
     this.channelRepo.update(channel.id, { enabled: true, status: "connecting" });
 
     try {
-      await this.validateMicrosoftEmailGraphReadAccess(channel);
+      await this.validateMicrosoftEmailGraphReadAccess(channel, options);
       this.channelRepo.update(channel.id, {
         enabled: true,
         status: "connected",
@@ -1997,7 +2044,10 @@ export class ChannelGateway {
     }
   }
 
-  private async validateMicrosoftEmailGraphReadAccess(channel: Channel): Promise<void> {
+  private async validateMicrosoftEmailGraphReadAccess(
+    channel: Channel,
+    options: ChannelConnectOptions = {},
+  ): Promise<void> {
     const oauthClientId = channel.config.oauthClientId as string | undefined;
     const refreshToken = channel.config.refreshToken as string | undefined;
     const accessToken =
@@ -2016,7 +2066,7 @@ export class ChannelGateway {
       (!tokenExpiresAt || Date.now() < tokenExpiresAt - 2 * 60 * 1000) &&
       tokenScopes?.includes("https://graph.microsoft.com/Mail.ReadWrite")
     ) {
-      await this.probeMicrosoftGraphReadAccess(accessToken);
+      await this.probeMicrosoftGraphReadAccess(accessToken, options);
       return;
     }
 
@@ -2025,7 +2075,7 @@ export class ChannelGateway {
         accessToken &&
         (!tokenExpiresAt || Date.now() < tokenExpiresAt - 2 * 60 * 1000)
       ) {
-        await this.probeMicrosoftGraphReadAccess(accessToken);
+        await this.probeMicrosoftGraphReadAccess(accessToken, options);
         return;
       }
       throw new Error(
@@ -2040,7 +2090,7 @@ export class ChannelGateway {
       tenant: (channel.config.oauthTenant as string | undefined) || MICROSOFT_EMAIL_DEFAULT_TENANT,
       scopes: [...MICROSOFT_EMAIL_GRAPH_READWRITE_SCOPES],
     });
-    await this.probeMicrosoftGraphReadAccess(refreshed.accessToken);
+    await this.probeMicrosoftGraphReadAccess(refreshed.accessToken, options);
 
     this.channelRepo.update(channel.id, {
       config: {
@@ -2060,13 +2110,28 @@ export class ChannelGateway {
     });
   }
 
-  private async probeMicrosoftGraphReadAccess(accessToken: string): Promise<void> {
+  private async probeMicrosoftGraphReadAccess(
+    accessToken: string,
+    options: ChannelConnectOptions = {},
+  ): Promise<void> {
     const url = new URL("https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages");
     url.searchParams.set("$top", "1");
     url.searchParams.set("$select", "id");
-    const response = await fetch(url.toString(), {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    const controller = new AbortController();
+    const timeout =
+      options.timeoutMs && options.timeoutMs > 0
+        ? setTimeout(() => controller.abort(), options.timeoutMs)
+        : undefined;
+    timeout?.unref?.();
+    let response: Response;
+    try {
+      response = await fetch(url.toString(), {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        signal: controller.signal,
+      });
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
     if (response.ok) return;
 
     const rawText = typeof response.text === "function" ? await response.text() : "";

--- a/src/electron/gateway/router.ts
+++ b/src/electron/gateway/router.ts
@@ -158,6 +158,28 @@ type MessageSecurityContext = {
   };
 };
 
+export interface ConnectAllOptions {
+  timeoutMs?: number;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number | undefined,
+  message: string,
+): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) return promise;
+  let timer: NodeJS.Timeout | undefined;
+  return new Promise<T>((resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(message));
+    }, timeoutMs);
+    timer.unref?.();
+    promise.then(resolve, reject).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+  });
+}
+
 export class MessageRouter {
   private adapters: Map<ChannelType, ChannelAdapter> = new Map();
   private adaptersByChannelId: Map<string, ChannelAdapter> = new Map();
@@ -1224,35 +1246,41 @@ export class MessageRouter {
   /**
    * Connect all enabled adapters
    */
-  async connectAll(): Promise<void> {
+  async connectAll(options: ConnectAllOptions = {}): Promise<void> {
     const enabledChannels = this.channelRepo.findEnabled();
 
-    for (const channel of enabledChannels) {
-      const adapter =
-        this.getAdapterByChannelId(channel.id) ||
-        this.adapters.get(channel.type as ChannelType);
-      if (!adapter) continue;
+    await Promise.all(
+      enabledChannels.map(async (channel) => {
+        const adapter =
+          this.getAdapterByChannelId(channel.id) ||
+          this.adapters.get(channel.type as ChannelType);
+        if (!adapter) return;
 
-      if (adapter.status !== "connected") {
-        try {
-          await adapter.connect();
-        } catch (error) {
-          console.error(`Failed to connect ${channel.type}:`, error);
-          continue;
+        if (adapter.status !== "connected") {
+          try {
+            await withTimeout(
+              adapter.connect(),
+              options.timeoutMs,
+              `Timed out connecting ${channel.type} channel ${channel.id}`,
+            );
+          } catch (error) {
+            console.error(`Failed to connect ${channel.type}:`, error);
+            return;
+          }
         }
-      }
 
-      if (adapter.status === "connected") {
-        try {
-          await this.restorePendingTaskRoutes(adapter);
-        } catch (error) {
-          console.error(
-            `[Router] Failed to restore pending tasks for ${adapter.type}:`,
-            error,
-          );
+        if (adapter.status === "connected") {
+          try {
+            await this.restorePendingTaskRoutes(adapter);
+          } catch (error) {
+            console.error(
+              `[Router] Failed to restore pending tasks for ${adapter.type}:`,
+              error,
+            );
+          }
         }
-      }
-    }
+      }),
+    );
   }
 
   private async restorePendingTaskRoutes(

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1356,37 +1356,64 @@ if (!gotTheLock) {
     const deferredStartupTasks: Array<{
       name: string;
       task: () => Promise<void>;
+      delayMs?: number;
     }> = [];
     const startupQuietMode = isStartupQuietMode();
     if (startupQuietMode) {
       logger.info("Startup quiet mode enabled; background autostart is disabled.");
     }
-    const deferStartupTask = (name: string, task: () => Promise<void>): void => {
-      deferredStartupTasks.push({ name, task });
+    const deferStartupTask = (
+      name: string,
+      task: () => Promise<void>,
+      options: { delayMs?: number } = {},
+    ): void => {
+      deferredStartupTasks.push({ name, task, delayMs: options.delayMs });
     };
     const runDeferredStartupTasks = (): void => {
       logStartupLane("post_interactive_startup", {
         event: "deferred_tasks_scheduled",
         taskCount: deferredStartupTasks.length,
       });
-      deferredStartupTasks.forEach(({ name, task }, index) => {
-        const timer = setTimeout(() => {
-          if (index === 0) {
-            logStartupLane("idle_startup", { event: "first_deferred_task_start" });
-          }
-          const startedAt = Date.now();
-          void task()
-            .then(() => {
-              logger.info(
-                `Deferred startup task "${name}" completed in ${Date.now() - startedAt} ms`,
-              );
-            })
-            .catch((error) => {
-              logger.error(`Deferred startup task "${name}" failed:`, error);
-            });
-        }, 250 + index * 50);
-        timer.unref?.();
-      });
+      const maxConcurrentTasks = 2;
+      let nextTaskIndex = 0;
+      let activeTaskCount = 0;
+      let firstTaskStarted = false;
+
+      const scheduleNext = (): void => {
+        while (
+          activeTaskCount < maxConcurrentTasks &&
+          nextTaskIndex < deferredStartupTasks.length
+        ) {
+          const currentIndex = nextTaskIndex;
+          const { name, task, delayMs } = deferredStartupTasks[currentIndex];
+          nextTaskIndex += 1;
+          activeTaskCount += 1;
+          const effectiveDelayMs = delayMs ?? 2500 + currentIndex * 500;
+          const timer = setTimeout(() => {
+            if (!firstTaskStarted) {
+              firstTaskStarted = true;
+              logStartupLane("idle_startup", { event: "first_deferred_task_start" });
+            }
+            const startedAt = Date.now();
+            void task()
+              .then(() => {
+                logger.info(
+                  `Deferred startup task "${name}" completed in ${Date.now() - startedAt} ms`,
+                );
+              })
+              .catch((error) => {
+                logger.error(`Deferred startup task "${name}" failed:`, error);
+              })
+              .finally(() => {
+                activeTaskCount = Math.max(0, activeTaskCount - 1);
+                scheduleNext();
+              });
+          }, effectiveDelayMs);
+          timer.unref?.();
+        }
+      };
+
+      scheduleNext();
     };
 
     const resolvedUserDataDir = startupUserDataDir || applyStableUserDataPath();
@@ -1432,7 +1459,24 @@ if (!gotTheLock) {
     // Initialize database first - required for SecureSettingsRepository
     const coreInitStartedAt = Date.now();
     dbManager = new DatabaseManager();
-    UsageInsightsProjector.initialize(dbManager.getDatabase()).warm();
+    const usageInsightsProjector = UsageInsightsProjector.initialize(
+      dbManager.getDatabase(),
+    );
+    if (startupQuietMode) {
+      usageInsightsProjector.warm();
+      await dbManager.runPostStartupMaintenance();
+    } else {
+      deferStartupTask(
+        "usage-insights-warm",
+        async () => {
+          usageInsightsProjector.warm();
+        },
+        { delayMs: 5000 },
+      );
+      deferStartupTask("database-maintenance", () => dbManager.runPostStartupMaintenance(), {
+        delayMs: 8000,
+      });
+    }
     const tempWorkspaceRoot = path.join(
       os.tmpdir(),
       TEMP_WORKSPACE_ROOT_DIR_NAME,
@@ -3095,12 +3139,14 @@ if (!gotTheLock) {
         logger.info("Channels auto-connect skipped in quiet mode");
       } else {
         deferStartupTask("channel-auto-connect", async () => {
-          await channelGateway.connectEnabledChannels();
+          await channelGateway.connectEnabledChannels({ timeoutMs: 10000 });
           const connectedStats = channelGateway.getStartupStats();
           logger.info(
             `Channels auto-connect complete: loaded=${connectedStats.loaded}, enabled=${connectedStats.enabled}, connected=${connectedStats.connected}`,
           );
           startXMentionBridge();
+        }, {
+          delayMs: 12000,
         });
       }
       // Initialize update manager with main window reference

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -135,8 +135,20 @@ import { classifyLiveTaskEvent } from "./utils/live-task-event-policy";
 const Settings = lazy(() =>
   import("./components/Settings").then((module) => ({ default: module.Settings })),
 );
+const mainContentModuleStartedAt = typeof performance !== "undefined" ? performance.now() : 0;
 const mainContentModulePromise = import("./components/MainContent");
-void mainContentModulePromise.catch(() => {});
+void mainContentModulePromise
+  .then(() => {
+    const now = typeof performance !== "undefined" ? performance.now() : 0;
+    void window.electronAPI?.logRendererPerf?.({
+      timestamp: new Date().toISOString(),
+      message: `[Startup] main_content_module_loaded at ${now.toFixed(1)}ms {"loadMs":${Math.max(
+        0,
+        now - mainContentModuleStartedAt,
+      ).toFixed(1)}}`,
+    });
+  })
+  .catch(() => {});
 const MainContent = lazy(() =>
   mainContentModulePromise.then((module) => ({ default: module.MainContent })),
 );


### PR DESCRIPTION
## Summary
- move expensive DB hygiene and usage-insights warmup out of the blocking startup path
- delay and bound deferred startup work, including channel auto-connect
- add timeout/parallel connect behavior for gateway adapters and Microsoft Graph probes
- add renderer timing for MainContent dynamic import and regression coverage for channel connect timeouts

## Verification
- npx vitest run src/electron/database/__tests__/schema-legacy-type-migration.test.ts src/electron/gateway/__tests__/router-connect-all.test.ts
  - router test passed; SQLite-backed schema test file skipped by existing native SQLite guard in this environment
- npm run build:electron
- npm run build:react
- git diff --check