### PR TITLE
feat(cli): add cowork local runner

### DIFF
--- a/bin/cowork-cli.js
+++ b/bin/cowork-cli.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const path = require("path");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+
+const packageDir = path.resolve(__dirname, "..");
+const mainPath = path.join(packageDir, "dist", "cli", "cli", "main.js");
+
+if (!fs.existsSync(mainPath)) {
+  console.log("[cowork] CLI build artifacts are missing, running npm run build:cli...");
+  const res = spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", ["run", "build:cli"], {
+    cwd: packageDir,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+    env: process.env,
+  });
+  if (res.status !== 0) {
+    process.exit(res.status || 1);
+  }
+}
+
+const cli = require(mainPath);
+Promise.resolve(cli.main(process.argv.slice(2)))
+  .then((code) => {
+    process.exitCode = typeof code === "number" ? code : 0;
+  })
+  .catch((error) => {
+    console.error(error?.stack || String(error));
+    process.exitCode = 1;
+  });

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,148 @@
+# CoWork OS CLI
+
+CoWork OS is now both a desktop app and a terminal agent surface. The desktop GUI remains the primary operator console for agents, artifacts, approvals, automations, Mission Control, and settings. The `cowork` command adds a fast local command-line entrypoint for starting work without opening a separate Control Plane session.
+
+## What `cowork` Runs
+
+The CLI has two local modes plus local management commands:
+
+- `cowork` opens an interactive terminal UI with the CoWork welcome panel, command shortcuts, local workspace/provider status, and a prompt for task input.
+- `cowork run "<task>"` runs a one-shot local task and streams the result back to the terminal.
+- Commands such as `cowork status`, `cowork sessions list`, `cowork tools list`, `cowork mcp list`, `cowork backup create`, and `cowork security audit` read or update the same local settings/database used by the desktop app.
+
+By default, these local modes do **not** require `COWORK_CONTROL_PLANE_TOKEN`. They use the same local CoWork profile, database, provider settings, workspaces, skills, and MCP connector configuration that the desktop app uses.
+
+Remote Control Plane mode is explicit:
+
+```bash
+cowork run "summarize the active project" --remote
+```
+
+Use `--remote` only when you intentionally want the CLI to call a running remote Control Plane endpoint. In that mode, configure `COWORK_CONTROL_PLANE_URL` and `COWORK_CONTROL_PLANE_TOKEN`, or pass the equivalent CLI options.
+
+## First Run
+
+Install globally from npm:
+
+```bash
+npm install -g cowork-os
+cowork
+```
+
+From a source checkout:
+
+```bash
+npm run setup
+npm run build:cli
+cowork
+```
+
+The source launcher can build missing CLI artifacts automatically, but `npm run build:cli` is the fastest explicit path when iterating locally.
+
+If you have already configured providers in the desktop app, `cowork` should pick them up. On macOS and Windows, the CLI prefers the bundled Electron runtime in `ELECTRON_RUN_AS_NODE=1` mode for local commands. That gives terminal commands normal stdout/stderr while preserving the Electron/Node ABI required by native modules and encrypted desktop settings. If Electron is unavailable, the CLI can fall back to the Node runner, but OS-encrypted desktop credentials and native modules may not be readable from that fallback process.
+
+## Commands
+
+```bash
+cowork
+cowork run "who are you?"
+cowork run "inspect this repo and list the riskiest files" --workspace /path/to/repo
+cowork run "return a compact status report" --json
+cowork providers list
+cowork providers configure openai --model gpt-5.5
+cowork providers fallback list
+cowork workspace list
+cowork sessions list
+cowork sessions export <sessionId> --output session.json
+cowork logs latest
+cowork tools list
+cowork mcp list
+cowork skills audit
+cowork models list
+cowork backup create --output cowork-backup.json
+cowork backup restore cowork-backup.json --dry-run
+cowork security audit
+cowork prompt-size "estimate this prompt"
+cowork completions zsh
+cowork dashboard status
+cowork tail <taskId>
+cowork approvals
+cowork run "run this on the remote node" --remote
+cowork --help
+```
+
+Interactive mode accepts free-text tasks and slash commands:
+
+- `/doctor` checks runtime, database, workspace, provider, and local CLI readiness.
+- `/providers list` shows locally configured model routes.
+- `/providers configure <provider>` saves common provider settings locally through the same encrypted settings store used by the desktop app.
+- `/workspace list` shows known local workspaces.
+- `/workspace use <path>` sets the working workspace for the session.
+- `/exit` leaves the CLI.
+
+`approve` and `reject` use a local desktop handoff by default. The CLI sends the response to the already-running CoWork OS app through the app's single-instance bridge, so the live task runtime can wake and continue without Control Plane. If no desktop app is running, open CoWork OS and retry, or use `cowork approve <approvalId> --remote` / `cowork reject <approvalId> --remote` against a running Control Plane target.
+
+### Local Management Commands
+
+These command groups are local-first and do not require a Control Plane token:
+
+- `cowork version` and `cowork status` show installed runtime, provider, workspace, task, MCP, and tool readiness.
+- `cowork sessions ...` manages local task lineages. Rename/delete/prune use CLI metadata; delete and prune require `--yes` and archive sessions from CLI lists instead of deleting task history.
+- `cowork logs latest|tail|grep` reads local developer logs when developer logging has captured them.
+- `cowork tools list|info|enable|disable` updates built-in tool category or per-tool settings.
+- `cowork mcp list|add|remove|enable|disable|test` updates local MCP server settings.
+- `cowork skills list|info|audit` inspects locally registered skills.
+- `cowork models list` shows the current provider model list and stored model presets.
+- `cowork providers fallback list|add|remove` manages global provider fallback routes.
+- `cowork backup create|restore` exports local workspaces, recent task metadata, provider settings, tool settings, MCP settings, and skills. Task content, approval payloads, and MCP secrets are redacted unless `--include-secrets --yes` is passed. Restore previews are safe with `--dry-run`; actual restore requires `--yes`, validates settings, restores settings only, and keeps restored MCP servers disabled until re-enabled.
+- `cowork security audit` checks local provider/tool/permission posture. Warnings return a non-zero exit code so CI can fail on risky local settings.
+- `cowork security rules list|remove` inspects or removes workspace permission rules. Removal requires `--yes`.
+- `cowork prompt-size` and `cowork prompt-preview` provide quick prompt diagnostics.
+- `cowork completions zsh|bash|fish` prints shell completion snippets.
+- `cowork dashboard` and `cowork open task <taskId>` launch the desktop app/deeplink without using the Control Plane.
+
+## Runtime Model
+
+The CLI is not a separate product backend. It is another surface over the same local runtime contracts:
+
+- `bin/cowork-cli.js` resolves the installed package, ensures CLI build output exists, and launches the TypeScript-compiled CLI.
+- `src/cli/main.ts` owns argument parsing, the interactive terminal UI, slash commands, local diagnostics, and remote-mode dispatch.
+- `src/cli/direct-run.ts` owns one-shot local execution and local management commands when the CLI runs with the bundled Electron-as-Node runtime.
+- `src/electron/main.ts` supports `--cowork-cli-direct-run`, a hidden app-entry mode retained for packaged app-entry compatibility, plus a single-instance approval handoff for local approval responses.
+
+Local one-shot execution initializes the database, settings, provider routing, workspace resolution, skills, MCP servers, and agent daemon, then creates a task and waits for completion. The CLI daemon disables startup recovery for that process so it does not recover, resume, or rewrite GUI-owned tasks while the desktop app is also running.
+
+Interactive `cowork` and local `cowork run` can be used while the GUI is installed and already configured. They share local profile state, but each CLI task is still a distinct task run with its own terminal output.
+
+## Security And Credentials
+
+- Local CLI mode keeps provider credentials and task data on the machine, following the desktop app's local-first model.
+- Normal local CLI use does not need a Control Plane token.
+- `--remote` is the token-gated path and should be treated like any other remote device operation.
+- `--json` emits structured JSONL events for machine consumers without exposing hidden reasoning.
+- Set `COWORK_CLI_DEBUG=1` when you need verbose local runtime diagnostics.
+
+## Troubleshooting
+
+If `cowork` reports missing CLI runtime output, run:
+
+```bash
+npm run build:cli
+```
+
+If `cowork run` prints `Missing token`, check whether `--remote` was passed or a remote alias is being used. Local one-shot tasks should run without a Control Plane token.
+
+If the CLI cannot see providers already configured in the desktop app, confirm the same install/profile is being used and try:
+
+```bash
+COWORK_CLI_DEBUG=1 cowork run "who are you?"
+```
+
+If the hidden Electron runner is unavailable in a source checkout, build the app-entry artifacts:
+
+```bash
+npm run build:electron
+npm run build:cli
+```
+
+See [Troubleshooting](troubleshooting.md#cowork-cli-issues) for failure-specific recovery steps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "zod": "^4.3.6"
       },
       "bin": {
+        "cowork": "bin/cowork-cli.js",
         "cowork-os": "bin/cowork.js",
         "coworkctl": "bin/coworkctl.js",
         "coworkd": "bin/coworkd.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cowork-os",
   "version": "0.5.48",
-  "description": "CoWork OS - GUI-first local AI super app and everything app for coding, email, agents, documents, spreadsheets, presentations, web design, automations, and agentic work",
+  "description": "CoWork OS - GUI-first, CLI-capable local AI super app and everything app for coding, email, agents, documents, spreadsheets, presentations, web design, automations, and agentic work",
   "overrides": {
     "@whiskeysockets/baileys": {
       "libsignal": "https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
@@ -64,12 +64,14 @@
     "CHANGELOG.md",
     "LICENSE",
     "tsconfig.json",
+    "tsconfig.cli.json",
     "tsconfig.daemon.json",
     "tsconfig.electron.json",
     "tsconfig.node.json",
     "vite.config.ts"
   ],
   "bin": {
+    "cowork": "bin/cowork-cli.js",
     "cowork-os": "bin/cowork.js",
     "coworkctl": "bin/coworkctl.js",
     "coworkd": "bin/coworkd.js",
@@ -99,10 +101,11 @@
     "dev:electron": "tsc -p tsconfig.electron.json && cross-env ELECTRON_RUN_AS_NODE= NODE_ENV=development electron .",
     "tunnel-relay:dev": "npm run build:electron && node dist/electron/electron/tunnels/relay.js",
     "tunnel-relay:test": "npm run build:electron && node scripts/smoke-secure-mcp-tunnel.mjs",
-    "build": "npm run build:react && npm run build:healthkit-bridge && npm run build:location-helper-macos && npm run build:location-helpers && concurrently -n electron,daemon \"npm run build:electron\" \"npm run build:daemon\" && npm run build:connectors",
+    "build": "npm run build:react && npm run build:healthkit-bridge && npm run build:location-helper-macos && npm run build:location-helpers && concurrently -n electron,daemon,cli \"npm run build:electron\" \"npm run build:daemon\" \"npm run build:cli\" && npm run build:connectors",
     "build:react": "vite build",
     "build:electron": "tsc -p tsconfig.electron.json",
     "build:daemon": "tsc -p tsconfig.daemon.json",
+    "build:cli": "tsc -p tsconfig.cli.json",
     "build:connectors": "concurrently -n salesforce,jira,hubspot,zendesk,servicenow,linear,asana,okta,resend,discord,google-workspace,figma,vercel,monday,finance-data,maps \"tsc -p connectors/salesforce-mcp/tsconfig.json\" \"tsc -p connectors/jira-mcp/tsconfig.json\" \"tsc -p connectors/hubspot-mcp/tsconfig.json\" \"tsc -p connectors/zendesk-mcp/tsconfig.json\" \"tsc -p connectors/servicenow-mcp/tsconfig.json\" \"tsc -p connectors/linear-mcp/tsconfig.json\" \"tsc -p connectors/asana-mcp/tsconfig.json\" \"tsc -p connectors/okta-mcp/tsconfig.json\" \"tsc -p connectors/resend-mcp/tsconfig.json\" \"tsc -p connectors/discord-mcp/tsconfig.json\" \"tsc -p connectors/google-workspace-mcp/tsconfig.json\" \"tsc -p connectors/figma-mcp/tsconfig.json\" \"tsc -p connectors/vercel-mcp/tsconfig.json\" \"tsc -p connectors/monday-mcp/tsconfig.json\" \"tsc -p connectors/finance-data-mcp/tsconfig.json\" \"tsc -p connectors/maps-mcp/tsconfig.json\"",
     "prepack": "npm run build",
     "release:smoke": "npm run build && node scripts/release-smoke-install.mjs",

--- a/src/cli/__tests__/config-store.test.ts
+++ b/src/cli/__tests__/config-store.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CONTROL_PLANE_URL,
+  createDefaultConfig,
+  removeProfileToken,
+  resolveConnection,
+  upsertProfile,
+} from "../config-store";
+
+describe("CLI config store", () => {
+  it("creates a local default profile", () => {
+    expect(createDefaultConfig()).toEqual({
+      defaultProfile: "local",
+      profiles: {
+        local: { url: DEFAULT_CONTROL_PLANE_URL },
+      },
+    });
+  });
+
+  it("resolves explicit connection options before saved profile values", () => {
+    const config = upsertProfile(
+      createDefaultConfig(),
+      "vps",
+      { url: "ws://saved:18789", token: "saved-token" },
+      true,
+    );
+
+    expect(
+      resolveConnection({
+        config,
+        url: "ws://override:18789",
+        token: "override-token",
+      }),
+    ).toMatchObject({
+      profileName: "vps",
+      url: "ws://override:18789",
+      token: "override-token",
+    });
+  });
+
+  it("removes only the stored token for a profile", () => {
+    const config = upsertProfile(
+      createDefaultConfig(),
+      "local",
+      { url: "ws://127.0.0.1:9999", token: "secret" },
+      true,
+    );
+
+    expect(removeProfileToken(config, "local").profiles.local).toEqual({
+      url: "ws://127.0.0.1:9999",
+    });
+  });
+});

--- a/src/cli/__tests__/format.test.ts
+++ b/src/cli/__tests__/format.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTaskTitle,
+  formatTaskEventFrame,
+  isTerminalTaskFrame,
+  matchesTask,
+} from "../format";
+
+describe("CLI formatting", () => {
+  it("builds compact task titles from prompts", () => {
+    expect(buildTaskTitle("  summarize\n\nthis   repository  ")).toBe("summarize this repository");
+    expect(buildTaskTitle("x".repeat(100))).toHaveLength(80);
+  });
+
+  it("renders task event messages without raw JSON", () => {
+    expect(
+      formatTaskEventFrame({
+        type: "event",
+        event: "task.event",
+        payload: {
+          taskId: "task-1",
+          message: "Reading files",
+        },
+      }),
+    ).toBe("task.event task-1: Reading files");
+  });
+
+  it("matches nested task event payloads", () => {
+    const frame = {
+      type: "event" as const,
+      event: "task.event",
+      payload: {
+        event: {
+          taskId: "task-2",
+          status: "completed",
+        },
+      },
+    };
+
+    expect(matchesTask(frame, "task-2")).toBe(true);
+    expect(isTerminalTaskFrame(frame, "task-2")).toBe(true);
+  });
+
+  it("detects terminal top-level task frames", () => {
+    expect(
+      isTerminalTaskFrame(
+        {
+          type: "event",
+          event: "task.completed",
+          payload: { taskId: "task-3" },
+        },
+        "task-3",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/cli/__tests__/local-control-plane-discovery.test.ts
+++ b/src/cli/__tests__/local-control-plane-discovery.test.ts
@@ -1,0 +1,108 @@
+import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  discoverLocalControlPlane,
+  discoverUserDataDirs,
+} from "../local-control-plane-discovery";
+
+const OLD_USER_DATA_DIR = process.env.COWORK_USER_DATA_DIR;
+
+describe("local control-plane discovery", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "cowork-cli-discovery-"));
+    process.env.COWORK_USER_DATA_DIR = tempDir;
+  });
+
+  afterEach(() => {
+    if (OLD_USER_DATA_DIR === undefined) {
+      delete process.env.COWORK_USER_DATA_DIR;
+    } else {
+      process.env.COWORK_USER_DATA_DIR = OLD_USER_DATA_DIR;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("includes the override user-data directory", () => {
+    expect(discoverUserDataDirs()).toContain(path.resolve(tempDir));
+  });
+
+  it("discovers app-encrypted control-plane settings from the GUI database", () => {
+    writeControlPlaneSettings(tempDir, {
+      enabled: true,
+      host: "127.0.0.1",
+      port: 18888,
+      token: "local-token",
+    });
+
+    expect(discoverLocalControlPlane()).toMatchObject({
+      url: "ws://127.0.0.1:18888",
+      token: "local-token",
+    });
+  });
+
+  it("prefers the local descriptor written by a running GUI", () => {
+    fs.writeFileSync(
+      path.join(tempDir, "control-plane-local.json"),
+      JSON.stringify({
+        version: 1,
+        url: "ws://127.0.0.1:19999",
+        token: "descriptor-token",
+        pid: process.pid,
+      }),
+    );
+
+    expect(discoverLocalControlPlane()).toMatchObject({
+      url: "ws://127.0.0.1:19999",
+      token: "descriptor-token",
+    });
+  });
+
+  it("reports OS keychain settings as a one-time login fallback", () => {
+    writeSecureSettingsRow(tempDir, "os:not-decryptable-in-node", "bad-checksum");
+
+    expect(discoverLocalControlPlane().error).toContain("OS keychain");
+  });
+});
+
+function writeControlPlaneSettings(userDataDir: string, settings: object): void {
+  const raw = JSON.stringify(settings);
+  writeSecureSettingsRow(userDataDir, encryptAppSettings(userDataDir, raw), checksum(raw));
+}
+
+function writeSecureSettingsRow(userDataDir: string, encryptedData: string, rowChecksum: string): void {
+  fs.mkdirSync(userDataDir, { recursive: true });
+  const dbPath = path.join(userDataDir, "cowork-os.db");
+  execFileSync("sqlite3", [
+    dbPath,
+    "CREATE TABLE secure_settings (id TEXT PRIMARY KEY, category TEXT NOT NULL, encrypted_data TEXT NOT NULL, checksum TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);",
+  ]);
+  execFileSync("sqlite3", [
+    dbPath,
+    `INSERT INTO secure_settings (id, category, encrypted_data, checksum, created_at, updated_at) VALUES ('id-1', 'controlplane', '${escapeSql(encryptedData)}', '${escapeSql(rowChecksum)}', 1, 1);`,
+  ]);
+}
+
+function encryptAppSettings(userDataDir: string, data: string): string {
+  const machineId = "test-machine-id";
+  fs.writeFileSync(path.join(userDataDir, ".cowork-machine-id"), machineId, "utf8");
+  const key = crypto.pbkdf2Sync("cowork-os-secure-settings-v1", machineId, 100000, 32, "sha512");
+  const iv = Buffer.alloc(16, 1);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  let encrypted = cipher.update(data, "utf8", "base64");
+  encrypted += cipher.final("base64");
+  return `app:${iv.toString("base64")}:${cipher.getAuthTag().toString("base64")}:${encrypted}`;
+}
+
+function checksum(data: string): string {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+function escapeSql(value: string): string {
+  return value.replace(/'/g, "''");
+}

--- a/src/cli/__tests__/main.test.ts
+++ b/src/cli/__tests__/main.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { main, parseArgs, parseInteractiveCommand } from "../main";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CLI argument parsing", () => {
+  it("separates command, positional args, and value flags", () => {
+    const parsed = parseArgs([
+      "run",
+      "write a brief",
+      "--cwd",
+      "/tmp/project",
+      "--workspace-id",
+      "ws-1",
+      "--no-follow",
+    ]);
+
+    expect(parsed.command).toBe("run");
+    expect(parsed.rest).toEqual(["write a brief"]);
+    expect(parsed.flags.get("--cwd")).toBe("/tmp/project");
+    expect(parsed.flags.get("--workspace-id")).toBe("ws-1");
+    expect(parsed.flags.get("--no-follow")).toBe(true);
+  });
+
+  it("keeps subcommands as positional args", () => {
+    const parsed = parseArgs(["providers", "configure", "openai", "--model", "gpt-4.1-mini"]);
+
+    expect(parsed.command).toBe("providers");
+    expect(parsed.rest).toEqual(["configure", "openai"]);
+    expect(parsed.flags.get("--model")).toBe("gpt-4.1-mini");
+  });
+
+  it("parses task lifecycle flags", () => {
+    const parsed = parseArgs(["tasks", "list", "--active", "--cli", "--limit", "20"]);
+
+    expect(parsed.command).toBe("tasks");
+    expect(parsed.rest).toEqual(["list"]);
+    expect(parsed.flags.get("--active")).toBe(true);
+    expect(parsed.flags.get("--cli")).toBe(true);
+    expect(parsed.flags.get("--limit")).toBe("20");
+  });
+
+  it("parses detached forced run flags", () => {
+    const parsed = parseArgs(["run", "doctor", "--force", "--detach"]);
+
+    expect(parsed.command).toBe("run");
+    expect(parsed.rest).toEqual(["doctor"]);
+    expect(parsed.flags.get("--force")).toBe(true);
+    expect(parsed.flags.get("--detach")).toBe(true);
+  });
+});
+
+describe("interactive command parsing", () => {
+  it("treats free text as a task prompt", () => {
+    expect(parseInteractiveCommand("summarize this repo")).toEqual(["run", "summarize this repo"]);
+  });
+
+  it("maps slash commands to CLI argv", () => {
+    expect(parseInteractiveCommand("/workspace list")).toEqual(["workspace", "list"]);
+    expect(parseInteractiveCommand("/tasks list --active")).toEqual(["tasks", "list", "--active"]);
+    expect(parseInteractiveCommand("/providers configure openai --model \"gpt-4.1-mini\"")).toEqual([
+      "providers",
+      "configure",
+      "openai",
+      "--model",
+      "gpt-4.1-mini",
+    ]);
+  });
+
+  it("supports exit aliases", () => {
+    expect(parseInteractiveCommand("/exit")).toEqual(["exit"]);
+    expect(parseInteractiveCommand("/quit")).toEqual(["exit"]);
+  });
+});
+
+describe("run command guard", () => {
+  it("rejects exact CLI command names as task prompts without --force", async () => {
+    let stderr = "";
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+      stderr += String(chunk);
+      return true;
+    });
+
+    const code = await main(["run", "doctor"]);
+
+    expect(code).toBe(1);
+    expect(stderr).toContain('Did you mean `cowork doctor`?');
+    expect(stderr).toContain("cowork run --force doctor");
+  });
+});

--- a/src/cli/__tests__/terminal-ui.test.ts
+++ b/src/cli/__tests__/terminal-ui.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { promptMarker, renderWelcomeScreen } from "../terminal-ui";
+
+describe("terminal UI", () => {
+  it("renders a CoWork OS welcome screen", () => {
+    const screen = renderWelcomeScreen({
+      version: "0.0.0-test",
+      cwd: "/tmp/cowork",
+      width: 90,
+      color: false,
+    });
+
+    expect(screen).toContain("CoWork OS 0.0.0-test");
+    expect(screen).toContain("Getting started");
+    expect(screen).toContain("/doctor");
+    expect(screen).toContain("/workspace list");
+    expect(screen).toContain("/effort");
+  });
+
+  it("uses the agent-style prompt marker", () => {
+    expect(promptMarker(false)).toBe("❯ ");
+  });
+});

--- a/src/cli/config-store.ts
+++ b/src/cli/config-store.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface CliProfile {
+  url: string;
+  token?: string;
+}
+
+export interface CliConfig {
+  defaultProfile: string;
+  profiles: Record<string, CliProfile>;
+}
+
+export interface ResolvedConnection {
+  profileName: string;
+  url: string;
+  token: string;
+}
+
+export const DEFAULT_CONTROL_PLANE_URL = "ws://127.0.0.1:18789";
+
+export function getConfigPath(): string {
+  const root = process.env.COWORK_CLI_CONFIG_DIR || path.join(os.homedir(), ".cowork-os", "cli");
+  return path.join(root, "config.json");
+}
+
+export function createDefaultConfig(): CliConfig {
+  return {
+    defaultProfile: "local",
+    profiles: {
+      local: {
+        url: DEFAULT_CONTROL_PLANE_URL,
+      },
+    },
+  };
+}
+
+export function loadCliConfig(configPath = getConfigPath()): CliConfig {
+  if (!fs.existsSync(configPath)) return createDefaultConfig();
+  try {
+    const raw = fs.readFileSync(configPath, "utf8");
+    const parsed = JSON.parse(raw);
+    return normalizeConfig(parsed);
+  } catch {
+    return createDefaultConfig();
+  }
+}
+
+export function saveCliConfig(config: CliConfig, configPath = getConfigPath()): void {
+  const dir = path.dirname(configPath);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(configPath, `${JSON.stringify(normalizeConfig(config), null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  try {
+    fs.chmodSync(dir, 0o700);
+    fs.chmodSync(configPath, 0o600);
+  } catch {
+    // Best-effort only, especially on Windows.
+  }
+}
+
+export function resolveConnection(options: {
+  config?: CliConfig;
+  profile?: string;
+  url?: string;
+  token?: string;
+}): ResolvedConnection {
+  const config = options.config ?? loadCliConfig();
+  const profileName = options.profile || config.defaultProfile || "local";
+  const profile = config.profiles[profileName] || config.profiles.local || { url: DEFAULT_CONTROL_PLANE_URL };
+  const url = options.url || process.env.COWORK_CONTROL_PLANE_URL || profile.url || DEFAULT_CONTROL_PLANE_URL;
+  const token = options.token || process.env.COWORK_CONTROL_PLANE_TOKEN || profile.token || "";
+  return { profileName, url, token };
+}
+
+export function upsertProfile(
+  config: CliConfig,
+  profileName: string,
+  updates: Partial<CliProfile>,
+  makeDefault: boolean,
+): CliConfig {
+  const name = profileName.trim() || "local";
+  const current = config.profiles[name] || { url: DEFAULT_CONTROL_PLANE_URL };
+  const next: CliConfig = {
+    defaultProfile: makeDefault ? name : config.defaultProfile || name,
+    profiles: {
+      ...config.profiles,
+      [name]: {
+        ...current,
+        ...updates,
+        url: updates.url || current.url || DEFAULT_CONTROL_PLANE_URL,
+      },
+    },
+  };
+  return normalizeConfig(next);
+}
+
+export function removeProfileToken(config: CliConfig, profileName: string): CliConfig {
+  const name = profileName.trim() || config.defaultProfile || "local";
+  const profile = config.profiles[name];
+  if (!profile) return normalizeConfig(config);
+  const { token: _token, ...rest } = profile;
+  return normalizeConfig({
+    ...config,
+    profiles: {
+      ...config.profiles,
+      [name]: rest,
+    },
+  });
+}
+
+function normalizeConfig(input: unknown): CliConfig {
+  const raw = input && typeof input === "object" ? (input as Partial<CliConfig>) : {};
+  const profilesRaw = raw.profiles && typeof raw.profiles === "object" ? raw.profiles : {};
+  const profiles: Record<string, CliProfile> = {};
+  for (const [name, value] of Object.entries(profilesRaw)) {
+    if (!value || typeof value !== "object") continue;
+    const profile = value as Partial<CliProfile>;
+    profiles[name] = {
+      url: typeof profile.url === "string" && profile.url.trim() ? profile.url.trim() : DEFAULT_CONTROL_PLANE_URL,
+      ...(typeof profile.token === "string" && profile.token.trim() ? { token: profile.token.trim() } : {}),
+    };
+  }
+  if (!profiles.local) profiles.local = { url: DEFAULT_CONTROL_PLANE_URL };
+  const defaultProfile =
+    typeof raw.defaultProfile === "string" && profiles[raw.defaultProfile] ? raw.defaultProfile : "local";
+  return { defaultProfile, profiles };
+}

--- a/src/cli/control-plane-client.ts
+++ b/src/cli/control-plane-client.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import WebSocket from "ws";
+
+export interface ControlPlaneConnectionOptions {
+  url: string;
+  token: string;
+  deviceName?: string;
+  timeoutMs?: number;
+}
+
+export interface ControlPlaneFrame {
+  type: "req" | "res" | "event";
+  id?: string;
+  method?: string;
+  ok?: boolean;
+  payload?: unknown;
+  error?: { code?: string; message?: string; details?: unknown };
+  event?: string;
+  seq?: number;
+  stateVersion?: string;
+}
+
+export class ControlPlaneRequestError extends Error {
+  readonly code?: string;
+  readonly details?: unknown;
+
+  constructor(message: string, code?: string, details?: unknown) {
+    super(message);
+    this.name = "ControlPlaneRequestError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export class ControlPlaneClient {
+  private ws: WebSocket | null = null;
+  private readonly listeners = new Set<(frame: ControlPlaneFrame) => void>();
+  private readonly timeoutMs: number;
+
+  constructor(private readonly options: ControlPlaneConnectionOptions) {
+    this.timeoutMs = options.timeoutMs ?? 15000;
+  }
+
+  async connect(): Promise<void> {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) return;
+
+    const ws = new WebSocket(this.options.url);
+    this.ws = ws;
+    ws.on("message", (data) => {
+      const frame = parseFrame(String(data));
+      if (!frame || frame.type !== "event") return;
+      for (const listener of this.listeners) listener(frame);
+    });
+
+    await waitForOpen(ws, this.timeoutMs);
+    await this.request("connect", {
+      token: this.options.token,
+      deviceName: this.options.deviceName ?? "cowork-cli",
+    });
+  }
+
+  onEvent(listener: (frame: ControlPlaneFrame) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async request<T = unknown>(method: string, params?: unknown, timeoutMs = this.timeoutMs): Promise<T> {
+    const ws = this.requireSocket();
+    const id = randomUUID();
+
+    const response = new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.off("message", onMessage);
+        reject(new ControlPlaneRequestError(`Timed out waiting for ${method}`));
+      }, timeoutMs);
+
+      const onMessage = (data: WebSocket.RawData) => {
+        const frame = parseFrame(String(data));
+        if (!frame || frame.type !== "res" || frame.id !== id) return;
+        clearTimeout(timer);
+        ws.off("message", onMessage);
+        if (frame.ok) {
+          resolve(frame.payload as T);
+          return;
+        }
+        reject(
+          new ControlPlaneRequestError(
+            frame.error?.message || `${method} failed`,
+            frame.error?.code,
+            frame.error?.details,
+          ),
+        );
+      };
+
+      ws.on("message", onMessage);
+    });
+
+    ws.send(JSON.stringify({ type: "req", id, method, ...(params !== undefined ? { params } : {}) }));
+    return response;
+  }
+
+  close(): void {
+    if (!this.ws) return;
+    this.ws.close();
+    this.ws = null;
+  }
+
+  private requireSocket(): WebSocket {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new ControlPlaneRequestError("Control plane is not connected");
+    }
+    return this.ws;
+  }
+}
+
+function waitForOpen(ws: WebSocket, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new ControlPlaneRequestError("Timed out connecting to the control plane"));
+    }, timeoutMs);
+
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("open", onOpen);
+      ws.off("error", onError);
+    };
+
+    ws.once("open", onOpen);
+    ws.once("error", onError);
+  });
+}
+
+function parseFrame(raw: string): ControlPlaneFrame | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    if (parsed.type !== "req" && parsed.type !== "res" && parsed.type !== "event") return null;
+    return parsed as ControlPlaneFrame;
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/direct-run.ts
+++ b/src/cli/direct-run.ts
@@ -1,0 +1,2309 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import type Database from "better-sqlite3";
+import { DatabaseManager } from "../electron/database/schema";
+import { SecureSettingsRepository } from "../electron/database/SecureSettingsRepository";
+import {
+  ApprovalRepository,
+  LLMModelRepository,
+  SkillRepository,
+  TaskEventRepository,
+  TaskRepository,
+  WorkspacePermissionRuleRepository,
+  WorkspaceRepository,
+} from "../electron/database/repositories";
+import { AgentDaemon } from "../electron/agent/daemon";
+import { LLMProviderFactory } from "../electron/agent/llm";
+import { SearchProviderFactory } from "../electron/agent/search";
+import { BuiltinToolsSettingsManager } from "../electron/agent/tools/builtin-settings";
+import { GuardrailManager } from "../electron/guardrails/guardrail-manager";
+import { AppearanceManager } from "../electron/settings/appearance-manager";
+import { PersonalityManager } from "../electron/settings/personality-manager";
+import { MemoryFeaturesManager } from "../electron/settings/memory-features-manager";
+import { MemoryService } from "../electron/memory/MemoryService";
+import { MCPClientManager } from "../electron/mcp/client/MCPClientManager";
+import { MCPSettingsManager } from "../electron/mcp/settings";
+import { getUserDataDir } from "../electron/utils/user-data-dir";
+import { LLMSettingsSchema, MCPSettingsSchema } from "../electron/utils/validation";
+import {
+  importProcessEnvToSettings,
+  migrateEnvToSettings,
+} from "../electron/utils/env-migration";
+import {
+  getEnvSettingsImportModeFromArgsOrEnv,
+  shouldImportEnvSettingsFromArgsOrEnv,
+} from "../electron/utils/runtime-mode";
+import { isTerminalTaskStatus } from "../shared/task-status";
+import type { AgentConfig, CliTaskOwnership, Task } from "../shared/types";
+import { buildTaskTitle } from "./format";
+
+type Any = Record<string, any>;
+
+interface DirectRunArgs {
+  command:
+    | "run"
+    | "doctor"
+    | "version"
+    | "status"
+    | "providers-list"
+    | "providers-fallback-list"
+    | "providers-fallback-add"
+    | "providers-fallback-remove"
+    | "workspace-list"
+    | "workspace-create"
+    | "tail"
+    | "approvals-list"
+    | "providers-configure"
+    | "sessions-list"
+    | "sessions-show"
+    | "sessions-export"
+    | "sessions-rename"
+    | "sessions-delete"
+    | "sessions-prune"
+    | "tasks-list"
+    | "tasks-cancel"
+    | "tasks-attach"
+    | "tasks-stale"
+    | "tasks-cleanup"
+    | "logs-latest"
+    | "logs-tail"
+    | "logs-grep"
+    | "tools-list"
+    | "tools-info"
+    | "tools-enable"
+    | "tools-disable"
+    | "mcp-list"
+    | "mcp-add"
+    | "mcp-remove"
+    | "mcp-enable"
+    | "mcp-disable"
+    | "mcp-test"
+    | "skills-list"
+    | "skills-info"
+    | "skills-audit"
+    | "models-list"
+    | "backup-create"
+    | "backup-restore"
+    | "security-audit"
+    | "security-rules-list"
+    | "security-rules-remove"
+    | "prompt-size"
+    | "prompt-preview"
+    | "dashboard-status";
+  prompt: string;
+  cwd: string;
+  taskId?: string;
+  sessionId?: string;
+  limit?: number;
+  days?: number;
+  providerType?: string;
+  apiKey?: string;
+  model?: string;
+  baseUrl?: string;
+  output?: string;
+  query?: string;
+  name?: string;
+  transport?: string;
+  commandLine?: string;
+  url?: string;
+  category?: string;
+  tool?: string;
+  ruleId?: string;
+  workspaceName?: string;
+  title?: string;
+  workspaceId?: string;
+  shellAccess?: boolean;
+  detach?: boolean;
+  detachedWorker?: boolean;
+  readyFile?: string;
+  activeOnly?: boolean;
+  cliOnly?: boolean;
+  interruptedCli?: boolean;
+  includeSecrets?: boolean;
+  yes?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<number> {
+  const args = parseDirectRunArgs(argv);
+  if (args.command === "run" && !args.prompt) {
+    process.stderr.write('Usage: cowork-direct-run --prompt "task" [--cwd <path>]\n');
+    return 1;
+  }
+
+  process.env.COWORK_HEADLESS = process.env.COWORK_HEADLESS || "1";
+  const allowEnvImport = shouldImportEnvForCommand(args.command);
+  if (allowEnvImport) {
+    process.env.COWORK_IMPORT_ENV_SETTINGS =
+      process.env.COWORK_IMPORT_ENV_SETTINGS ||
+      (hasProviderEnv() ? "1" : process.env.COWORK_IMPORT_ENV_SETTINGS || "");
+  }
+
+  let daemon: AgentDaemon | null = null;
+  let mcpClientManager: MCPClientManager | null = null;
+  let taskRepo: TaskRepository | null = null;
+  let activeTaskId: string | null = null;
+  let activeCliRunId: string | null = null;
+  let activeInterruptPolicy: CliTaskOwnership["interruptPolicy"] = "cancel";
+  let cliHeartbeat: ReturnType<typeof setInterval> | null = null;
+  let done = false;
+  const restoreConsole = installCliLogFilter();
+
+  try {
+    const dbManager = new DatabaseManager();
+    new SecureSettingsRepository(dbManager.getDatabase());
+    taskRepo = new TaskRepository(dbManager.getDatabase());
+
+    LLMProviderFactory.initialize();
+    SearchProviderFactory.initialize();
+    GuardrailManager.initialize();
+    AppearanceManager.initialize();
+    PersonalityManager.initialize();
+    MemoryFeaturesManager.initialize();
+
+    if (allowEnvImport) {
+      await migrateEnvToSettings();
+    }
+    if (allowEnvImport && shouldImportEnvSettingsFromArgsOrEnv()) {
+      await importProcessEnvToSettings({
+        mode: getEnvSettingsImportModeFromArgsOrEnv(),
+      });
+    }
+
+    const localResult = await runLocalMetadataCommand(dbManager, args);
+    if (localResult !== null) return localResult;
+
+    MemoryService.initialize(dbManager);
+
+    daemon = new AgentDaemon(dbManager, { startupRecovery: false });
+    process.once("SIGINT", onSignal);
+    process.once("SIGTERM", onSignal);
+    await daemon.initialize();
+
+    try {
+      mcpClientManager = MCPClientManager.getInstance();
+      await mcpClientManager.initialize();
+    } catch (error) {
+      const message = `[MCP] ${error instanceof Error ? error.message : String(error)}`;
+      writeEvent(args, { type: "mcp_error", message }, message);
+    }
+
+    const workspace = await resolveWorkspace(daemon, args);
+    if (args.shellAccess) {
+      daemon.updateWorkspacePermissions(workspace.id, { shell: true });
+    }
+    const cliRunId = randomUUID();
+    const cliOwnership: CliTaskOwnership = {
+      owner: "cowork-run",
+      runId: cliRunId,
+      pid: process.pid,
+      startedAt: Date.now(),
+      cwd: path.resolve(args.cwd),
+      mode: args.detachedWorker || args.detach ? "detached" : "attached",
+      interruptPolicy: args.detachedWorker || args.detach ? "detach" : "cancel",
+      lastSeenAt: Date.now(),
+    };
+    const agentConfig: AgentConfig = {
+      ...(args.shellAccess ? { shellAccess: true } : {}),
+      cli: cliOwnership,
+    };
+
+    const task = await daemon.createTask({
+      title: args.title || buildTaskTitle(args.prompt),
+      prompt: args.prompt,
+      workspaceId: workspace.id,
+      agentConfig,
+      autoStart: false,
+    });
+    activeTaskId = task.id;
+    activeCliRunId = cliRunId;
+    activeInterruptPolicy = cliOwnership.interruptPolicy;
+    startCliHeartbeat();
+
+    writeEvent(args, {
+      type: "task_created",
+      task: {
+        id: task.id,
+        title: task.title,
+        status: task.status,
+        workspaceId: task.workspaceId,
+      },
+    }, `Created task: ${task.id}  ${task.title}`);
+    if (args.readyFile) {
+      await writeDetachedReadyFile(args.readyFile, task);
+    }
+
+    daemon.on("assistant_message", (payload: Any) => {
+      if (payload?.taskId !== task.id) return;
+      const message = stringifyMessage(payload.message || payload.text || payload.content);
+      if (message) writeEvent(args, { type: "assistant_message", taskId: task.id, message }, message);
+    });
+    daemon.on("task_status", (payload: Any) => {
+      if (payload?.taskId !== task.id) return;
+      const message = stringifyMessage(payload.message || payload.status);
+      if (message) writeEvent(args, { type: "task_status", taskId: task.id, message }, message);
+    });
+    daemon.on("task_completed", (payload: Any) => {
+      if (payload?.taskId !== task.id) return;
+      const message = stringifyMessage(payload.message || payload.resultSummary || "Task completed.");
+      if (message) writeEvent(args, { type: "task_completed", taskId: task.id, message }, message);
+      done = true;
+    });
+
+    await daemon.startTask(task);
+
+    const status = await waitForTerminalTask(daemon, task.id, args);
+    await updateActiveCliOwnership({ endedAt: Date.now(), exitCode: status === "completed" ? 0 : 1 });
+    stopCliHeartbeat();
+    activeTaskId = null;
+    activeCliRunId = null;
+    done = true;
+    return status === "failed" || status === "cancelled" ? 1 : 0;
+  } catch (error) {
+    writeError(args, formatError(error));
+    return 1;
+  } finally {
+    done = true;
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+    stopCliHeartbeat();
+    await shutdownRuntime();
+    restoreConsole();
+  }
+
+  function onSignal(signal?: NodeJS.Signals): void {
+    if (done) return;
+    done = true;
+    const shouldCancel = activeInterruptPolicy === "cancel" || signal === "SIGTERM";
+    const settle = shouldCancel
+      ? cancelActiveTask()
+      : updateActiveCliOwnership({ endedAt: Date.now(), exitCode: 130 });
+    void settle.finally(() => {
+      stopCliHeartbeat();
+      void shutdownRuntime().finally(() => process.exit(130));
+    });
+  }
+
+  async function cancelActiveTask(): Promise<void> {
+    const taskId = activeTaskId;
+    if (!daemon || !taskId) return;
+    try {
+      await daemon.cancelTask(taskId);
+      await updateActiveCliOwnership({ endedAt: Date.now(), exitCode: 130 });
+    } catch {
+      // Best-effort: SIGINT should still tear down the direct runner.
+    } finally {
+      activeTaskId = null;
+      activeCliRunId = null;
+    }
+  }
+
+  function startCliHeartbeat(): void {
+    stopCliHeartbeat();
+    cliHeartbeat = setInterval(() => {
+      void updateActiveCliOwnership({ lastSeenAt: Date.now() });
+    }, 5000);
+  }
+
+  function stopCliHeartbeat(): void {
+    if (cliHeartbeat) {
+      clearInterval(cliHeartbeat);
+      cliHeartbeat = null;
+    }
+  }
+
+  async function updateActiveCliOwnership(updates: Partial<CliTaskOwnership>): Promise<void> {
+    const taskId = activeTaskId;
+    const runId = activeCliRunId;
+    if (!taskRepo || !taskId || !runId) return;
+    const task = taskRepo.findById(taskId);
+    const cli = getCliOwnership(task);
+    if (!task || !cli || cli.runId !== runId) return;
+    taskRepo.update(taskId, {
+      agentConfig: {
+        ...(task.agentConfig || {}),
+        cli: {
+          ...cli,
+          ...updates,
+        },
+      },
+    });
+  }
+
+  async function shutdownRuntime(): Promise<void> {
+    try {
+      await mcpClientManager?.shutdown?.();
+    } catch {
+      // Best-effort.
+    }
+    try {
+      await daemon?.shutdown();
+    } catch {
+      // Best-effort.
+    }
+  }
+}
+
+async function resolveWorkspace(daemon: AgentDaemon, args: DirectRunArgs) {
+  if (args.workspaceId) {
+    const workspace = daemon.getWorkspaceById(args.workspaceId);
+    if (!workspace) throw new Error(`Workspace not found: ${args.workspaceId}`);
+    return workspace;
+  }
+
+  const cwd = path.resolve(args.cwd);
+  await fs.mkdir(cwd, { recursive: true });
+  const existing = daemon.getWorkspaceByPath(cwd);
+  if (existing) return existing;
+  return daemon.createWorkspace(path.basename(cwd) || "Workspace", cwd);
+}
+
+async function waitForTerminalTask(
+  daemon: AgentDaemon,
+  taskId: string,
+  args: DirectRunArgs,
+): Promise<Task["status"]> {
+  let lastStatus = "";
+  while (true) {
+    const task = await daemon.getTaskById(taskId);
+    if (!task) throw new Error(`Task disappeared: ${taskId}`);
+    if (task.status !== lastStatus) {
+      lastStatus = task.status;
+      if (task.status !== "pending" && task.status !== "executing") {
+        writeEvent(args, { type: "status", taskId, status: task.status }, `Status: ${task.status}`);
+      }
+    }
+    if (isTerminalTaskStatus(task.status)) {
+      if (task.resultSummary) {
+        writeEvent(args, { type: "result_summary", taskId, message: task.resultSummary }, task.resultSummary);
+      }
+      if (task.error) writeError(args, task.error, taskId);
+      return task.status;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+}
+
+function parseDirectRunArgs(argv: string[]): DirectRunArgs {
+  const args: DirectRunArgs = { command: "run", prompt: "", cwd: process.cwd() };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case "--doctor":
+        args.command = "doctor";
+        break;
+      case "--version":
+        args.command = "version";
+        break;
+      case "--status":
+        args.command = "status";
+        break;
+      case "--providers-list":
+        args.command = "providers-list";
+        break;
+      case "--providers-fallback-list":
+        args.command = "providers-fallback-list";
+        break;
+      case "--providers-fallback-add":
+        args.command = "providers-fallback-add";
+        break;
+      case "--providers-fallback-remove":
+        args.command = "providers-fallback-remove";
+        break;
+      case "--workspace-list":
+        args.command = "workspace-list";
+        break;
+      case "--workspace-create":
+        args.command = "workspace-create";
+        break;
+      case "--tail":
+        args.command = "tail";
+        break;
+      case "--approvals-list":
+        args.command = "approvals-list";
+        break;
+      case "--providers-configure":
+        args.command = "providers-configure";
+        break;
+      case "--sessions-list":
+        args.command = "sessions-list";
+        break;
+      case "--sessions-show":
+        args.command = "sessions-show";
+        break;
+      case "--sessions-export":
+        args.command = "sessions-export";
+        break;
+      case "--sessions-rename":
+        args.command = "sessions-rename";
+        break;
+      case "--sessions-delete":
+        args.command = "sessions-delete";
+        break;
+      case "--sessions-prune":
+        args.command = "sessions-prune";
+        break;
+      case "--tasks-list":
+        args.command = "tasks-list";
+        break;
+      case "--tasks-cancel":
+        args.command = "tasks-cancel";
+        break;
+      case "--tasks-attach":
+        args.command = "tasks-attach";
+        break;
+      case "--tasks-stale":
+        args.command = "tasks-stale";
+        break;
+      case "--tasks-cleanup":
+        args.command = "tasks-cleanup";
+        break;
+      case "--logs-latest":
+        args.command = "logs-latest";
+        break;
+      case "--logs-tail":
+        args.command = "logs-tail";
+        break;
+      case "--logs-grep":
+        args.command = "logs-grep";
+        break;
+      case "--tools-list":
+        args.command = "tools-list";
+        break;
+      case "--tools-info":
+        args.command = "tools-info";
+        break;
+      case "--tools-enable":
+        args.command = "tools-enable";
+        break;
+      case "--tools-disable":
+        args.command = "tools-disable";
+        break;
+      case "--mcp-list":
+        args.command = "mcp-list";
+        break;
+      case "--mcp-add":
+        args.command = "mcp-add";
+        break;
+      case "--mcp-remove":
+        args.command = "mcp-remove";
+        break;
+      case "--mcp-enable":
+        args.command = "mcp-enable";
+        break;
+      case "--mcp-disable":
+        args.command = "mcp-disable";
+        break;
+      case "--mcp-test":
+        args.command = "mcp-test";
+        break;
+      case "--skills-list":
+        args.command = "skills-list";
+        break;
+      case "--skills-info":
+        args.command = "skills-info";
+        break;
+      case "--skills-audit":
+        args.command = "skills-audit";
+        break;
+      case "--models-list":
+        args.command = "models-list";
+        break;
+      case "--backup-create":
+        args.command = "backup-create";
+        break;
+      case "--backup-restore":
+        args.command = "backup-restore";
+        break;
+      case "--security-audit":
+        args.command = "security-audit";
+        break;
+      case "--security-rules-list":
+        args.command = "security-rules-list";
+        break;
+      case "--security-rules-remove":
+        args.command = "security-rules-remove";
+        break;
+      case "--prompt-size":
+        args.command = "prompt-size";
+        break;
+      case "--prompt-preview":
+        args.command = "prompt-preview";
+        break;
+      case "--dashboard-status":
+        args.command = "dashboard-status";
+        break;
+      case "--task-id":
+        args.taskId = next || "";
+        i++;
+        break;
+      case "--session-id":
+        args.sessionId = next || "";
+        i++;
+        break;
+      case "--provider":
+        args.providerType = next || "";
+        i++;
+        break;
+      case "--name":
+        args.name = next || "";
+        args.workspaceName = args.workspaceName || args.name;
+        i++;
+        break;
+      case "--transport":
+        args.transport = next || "";
+        i++;
+        break;
+      case "--command":
+        args.commandLine = next || "";
+        i++;
+        break;
+      case "--url":
+        args.url = next || "";
+        i++;
+        break;
+      case "--output":
+        args.output = next || "";
+        i++;
+        break;
+      case "--query":
+        args.query = next || "";
+        i++;
+        break;
+      case "--category":
+        args.category = next || "";
+        i++;
+        break;
+      case "--tool":
+        args.tool = next || "";
+        i++;
+        break;
+      case "--rule-id":
+        args.ruleId = next || "";
+        i++;
+        break;
+      case "--api-key":
+        args.apiKey = next || "";
+        i++;
+        break;
+      case "--model":
+        args.model = next || "";
+        i++;
+        break;
+      case "--base-url":
+        args.baseUrl = next || "";
+        i++;
+        break;
+      case "--limit":
+        args.limit = sanitizeLimit(next);
+        i++;
+        break;
+      case "--days":
+        args.days = sanitizeDays(next);
+        i++;
+        break;
+      case "--prompt":
+        args.prompt = next || "";
+        i++;
+        break;
+      case "--cwd":
+        args.cwd = next || process.cwd();
+        i++;
+        break;
+      case "--title":
+        args.title = next || "";
+        i++;
+        break;
+      case "--workspace-id":
+        args.workspaceId = next || "";
+        i++;
+        break;
+      case "--shell":
+        args.shellAccess = true;
+        break;
+      case "--detach":
+        args.detach = true;
+        break;
+      case "--detached-worker":
+        args.detachedWorker = true;
+        break;
+      case "--ready-file":
+        args.readyFile = next || "";
+        i++;
+        break;
+      case "--active":
+        args.activeOnly = true;
+        break;
+      case "--cli":
+        args.cliOnly = true;
+        break;
+      case "--interrupted-cli":
+        args.interruptedCli = true;
+        break;
+      case "--include-secrets":
+        args.includeSecrets = true;
+        break;
+      case "--yes":
+      case "-y":
+        args.yes = true;
+        break;
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      default:
+        break;
+    }
+  }
+  return args;
+}
+
+async function runLocalMetadataCommand(
+  dbManager: DatabaseManager,
+  args: DirectRunArgs,
+): Promise<number | null> {
+  const db = dbManager.getDatabase();
+  const tasks = new TaskRepository(db);
+  const workspaces = new WorkspaceRepository(db);
+  const approvals = new ApprovalRepository(db);
+
+  switch (args.command) {
+    case "doctor": {
+      const providerStatus = LLMProviderFactory.getConfigStatus();
+      const allWorkspaces = workspaces.findAll();
+      const payload = {
+        type: "doctor",
+        ok: true,
+        runtime: "local",
+        profileData: "local",
+        currentProvider: providerStatus.currentProvider,
+        currentModel: providerStatus.currentModel,
+        configuredProviders: providerStatus.providers.filter((provider) => provider.configured),
+        workspaceCount: allWorkspaces.length,
+        cwd: path.resolve(args.cwd),
+      };
+      writeEvent(args, payload, formatDoctor(payload));
+      return 0;
+    }
+    case "version": {
+      const pkg = await readPackageInfo();
+      const payload = {
+        type: "version",
+        version: pkg.version,
+        name: pkg.name,
+        node: process.versions.node,
+        electron: process.versions.electron || null,
+        platform: process.platform,
+        arch: process.arch,
+        userData: getUserDataDir(),
+      };
+      writeEvent(
+        args,
+        payload,
+        [
+          `CoWork OS ${pkg.version}`,
+          `Node ${process.versions.node}`,
+          ...(process.versions.electron ? [`Electron ${process.versions.electron}`] : []),
+          `${process.platform} ${process.arch}`,
+        ].join("\n"),
+      );
+      return 0;
+    }
+    case "providers-list": {
+      const providerStatus = LLMProviderFactory.getConfigStatus();
+      const configured = providerStatus.providers.filter((provider) => provider.configured);
+      writeEvent(
+        args,
+        {
+          type: "providers",
+          currentProvider: providerStatus.currentProvider,
+          currentModel: providerStatus.currentModel,
+          providers: providerStatus.providers,
+        },
+        [
+          `Current: ${providerStatus.currentProvider} (${providerStatus.currentModel || "default model"})`,
+          ...(configured.length
+            ? configured.map((provider) => `- ${provider.name} (${provider.type}) configured`)
+            : ["No local providers configured. Open Settings > LLM in the desktop app or import provider env settings."]),
+        ].join("\n"),
+      );
+      return 0;
+    }
+    case "providers-configure": {
+      if (!args.providerType) throw new Error("Usage: cowork providers configure <provider> [--api-key <key>] [--model <model>] [--base-url <url>]");
+      const result = configureLocalProvider(args);
+      writeEvent(
+        args,
+        { type: "provider_configured", providerType: result.providerType, model: result.model },
+        `Configured local provider "${result.providerType}"${result.model ? ` (${result.model})` : ""}.`,
+      );
+      return 0;
+    }
+    case "workspace-list": {
+      const allWorkspaces = workspaces.findAll();
+      const visibleWorkspaces = allWorkspaces.filter((workspace) => !workspace.isTemp && !workspace.id.startsWith("__temp_workspace__"));
+      writeEvent(
+        args,
+        { type: "workspaces", workspaces: visibleWorkspaces, totalCount: allWorkspaces.length, hiddenTemporaryCount: allWorkspaces.length - visibleWorkspaces.length },
+        visibleWorkspaces.length
+          ? [
+              ...visibleWorkspaces.map((workspace) => `${workspace.name}  ${workspace.path}  (${workspace.id})`),
+              ...(allWorkspaces.length > visibleWorkspaces.length
+                ? [`Hidden temporary workspaces: ${allWorkspaces.length - visibleWorkspaces.length}`]
+                : []),
+            ].join("\n")
+          : "No local workspaces configured.",
+      );
+      return 0;
+    }
+    case "workspace-create": {
+      const workspacePath = path.resolve(args.cwd);
+      await fs.mkdir(workspacePath, { recursive: true });
+      const existing = workspaces.findByPath(workspacePath);
+      const workspace =
+        existing ||
+        workspaces.create(args.workspaceName || path.basename(workspacePath) || "Workspace", workspacePath, {
+          read: true,
+          write: true,
+          delete: false,
+          network: true,
+          shell: false,
+        });
+      writeEvent(
+        args,
+        { type: "workspace", workspace, created: !existing },
+        `${existing ? "Workspace exists" : "Created workspace"}: ${workspace.name}  ${workspace.path}  (${workspace.id})`,
+      );
+      return 0;
+    }
+    case "tail": {
+      if (!args.taskId) throw new Error("Usage: cowork tail <taskId> [--limit <n>]");
+      const task = tasks.findById(args.taskId);
+      if (!task) throw new Error(`Task not found: ${args.taskId}`);
+      const events = new TaskEventRepository(db).findRecentByTaskId(args.taskId, args.limit || 200);
+      writeEvent(
+        args,
+        { type: "task_events", task, events },
+        events.length
+          ? events.map(formatTaskEventLine).join("\n")
+          : `No events found for task ${args.taskId}.`,
+      );
+      return 0;
+    }
+    case "approvals-list": {
+      const rows = approvals.findPending(args.limit || 100);
+      writeEvent(
+        args,
+        { type: "approvals", approvals: rows },
+        rows.length
+          ? rows.map((approval) => `${approval.id}  ${approval.type}  ${approval.description}  task=${approval.taskId}`).join("\n")
+          : "No pending approvals.",
+      );
+      return 0;
+    }
+    case "status":
+    case "dashboard-status": {
+      const providerStatus = LLMProviderFactory.getConfigStatus();
+      const mcpSettings = MCPSettingsManager.loadSettings();
+      const toolSettings = BuiltinToolsSettingsManager.loadSettings();
+      const taskCounts = countTasksByStatus(db);
+      const workspaceCount = workspaces.findAll().length;
+      const pendingApprovals = approvals.findPending(1000).length;
+      const enabledToolCategories = Object.entries(toolSettings.categories)
+        .filter(([, value]) => value.enabled)
+        .map(([key]) => key);
+      const payload = {
+        type: args.command === "dashboard-status" ? "dashboard_status" : "status",
+        runtime: "local",
+        controlPlaneRequired: false,
+        currentProvider: providerStatus.currentProvider,
+        currentModel: providerStatus.currentModel,
+        configuredProviders: providerStatus.providers.filter((provider) => provider.configured),
+        workspaceCount,
+        taskCounts,
+        pendingApprovals,
+        mcpServers: mcpSettings.servers.length,
+        enabledToolCategories,
+      };
+      writeEvent(
+        args,
+        payload,
+        [
+          "CoWork OS local status",
+          "- runtime: local direct runner",
+          "- control plane: not required",
+          `- provider: ${providerStatus.currentProvider} (${providerStatus.currentModel || "default model"})`,
+          `- workspaces: ${workspaceCount}`,
+          `- tasks: ${formatCountMap(taskCounts) || "none"}`,
+          `- pending approvals: ${pendingApprovals}`,
+          `- mcp servers: ${mcpSettings.servers.length}`,
+          `- enabled tool categories: ${enabledToolCategories.join(", ") || "none"}`,
+        ].join("\n"),
+      );
+      return 0;
+    }
+    case "sessions-list":
+      return await listSessions(tasks, args);
+    case "sessions-show":
+      return await showSession(tasks, args);
+    case "sessions-export":
+      return await exportSession(tasks, args);
+    case "sessions-rename":
+      return await renameSession(tasks, args);
+    case "sessions-delete":
+      return await deleteSession(tasks, args);
+    case "sessions-prune":
+      return await pruneSessions(tasks, args);
+    case "tasks-list":
+      return listCliTasks(tasks, args);
+    case "tasks-cancel":
+      return cancelCliTask(tasks, new TaskEventRepository(db), args);
+    case "tasks-attach":
+      return await attachCliTask(tasks, new TaskEventRepository(db), args);
+    case "tasks-stale":
+      return listStaleCliTasks(tasks, args);
+    case "tasks-cleanup":
+      return cleanupStaleCliTasks(tasks, new TaskEventRepository(db), args);
+    case "logs-latest":
+    case "logs-tail":
+    case "logs-grep":
+      return await logsCommand(args);
+    case "tools-list":
+    case "tools-info":
+    case "tools-enable":
+    case "tools-disable":
+      return toolsCommand(args);
+    case "mcp-list":
+    case "mcp-add":
+    case "mcp-remove":
+    case "mcp-enable":
+    case "mcp-disable":
+      return mcpSettingsCommand(args);
+    case "mcp-test":
+      return await mcpTestCommand(args);
+    case "skills-list":
+    case "skills-info":
+    case "skills-audit":
+      return await skillsCommand(new SkillRepository(db), args);
+    case "models-list":
+      return modelsCommand(new LLMModelRepository(db), args);
+    case "providers-fallback-list":
+    case "providers-fallback-add":
+    case "providers-fallback-remove":
+      return providerFallbackCommand(args);
+    case "backup-create":
+      return await createBackup(dbManager, args);
+    case "backup-restore":
+      return await restoreBackup(args);
+    case "security-audit":
+      return securityAuditCommand(db, args);
+    case "security-rules-list":
+      return securityRulesListCommand(db, args);
+    case "security-rules-remove":
+      return securityRulesRemoveCommand(db, args);
+    case "prompt-size":
+    case "prompt-preview":
+      return promptCommand(args);
+    default:
+      return null;
+  }
+}
+
+async function listSessions(taskRepo: TaskRepository, args: DirectRunArgs): Promise<number> {
+  const metadata = await readSessionMetadata();
+  const sessions = buildSessionSummaries(taskRepo.findAll(args.limit || 1000))
+    .filter((session) => !metadata[session.id]?.archivedAt);
+  const limited = sessions.slice(0, args.limit || 50);
+  writeEvent(
+    args,
+    { type: "sessions", sessions: limited, metadata },
+    limited.length
+      ? limited
+          .map((session) => {
+            const name = metadata[session.id]?.name || session.title || "Untitled";
+            return `${session.id}  ${name}  tasks=${session.count}  latest=${session.latestStatus}  updated=${formatDate(session.updatedAt)}`;
+          })
+          .join("\n")
+      : "No local sessions found.",
+  );
+  return 0;
+}
+
+async function showSession(taskRepo: TaskRepository, args: DirectRunArgs): Promise<number> {
+  const sessionId = requireSessionId(args);
+  const rows = tasksForSession(taskRepo, sessionId, args.limit || 200);
+  const metadata = await readSessionMetadata();
+  if (rows.length === 0) throw new Error(`Session not found: ${sessionId}`);
+  writeEvent(
+    args,
+    { type: "session", sessionId, metadata: metadata[sessionId] || null, tasks: rows },
+    [
+      `Session: ${sessionId}`,
+      ...(metadata[sessionId]?.name ? [`Name: ${metadata[sessionId].name}`] : []),
+      ...rows.map((task) => `${formatDate(task.updatedAt || task.createdAt)}  ${task.status}  ${task.id}  ${task.title}`),
+    ].join("\n"),
+  );
+  return 0;
+}
+
+async function exportSession(taskRepo: TaskRepository, args: DirectRunArgs): Promise<number> {
+  const sessionId = requireSessionId(args);
+  const rows = tasksForSession(taskRepo, sessionId, args.limit || 1000);
+  if (rows.length === 0) throw new Error(`Session not found: ${sessionId}`);
+  const payload = {
+    type: "session_export",
+    exportedAt: new Date().toISOString(),
+    sessionId,
+    tasks: rows,
+  };
+  if (args.output) {
+    await fs.writeFile(path.resolve(args.output), JSON.stringify(payload, null, 2));
+    writeEvent(args, payload, `Exported session ${sessionId} to ${path.resolve(args.output)}.`);
+  } else {
+    writeEvent(args, payload, JSON.stringify(payload, null, 2));
+  }
+  return 0;
+}
+
+async function renameSession(taskRepo: TaskRepository, args: DirectRunArgs): Promise<number> {
+  const sessionId = requireSessionId(args);
+  const name = (args.name || args.title || "").trim();
+  if (!name) throw new Error("Usage: cowork sessions rename <sessionId> <name>");
+  if (tasksForSession(taskRepo, sessionId, 1).length === 0) throw new Error(`Session not found: ${sessionId}`);
+  const metadata = await readSessionMetadata();
+  metadata[sessionId] = { ...(metadata[sessionId] || {}), name, updatedAt: Date.now() };
+  await writeSessionMetadata(metadata);
+  writeEvent(args, { type: "session_renamed", sessionId, name }, `Renamed session ${sessionId} to "${name}".`);
+  return 0;
+}
+
+async function deleteSession(taskRepo: TaskRepository, args: DirectRunArgs): Promise<number> {
+  const sessionId = requireSessionId(args);
+  const rows = tasksForSession(taskRepo, sessionId, 10000);
+  if (rows.length === 0) throw new Error(`Session not found: ${sessionId}`);
+  if (!args.yes) {
+    writeEvent(
+      args,
+      { type: "session_delete_preview", sessionId, taskCount: rows.length, requiresYes: true },
+      `Session ${sessionId} has ${rows.length} task(s). Re-run with --yes to archive it from CLI lists.`,
+    );
+    return 1;
+  }
+  const metadata = await readSessionMetadata();
+  metadata[sessionId] = { ...(metadata[sessionId] || {}), archivedAt: Date.now(), updatedAt: Date.now() };
+  await writeSessionMetadata(metadata);
+  writeEvent(args, { type: "session_archived", sessionId, taskCount: rows.length }, `Archived session ${sessionId} from CLI lists. No task data was deleted.`);
+  return 0;
+}
+
+async function pruneSessions(taskRepo: TaskRepository, args: DirectRunArgs): Promise<number> {
+  const days = args.days || 30;
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  const metadata = await readSessionMetadata();
+  const sessions = buildSessionSummaries(taskRepo.findAll(10000)).filter(
+    (session) => session.updatedAt < cutoff && session.terminal && !metadata[session.id]?.archivedAt,
+  );
+  const taskCount = sessions.reduce((sum, session) => sum + session.count, 0);
+  if (!args.yes) {
+    writeEvent(
+      args,
+      { type: "sessions_prune_preview", days, sessions: sessions.length, taskCount, requiresYes: true },
+      `Would archive ${sessions.length} terminal session(s) (${taskCount} task(s)) older than ${days} day(s) from CLI lists. Re-run with --yes.`,
+    );
+    return sessions.length ? 1 : 0;
+  }
+  for (const session of sessions) {
+    metadata[session.id] = { ...(metadata[session.id] || {}), archivedAt: Date.now(), updatedAt: Date.now() };
+  }
+  await writeSessionMetadata(metadata);
+  writeEvent(args, { type: "sessions_archived", days, sessions: sessions.length, taskCount }, `Archived ${sessions.length} session(s) from CLI lists. No task data was deleted.`);
+  return 0;
+}
+
+function listCliTasks(taskRepo: TaskRepository, args: DirectRunArgs): number {
+  const rows = taskRepo.findAll(args.limit || 1000)
+    .filter((task) => !args.activeOnly || !isTerminalTaskStatus(task.status))
+    .filter((task) => !args.cliOnly || Boolean(getCliOwnership(task)))
+    .slice(0, args.limit || 50);
+  writeEvent(
+    args,
+    { type: "tasks", tasks: rows },
+    rows.length
+      ? rows.map(formatCliTaskLine).join("\n")
+      : "No matching local tasks found.",
+  );
+  return 0;
+}
+
+function cancelCliTask(
+  taskRepo: TaskRepository,
+  eventRepo: TaskEventRepository,
+  args: DirectRunArgs,
+): number {
+  const taskId = (args.taskId || args.name || args.prompt || "").trim();
+  if (!taskId) throw new Error("Usage: cowork tasks cancel <taskId>");
+  const task = taskRepo.findById(taskId);
+  if (!task) throw new Error(`Task not found: ${taskId}`);
+  if (isTerminalTaskStatus(task.status)) {
+    writeEvent(args, { type: "task_cancel_noop", task }, `Task ${task.id} is already ${task.status}.`);
+    return 0;
+  }
+  if (!getCliOwnership(task)) {
+    throw new Error(
+      "Local task cancellation is limited to CLI-owned tasks. Use `cowork tasks cancel <taskId> --remote` to cancel a task owned by the desktop app.",
+    );
+  }
+  terminateCliOwner(task);
+  markTaskCancelled(taskRepo, eventRepo, task, "Task was stopped by CLI command", 130);
+  writeEvent(args, { type: "task_cancelled", taskId: task.id }, `Cancelled task ${task.id}.`);
+  return 0;
+}
+
+async function attachCliTask(
+  taskRepo: TaskRepository,
+  eventRepo: TaskEventRepository,
+  args: DirectRunArgs,
+): Promise<number> {
+  const taskId = (args.taskId || args.name || args.prompt || "").trim();
+  if (!taskId) throw new Error("Usage: cowork tasks attach <taskId>");
+  const task = taskRepo.findById(taskId);
+  if (!task) throw new Error(`Task not found: ${taskId}`);
+  const seen = new Set<string>();
+  const printNewEvents = () => {
+    const events = eventRepo.findRecentByTaskId(taskId, args.limit || 200);
+    for (const event of events) {
+      const key = event.id || `${event.timestamp}:${event.type}:${JSON.stringify(event.payload || {})}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      writeEvent(args, { type: "task_event", taskId, event }, formatTaskEventLine(event));
+    }
+  };
+  printNewEvents();
+  if (isTerminalTaskStatus(task.status)) return task.status === "failed" || task.status === "cancelled" ? 1 : 0;
+
+  return await new Promise((resolve) => {
+    const interval = setInterval(() => {
+      printNewEvents();
+      const latest = taskRepo.findById(taskId);
+      if (!latest || isTerminalTaskStatus(latest.status)) {
+        clearInterval(interval);
+        resolve(!latest || latest.status === "failed" || latest.status === "cancelled" ? 1 : 0);
+      }
+    }, 1000);
+    const onSignal = () => {
+      clearInterval(interval);
+      resolve(130);
+    };
+    process.once("SIGINT", onSignal);
+    process.once("SIGTERM", onSignal);
+  });
+}
+
+function listStaleCliTasks(taskRepo: TaskRepository, args: DirectRunArgs): number {
+  const rows = findStaleCliTasks(taskRepo, args.limit || 1000);
+  writeEvent(
+    args,
+    { type: "stale_cli_tasks", tasks: rows },
+    rows.length
+      ? rows.map(formatCliTaskLine).join("\n")
+      : "No stale attached CLI tasks found.",
+  );
+  return rows.length ? 1 : 0;
+}
+
+function cleanupStaleCliTasks(
+  taskRepo: TaskRepository,
+  eventRepo: TaskEventRepository,
+  args: DirectRunArgs,
+): number {
+  if (!args.interruptedCli) {
+    throw new Error("Usage: cowork tasks cleanup --interrupted-cli --yes");
+  }
+  const rows = findStaleCliTasks(taskRepo, args.limit || 1000);
+  if (!args.yes) {
+    writeEvent(
+      args,
+      { type: "stale_cli_tasks_cleanup_preview", tasks: rows, requiresYes: true },
+      rows.length
+        ? `Would cancel ${rows.length} stale attached CLI task(s). Re-run with --yes.`
+        : "No stale attached CLI tasks found.",
+    );
+    return rows.length ? 1 : 0;
+  }
+  for (const task of rows) {
+    markTaskCancelled(taskRepo, eventRepo, task, "CLI task owner exited before completion", 130);
+  }
+  writeEvent(
+    args,
+    { type: "stale_cli_tasks_cleaned", taskIds: rows.map((task) => task.id) },
+    rows.length
+      ? `Cancelled ${rows.length} stale attached CLI task(s).`
+      : "No stale attached CLI tasks found.",
+  );
+  return 0;
+}
+
+async function logsCommand(args: DirectRunArgs): Promise<number> {
+  const root = await findPackageRoot();
+  const latest = path.join(root, "logs", "dev-latest.log");
+  let text = "";
+  try {
+    text = await fs.readFile(latest, "utf8");
+  } catch {
+    writeEvent(args, { type: "logs", path: latest, exists: false }, `No development log found at ${latest}.`);
+    return 1;
+  }
+  const limit = args.limit || 80;
+  let lines = text.split(/\r?\n/).filter(Boolean);
+  if (args.command === "logs-grep") {
+    const query = (args.query || args.prompt || "").trim();
+    if (!query) throw new Error("Usage: cowork logs grep <query>");
+    lines = lines.filter((line) => line.toLowerCase().includes(query.toLowerCase()));
+  }
+  const tail = lines.slice(-limit);
+  writeEvent(args, { type: "logs", path: latest, lines: tail }, tail.length ? tail.join("\n") : "No matching log lines.");
+  return 0;
+}
+
+function toolsCommand(args: DirectRunArgs): number {
+  const settings = BuiltinToolsSettingsManager.loadSettings();
+  if (args.command === "tools-list") {
+    const categories = Object.entries(settings.categories).map(([name, config]) => ({
+      name,
+      enabled: config.enabled,
+      priority: config.priority,
+      tools: BuiltinToolsSettingsManager.getToolsByCategory()[name] || [],
+    }));
+    writeEvent(
+      args,
+      { type: "tools", categories, overrides: settings.toolOverrides },
+      categories
+        .map((category) => `${category.name}  ${category.enabled ? "enabled" : "disabled"}  ${category.priority}  tools=${category.tools.length}`)
+        .join("\n"),
+    );
+    return 0;
+  }
+  const target = args.category || args.tool || args.name || args.prompt;
+  if (!target) throw new Error("Usage: cowork tools info|enable|disable <category-or-tool>");
+  const categories = settings.categories as Any;
+  const isCategory = Boolean(categories[target]);
+  if (args.command === "tools-info") {
+    const payload = isCategory
+      ? { type: "tool_category", name: target, ...categories[target], tools: BuiltinToolsSettingsManager.getToolsByCategory()[target] || [] }
+      : {
+          type: "tool",
+          name: target,
+          enabled: BuiltinToolsSettingsManager.isToolEnabled(target),
+          category: BuiltinToolsSettingsManager.getToolCategory(target),
+          priority: BuiltinToolsSettingsManager.getToolPriority(target),
+          autoApprove: BuiltinToolsSettingsManager.getToolAutoApprove(target),
+          timeoutMs: BuiltinToolsSettingsManager.getToolTimeoutMs(target),
+        };
+    writeEvent(args, payload, JSON.stringify(payload, null, 2));
+    return 0;
+  }
+  const enabled = args.command === "tools-enable";
+  if (isCategory) {
+    BuiltinToolsSettingsManager.setCategoryEnabled(target as keyof typeof settings.categories, enabled);
+  } else {
+    BuiltinToolsSettingsManager.setToolOverride(target, { enabled, priority: BuiltinToolsSettingsManager.getToolPriority(target) });
+  }
+  writeEvent(args, { type: "tool_updated", target, enabled }, `${enabled ? "Enabled" : "Disabled"} ${isCategory ? "category" : "tool"} ${target}.`);
+  return 0;
+}
+
+function mcpSettingsCommand(args: DirectRunArgs): number {
+  MCPSettingsManager.initialize();
+  if (args.command === "mcp-list") {
+    const settings = MCPSettingsManager.getSettingsForDisplay();
+    writeEvent(
+      args,
+      { type: "mcp_servers", servers: settings.servers },
+      settings.servers.length
+        ? settings.servers
+            .map((server) => `${server.id}  ${server.name}  ${server.enabled ? "enabled" : "disabled"}  ${server.transport}  ${server.command || server.url || ""}`)
+            .join("\n")
+        : "No MCP servers configured.",
+    );
+    return 0;
+  }
+  if (args.command === "mcp-add") {
+    const name = (args.name || "").trim();
+    if (!name) throw new Error("Usage: cowork mcp add --name <name> (--command <cmd> | --url <url>)");
+    const transport = normalizeMcpTransport(args.transport || (args.url ? "streamable-http" : "stdio"));
+    const commandParts = args.commandLine ? splitCommandLine(args.commandLine) : [];
+    if (transport === "stdio" && commandParts.length === 0) throw new Error("stdio MCP servers require --command.");
+    if (transport !== "stdio" && !args.url) throw new Error(`${transport} MCP servers require --url.`);
+    const server = MCPSettingsManager.addServer({
+      name,
+      enabled: true,
+      transport,
+      ...(transport === "stdio"
+        ? { command: commandParts[0], args: commandParts.slice(1), cwd: path.resolve(args.cwd) }
+        : { url: args.url }),
+    });
+    writeEvent(args, { type: "mcp_server_added", server }, `Added MCP server ${server.name} (${server.id}).`);
+    return 0;
+  }
+  const id = args.name || args.prompt || "";
+  if (!id) throw new Error("Usage: cowork mcp remove|enable|disable <serverId>");
+  if (args.command === "mcp-remove") {
+    const removed = MCPSettingsManager.removeServer(id);
+    writeEvent(args, { type: "mcp_server_removed", id, removed }, removed ? `Removed MCP server ${id}.` : `MCP server not found: ${id}.`);
+    return removed ? 0 : 1;
+  }
+  const enabled = args.command === "mcp-enable";
+  const server = MCPSettingsManager.toggleServer(id, enabled);
+  writeEvent(args, { type: "mcp_server_updated", id, enabled, server }, server ? `${enabled ? "Enabled" : "Disabled"} MCP server ${id}.` : `MCP server not found: ${id}.`);
+  return server ? 0 : 1;
+}
+
+async function mcpTestCommand(args: DirectRunArgs): Promise<number> {
+  MCPSettingsManager.initialize();
+  const manager = MCPClientManager.getInstance();
+  const target = args.name || args.prompt || "";
+  if (target) {
+    const result = await manager.testServer(target);
+    writeEvent(args, { type: "mcp_test", id: target, ...result }, result.success ? `MCP server ${target} connected. tools=${result.tools || 0}` : `MCP server ${target} failed: ${result.error}`);
+    return result.success ? 0 : 1;
+  }
+  const statuses = manager.getStatus();
+  writeEvent(
+    args,
+    { type: "mcp_status", statuses },
+    statuses.length
+      ? statuses.map((status) => `${status.id}  ${status.name}  ${status.status}  tools=${status.tools.length}${status.error ? `  error=${status.error}` : ""}`).join("\n")
+      : "No MCP servers configured.",
+  );
+  return statuses.some((status) => status.status === "error") ? 1 : 0;
+}
+
+async function skillsCommand(skillRepo: SkillRepository, args: DirectRunArgs): Promise<number> {
+  const dbSkills = skillRepo.findAll();
+  const status = await readOnlySkillStatus(args);
+  const skills = status.skills;
+  if (args.command === "skills-list") {
+    const limited = skills.slice(0, args.limit || 200);
+    writeEvent(
+      args,
+      { type: "skills", skills: limited, summary: status.summary, databaseSkills: dbSkills },
+      limited.length ? limited.map((skill) => `${skill.id}  ${skill.name}  ${skill.source}  ${skill.category || "uncategorized"}`).join("\n") : "No local skills registered.",
+    );
+    return 0;
+  }
+  if (args.command === "skills-info") {
+    const query = (args.name || args.prompt || "").toLowerCase();
+    if (!query) throw new Error("Usage: cowork skills info <skillId-or-name>");
+    const skill = skills.find((candidate) => candidate.id === query || candidate.name.toLowerCase() === query || candidate.name.toLowerCase().includes(query));
+    if (!skill) throw new Error(`Skill not found: ${query}`);
+    writeEvent(args, { type: "skill", skill }, JSON.stringify(skill, null, 2));
+    return 0;
+  }
+  const invalid = skills.filter((skill) => !skill.id || !skill.name || (!skill.prompt && !skill.filePath));
+  writeEvent(
+    args,
+    { type: "skills_audit", summary: status.summary, invalid, databaseSkills: dbSkills },
+    invalid.length
+      ? `Skill audit found ${invalid.length} issue(s).`
+      : `Skill audit passed. ${skills.length} skill(s) registered.`,
+  );
+  return invalid.length ? 1 : 0;
+}
+
+function modelsCommand(modelRepo: LLMModelRepository, args: DirectRunArgs): number {
+  const status = LLMProviderFactory.getConfigStatus();
+  const configuredModels = status.models;
+  const dbModels = modelRepo.findAll();
+  writeEvent(
+    args,
+    { type: "models", currentProvider: status.currentProvider, currentModel: status.currentModel, models: configuredModels, databaseModels: dbModels },
+    [
+      `Current provider: ${status.currentProvider}`,
+      `Current model: ${status.currentModel || "default"}`,
+      ...configuredModels.slice(0, args.limit || 100).map((model) => `${model.key}  ${model.displayName || model.key}`),
+      ...(dbModels.length ? [`Database model presets: ${dbModels.length}`] : []),
+    ].join("\n"),
+  );
+  return 0;
+}
+
+function providerFallbackCommand(args: DirectRunArgs): number {
+  const settings = LLMProviderFactory.loadSettings() as Any;
+  const fallbacks = Array.isArray(settings.fallbackProviders) ? settings.fallbackProviders : [];
+  if (args.command === "providers-fallback-list") {
+    writeEvent(
+      args,
+      { type: "provider_fallbacks", fallbackProviders: fallbacks },
+      fallbacks.length
+        ? fallbacks.map((fallback: Any, index: number) => `${index + 1}. ${fallback.providerType}${fallback.modelKey ? ` (${fallback.modelKey})` : ""}`).join("\n")
+        : "No global provider fallbacks configured.",
+    );
+    return 0;
+  }
+  if (args.command === "providers-fallback-add") {
+    if (!args.providerType) throw new Error("Usage: cowork providers fallback add <provider> [--model <model>]");
+    const next = [...fallbacks, { providerType: normalizeProviderType(args.providerType), ...(args.model ? { modelKey: args.model } : {}) }];
+    settings.fallbackProviders = next;
+    LLMProviderFactory.saveSettings(settings as ReturnType<typeof LLMProviderFactory.loadSettings>);
+    writeEvent(args, { type: "provider_fallback_added", fallbackProviders: next }, `Added fallback provider ${args.providerType}.`);
+    return 0;
+  }
+  const provider = normalizeProviderType(args.providerType || args.name || args.prompt || "");
+  if (!provider) throw new Error("Usage: cowork providers fallback remove <provider>");
+  const next = fallbacks.filter((fallback: Any) => fallback.providerType !== provider);
+  settings.fallbackProviders = next;
+  LLMProviderFactory.saveSettings(settings as ReturnType<typeof LLMProviderFactory.loadSettings>);
+  writeEvent(args, { type: "provider_fallback_removed", provider, fallbackProviders: next }, `Removed fallback provider ${provider}.`);
+  return fallbacks.length === next.length ? 1 : 0;
+}
+
+async function createBackup(dbManager: DatabaseManager, args: DirectRunArgs): Promise<number> {
+  if (args.includeSecrets && !args.yes) {
+    throw new Error("Refusing to export secrets without --yes. Re-run with --include-secrets --yes if you really need them.");
+  }
+  const db = dbManager.getDatabase();
+  const payload = {
+    type: "cowork_backup",
+    version: (await readPackageInfo()).version,
+    exportedAt: new Date().toISOString(),
+    includeSecrets: Boolean(args.includeSecrets),
+    contentMode: args.includeSecrets ? "full_sensitive" : "redacted_metadata",
+    userData: getUserDataDir(),
+    workspaces: new WorkspaceRepository(db).findAll(),
+    tasks: sanitizeTasksForBackup(new TaskRepository(db).findAll(args.limit || 500), Boolean(args.includeSecrets)),
+    approvals: sanitizeApprovalsForBackup(new ApprovalRepository(db).findPending(1000), Boolean(args.includeSecrets)),
+    providers: redactObject(LLMProviderFactory.loadSettings(), !args.includeSecrets),
+    tools: BuiltinToolsSettingsManager.loadSettings(),
+    mcp: sanitizeMcpForBackup(args.includeSecrets ? MCPSettingsManager.loadSettings() : MCPSettingsManager.getSettingsForDisplay(), Boolean(args.includeSecrets)),
+    skills: new SkillRepository(db).findAll(),
+  };
+  const output = args.output || path.resolve(process.cwd(), `cowork-backup-${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
+  await fs.writeFile(path.resolve(output), JSON.stringify(payload, null, 2));
+  writeEvent(args, { type: "backup_created", output: path.resolve(output) }, `Created backup: ${path.resolve(output)}`);
+  return 0;
+}
+
+async function restoreBackup(args: DirectRunArgs): Promise<number> {
+  const input = args.output || args.prompt;
+  if (!input) throw new Error("Usage: cowork backup restore <backup.json> [--dry-run] [--yes]");
+  const parsed = JSON.parse(await fs.readFile(path.resolve(input), "utf8")) as Any;
+  if (parsed.type !== "cowork_backup") throw new Error("Not a CoWork backup file.");
+  const summary = {
+    workspaces: Array.isArray(parsed.workspaces) ? parsed.workspaces.length : 0,
+    tasks: Array.isArray(parsed.tasks) ? parsed.tasks.length : 0,
+    skills: Array.isArray(parsed.skills) ? parsed.skills.length : 0,
+    hasProviders: Boolean(parsed.providers),
+    hasTools: Boolean(parsed.tools),
+    hasMcp: Boolean(parsed.mcp),
+  };
+  if (args.dryRun || !args.yes) {
+    writeEvent(args, { type: "backup_restore_preview", input: path.resolve(input), summary, requiresYes: true }, `Backup is valid. Restore preview: ${JSON.stringify(summary)}. Re-run with --yes to restore settings.`);
+    return args.dryRun ? 0 : 1;
+  }
+  if (parsed.providers) LLMProviderFactory.saveSettings(LLMSettingsSchema.parse(parsed.providers) as ReturnType<typeof LLMProviderFactory.loadSettings>);
+  if (parsed.tools) BuiltinToolsSettingsManager.saveSettings(validateBuiltinToolsSettings(parsed.tools));
+  if (parsed.mcp) MCPSettingsManager.saveSettings(disableRestoredMcpServers(MCPSettingsSchema.parse(parsed.mcp)) as ReturnType<typeof MCPSettingsManager.loadSettings>);
+  writeEvent(args, { type: "backup_restored", input: path.resolve(input), summary }, "Restored provider, tool, and MCP settings from backup.");
+  return 0;
+}
+
+function securityAuditCommand(db: Database.Database, args: DirectRunArgs): number {
+  const providerStatus = LLMProviderFactory.getConfigStatus();
+  const tools = BuiltinToolsSettingsManager.loadSettings();
+  const workspaces = new WorkspaceRepository(db).findAll();
+  const permissionRepo = new WorkspacePermissionRuleRepository(db);
+  const rules = workspaces.flatMap((workspace) => permissionRepo.listByWorkspaceId(workspace.id));
+  const warnings: string[] = [];
+  if (providerStatus.providers.filter((provider) => provider.configured).length === 0) warnings.push("No configured LLM provider.");
+  if (tools.categories.shell?.enabled && tools.runCommandApprovalMode === "single_bundle") warnings.push("Shell tools are enabled with bundled approval mode.");
+  if (tools.categories.computer_use?.enabled) warnings.push("Computer-use tools are enabled.");
+  if (Object.keys(tools.toolAutoApprove || {}).length > 0) warnings.push("Some tools have auto-approval overrides.");
+  const allowRules = rules.filter((rule) => rule.effect === "allow");
+  if (allowRules.length > 0) warnings.push(`${allowRules.length} workspace allow rule(s) configured.`);
+  const payload = { type: "security_audit", ok: warnings.length === 0, warnings, providerStatus, permissionRules: rules.length };
+  writeEvent(
+    args,
+    payload,
+    warnings.length ? ["Security audit warnings:", ...warnings.map((warning) => `- ${warning}`)].join("\n") : "Security audit passed with no local warnings.",
+  );
+  return warnings.length ? 1 : 0;
+}
+
+function securityRulesListCommand(db: Database.Database, args: DirectRunArgs): number {
+  const repo = new WorkspacePermissionRuleRepository(db);
+  const workspaces = new WorkspaceRepository(db).findAll();
+  const workspaceRows = args.workspaceId
+    ? workspaces.filter((workspace) => workspace.id === args.workspaceId)
+    : workspaces;
+  const rules = workspaceRows.flatMap((workspace) =>
+    repo.listByWorkspaceId(workspace.id).map((rule) => ({ ...rule, workspaceName: workspace.name, workspacePath: workspace.path })),
+  );
+  writeEvent(
+    args,
+    { type: "security_rules", rules },
+    rules.length
+      ? rules.map((rule) => `${rule.id}  ${rule.effect}  ${rule.scope.kind}  ${rule.workspaceName}`).join("\n")
+      : "No workspace permission rules found.",
+  );
+  return 0;
+}
+
+function securityRulesRemoveCommand(db: Database.Database, args: DirectRunArgs): number {
+  const id = args.ruleId || args.name || args.prompt || "";
+  if (!id) throw new Error("Usage: cowork security rules remove <ruleId> --yes");
+  if (!args.yes) {
+    writeEvent(args, { type: "security_rule_remove_preview", id, requiresYes: true }, `Re-run with --yes to remove permission rule ${id}.`);
+    return 1;
+  }
+  const repo = new WorkspacePermissionRuleRepository(db);
+  const removed = repo.deleteById(id);
+  writeEvent(args, { type: "security_rule_removed", id, removed }, removed ? `Removed permission rule ${id}.` : `Permission rule not found: ${id}.`);
+  return removed ? 0 : 1;
+}
+
+function promptCommand(args: DirectRunArgs): number {
+  const text = args.prompt || "";
+  if (!text) throw new Error(`Usage: cowork ${args.command === "prompt-size" ? "prompt-size" : "prompt-preview"} <prompt text>`);
+  const chars = text.length;
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  const estimatedTokens = Math.max(1, Math.ceil(chars / 4));
+  const payload = { type: args.command, chars, words, estimatedTokens, preview: truncate(text, 500) };
+  writeEvent(
+    args,
+    payload,
+    args.command === "prompt-preview"
+      ? [`Chars: ${chars}`, `Estimated tokens: ${estimatedTokens}`, "", truncate(text, 1200)].join("\n")
+      : `Chars: ${chars}\nWords: ${words}\nEstimated tokens: ${estimatedTokens}`,
+  );
+  return 0;
+}
+
+function configureLocalProvider(args: DirectRunArgs): { providerType: string; model?: string } {
+  const rawProviderType = (args.providerType || "").trim();
+  const providerType = normalizeProviderType(rawProviderType);
+  if (!providerType) throw new Error("Provider is required.");
+
+  const settings = LLMProviderFactory.loadSettings() as Any;
+  const apiKey = args.apiKey?.trim();
+  const model = args.model?.trim();
+  const baseUrl = args.baseUrl?.trim();
+  const status = LLMProviderFactory.getConfigStatus();
+  const providerIsConfigured = status.providers.some(
+    (provider) => provider.type === providerType && provider.configured,
+  );
+  const switchingProvider = settings.providerType !== providerType;
+  if (switchingProvider && !providerIsConfigured && !apiKey && !baseUrl) {
+    throw new Error(
+      `Provider "${providerType}" is not configured. Pass --api-key/--base-url, configure it in the desktop app, or configure the active provider instead.`,
+    );
+  }
+
+  settings.providerType = providerType;
+  if (model) settings.modelKey = model;
+
+  const ensureNode = (key: string): Any => {
+    const existing = settings[key];
+    if (existing && typeof existing === "object") return existing;
+    settings[key] = {};
+    return settings[key];
+  };
+
+  switch (providerType) {
+    case "anthropic": {
+      const node = ensureNode("anthropic");
+      if (apiKey) {
+        node.apiKey = apiKey;
+        node.authMethod = "api_key";
+      }
+      break;
+    }
+    case "openai": {
+      const node = ensureNode("openai");
+      if (apiKey) {
+        node.apiKey = apiKey;
+        node.authMethod = "api_key";
+      }
+      if (model) node.model = model;
+      break;
+    }
+    case "gemini":
+    case "openrouter":
+    case "deepseek":
+    case "groq":
+    case "xai":
+    case "kimi":
+    case "ollama": {
+      const node = ensureNode(providerType);
+      if (apiKey) node.apiKey = apiKey;
+      if (model) node.model = model;
+      if (baseUrl) node.baseUrl = baseUrl;
+      break;
+    }
+    case "openai-compatible": {
+      const node = ensureNode("openaiCompatible");
+      if (apiKey) node.apiKey = apiKey;
+      if (model) node.model = model;
+      if (baseUrl) node.baseUrl = baseUrl;
+      break;
+    }
+    case "azure": {
+      const node = ensureNode("azure");
+      if (apiKey) node.apiKey = apiKey;
+      if (model) node.deployment = model;
+      if (baseUrl) node.endpoint = baseUrl;
+      break;
+    }
+    case "azure-anthropic": {
+      const node = ensureNode("azureAnthropic");
+      if (apiKey) node.apiKey = apiKey;
+      if (model) node.deployment = model;
+      if (baseUrl) node.endpoint = baseUrl;
+      break;
+    }
+    case "bedrock": {
+      const node = ensureNode("bedrock");
+      if (apiKey) node.accessKeyId = apiKey;
+      if (model) node.model = model;
+      break;
+    }
+    default: {
+      const customProviders = settings.customProviders && typeof settings.customProviders === "object"
+        ? settings.customProviders
+        : {};
+      settings.customProviders = customProviders;
+      const node = customProviders[providerType] && typeof customProviders[providerType] === "object"
+        ? customProviders[providerType]
+        : {};
+      customProviders[providerType] = node;
+      if (apiKey) node.apiKey = apiKey;
+      if (model) node.model = model;
+      if (baseUrl) node.baseUrl = baseUrl;
+      break;
+    }
+  }
+
+  LLMProviderFactory.saveSettings(settings as ReturnType<typeof LLMProviderFactory.loadSettings>);
+  return { providerType, model };
+}
+
+function normalizeProviderType(providerType: string): string {
+  switch (providerType) {
+    case "claude":
+      return "anthropic";
+    case "azure_anthropic":
+      return "azure-anthropic";
+    case "openai_compatible":
+      return "openai-compatible";
+    default:
+      return providerType;
+  }
+}
+
+function shouldImportEnvForCommand(command: DirectRunArgs["command"]): boolean {
+  return command === "run" || command === "providers-configure";
+}
+
+function buildSessionSummaries(tasks: Task[]): Array<{
+  id: string;
+  title: string;
+  count: number;
+  latestStatus: Task["status"];
+  updatedAt: number;
+  terminal: boolean;
+}> {
+  const groups = new Map<string, Task[]>();
+  for (const task of tasks) {
+    const sessionId = task.sessionId || task.id;
+    const existing = groups.get(sessionId) || [];
+    existing.push(task);
+    groups.set(sessionId, existing);
+  }
+  return [...groups.entries()]
+    .map(([id, rows]) => {
+      const sorted = [...rows].sort((a, b) => (b.updatedAt || b.createdAt || 0) - (a.updatedAt || a.createdAt || 0));
+      const latest = sorted[0];
+      return {
+        id,
+        title: latest?.title || "Untitled",
+        count: rows.length,
+        latestStatus: latest?.status || "pending",
+        updatedAt: latest?.updatedAt || latest?.createdAt || 0,
+        terminal: rows.every((task) => isTerminalTaskStatus(task.status)),
+      };
+    })
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+function tasksForSession(taskRepo: TaskRepository, sessionId: string, limit: number): Task[] {
+  const lineage = taskRepo.findBySessionId(sessionId, limit);
+  if (lineage.length > 0) return lineage;
+  const single = taskRepo.findById(sessionId);
+  return single ? [single] : [];
+}
+
+function getCliOwnership(task: Task | undefined | null): CliTaskOwnership | undefined {
+  const cli = task?.agentConfig?.cli;
+  if (!cli || cli.owner !== "cowork-run" || typeof cli.runId !== "string") return undefined;
+  return cli;
+}
+
+function findStaleCliTasks(taskRepo: TaskRepository, limit: number): Task[] {
+  const now = Date.now();
+  return taskRepo.findAll(limit)
+    .filter((task) => {
+      if (isTerminalTaskStatus(task.status)) return false;
+      const cli = getCliOwnership(task);
+      if (!cli || cli.mode !== "attached") return false;
+      if (cli.endedAt) return false;
+      if (isPidAlive(cli.pid)) return false;
+      const lastSeenAt = cli.lastSeenAt || cli.startedAt || task.updatedAt || task.createdAt;
+      return now - lastSeenAt > 30_000;
+    });
+}
+
+function markTaskCancelled(
+  taskRepo: TaskRepository,
+  eventRepo: TaskEventRepository,
+  task: Task,
+  message: string,
+  exitCode: number,
+): void {
+  const completedAt = Date.now();
+  const cli = getCliOwnership(task);
+  taskRepo.update(task.id, {
+    status: "cancelled",
+    completedAt,
+    lastRunDurationMs: Math.max(0, completedAt - (task.createdAt || completedAt)),
+    error: null,
+    terminalStatus: undefined,
+    failureClass: undefined,
+    ...(cli
+      ? {
+          agentConfig: {
+            ...(task.agentConfig || {}),
+            cli: {
+              ...cli,
+              endedAt: completedAt,
+              exitCode,
+            },
+          },
+        }
+      : {}),
+  });
+  eventRepo.create({
+    taskId: task.id,
+    timestamp: completedAt,
+    type: "task_status",
+    legacyType: "task_status",
+    schemaVersion: 2,
+    status: "cancelled",
+    payload: { status: "cancelled", message },
+  });
+  eventRepo.create({
+    taskId: task.id,
+    timestamp: completedAt,
+    type: "task_cancelled",
+    legacyType: "task_cancelled",
+    schemaVersion: 2,
+    status: "cancelled",
+    payload: { message },
+  });
+}
+
+function terminateCliOwner(task: Task): void {
+  const cli = getCliOwnership(task);
+  if (!cli || cli.pid === process.pid || cli.endedAt) return;
+  if (!isPidAlive(cli.pid)) return;
+  try {
+    process.kill(cli.pid, "SIGTERM");
+  } catch {
+    // Best-effort; the database cancellation still prevents stale UI state.
+  }
+}
+
+function isPidAlive(pid: unknown): boolean {
+  if (typeof pid !== "number" || !Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    return code === "EPERM";
+  }
+}
+
+function formatCliTaskLine(task: Task): string {
+  const cli = getCliOwnership(task);
+  const mode = cli ? `cli:${cli.mode}` : "app";
+  const updatedAt = formatDate(task.updatedAt || task.createdAt);
+  return `${task.id}  ${task.status}  ${mode}  updated=${updatedAt}  ${task.title}`;
+}
+
+function requireSessionId(args: DirectRunArgs): string {
+  const sessionId = (args.sessionId || args.name || args.prompt || "").trim();
+  if (!sessionId) throw new Error("Missing session id.");
+  return sessionId;
+}
+
+type SessionMetadata = Record<string, { name?: string; updatedAt?: number; archivedAt?: number }>;
+
+async function readSessionMetadata(): Promise<SessionMetadata> {
+  try {
+    const text = await fs.readFile(sessionMetadataPath(), "utf8");
+    const parsed = JSON.parse(text) as SessionMetadata;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeSessionMetadata(metadata: SessionMetadata): Promise<void> {
+  const file = sessionMetadataPath();
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, JSON.stringify(metadata, null, 2));
+}
+
+function sessionMetadataPath(): string {
+  return path.join(getUserDataDir(), "cli-session-metadata.json");
+}
+
+function countTasksByStatus(db: Database.Database): Record<string, number> {
+  try {
+    const rows = db.prepare("SELECT status, COUNT(1) as count FROM tasks GROUP BY status").all() as Any[];
+    return Object.fromEntries(rows.map((row) => [String(row.status || "unknown"), Number(row.count || 0)]));
+  } catch {
+    return {};
+  }
+}
+
+function formatCountMap(counts: Record<string, number>): string {
+  return Object.entries(counts)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join(", ");
+}
+
+function formatDate(value: unknown): string {
+  const timestamp = Number(value);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return "unknown";
+  return new Date(timestamp).toISOString();
+}
+
+async function writeDetachedReadyFile(file: string, task: Task): Promise<void> {
+  const resolved = path.resolve(file);
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  await fs.writeFile(
+    resolved,
+    JSON.stringify(
+      {
+        taskId: task.id,
+        title: task.title,
+        status: task.status,
+        workspaceId: task.workspaceId,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function readPackageInfo(): Promise<{ name: string; version: string }> {
+  const root = await findPackageRoot();
+  try {
+    const pkg = JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")) as { name?: string; version?: string };
+    return { name: pkg.name || "cowork-os", version: pkg.version || "dev" };
+  } catch {
+    return { name: "cowork-os", version: "dev" };
+  }
+}
+
+async function findPackageRoot(): Promise<string> {
+  const candidates = [
+    path.resolve(__dirname, "..", "..", ".."),
+    path.resolve(__dirname, "..", ".."),
+    process.cwd(),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const text = await fs.readFile(path.join(candidate, "package.json"), "utf8");
+      const pkg = JSON.parse(text) as { name?: string };
+      if (pkg.name === "cowork-os" || pkg.name === "@cowork/os") return candidate;
+    } catch {
+      // Try the next layout.
+    }
+  }
+  return process.cwd();
+}
+
+function normalizeMcpTransport(value: string): "stdio" | "sse" | "websocket" | "streamable-http" {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "stdio" || normalized === "sse" || normalized === "websocket" || normalized === "streamable-http") {
+    return normalized;
+  }
+  if (normalized === "http") return "streamable-http";
+  throw new Error(`Unsupported MCP transport: ${value}`);
+}
+
+function splitCommandLine(input: string): string[] {
+  const result: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (const ch of input) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        result.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current) result.push(current);
+  return result;
+}
+
+function redactObject(value: unknown, redact: boolean): unknown {
+  if (!redact) return value;
+  if (Array.isArray(value)) return value.map((item) => redactObject(item, redact));
+  if (!value || typeof value !== "object") return value;
+  const out: Any = {};
+  for (const [key, child] of Object.entries(value as Any)) {
+    if (/api.?key|token|secret|password|credential|accessKeyId|sessionToken/i.test(key)) {
+      out[key] = child ? "[redacted]" : child;
+    } else {
+      out[key] = redactObject(child, redact);
+    }
+  }
+  return out;
+}
+
+function sanitizeTasksForBackup(tasks: Task[], includeSensitiveContent: boolean): unknown[] {
+  if (includeSensitiveContent) return tasks;
+  return tasks.map((task) => ({
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    workspaceId: task.workspaceId,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    completedAt: task.completedAt,
+    sessionId: task.sessionId,
+    parentTaskId: task.parentTaskId,
+    source: task.source,
+    labels: task.labels,
+    resultSummary: task.resultSummary ? "[redacted]" : undefined,
+    prompt: task.prompt ? "[redacted]" : undefined,
+    rawPrompt: task.rawPrompt ? "[redacted]" : undefined,
+    userPrompt: task.userPrompt ? "[redacted]" : undefined,
+    error: task.error ? "[redacted]" : undefined,
+  }));
+}
+
+function sanitizeApprovalsForBackup(approvals: unknown[], includeSensitiveContent: boolean): unknown[] {
+  if (includeSensitiveContent) return approvals;
+  return approvals.map((approval) => {
+    if (!approval || typeof approval !== "object") return approval;
+    const row = approval as Any;
+    return {
+      id: row.id,
+      taskId: row.taskId,
+      type: row.type,
+      status: row.status,
+      createdAt: row.createdAt,
+      description: row.description ? "[redacted]" : undefined,
+      payload: row.payload ? "[redacted]" : undefined,
+    };
+  });
+}
+
+function sanitizeMcpForBackup(settings: unknown, includeSensitiveContent: boolean): unknown {
+  if (includeSensitiveContent) return settings;
+  const cloned = redactObject(settings, true) as Any;
+  if (Array.isArray(cloned?.servers)) {
+    cloned.servers = cloned.servers.map((server: Any) => ({
+      ...server,
+      env: server.env ? redactObject(server.env, true) : undefined,
+      headers: server.headers ? redactObject(server.headers, true) : undefined,
+      auth: server.auth ? redactObject(server.auth, true) : undefined,
+    }));
+  }
+  return cloned;
+}
+
+interface CliSkillEntry {
+  id: string;
+  name: string;
+  description?: string;
+  category?: string;
+  prompt?: string;
+  filePath: string;
+  source: "bundled" | "managed" | "workspace";
+  disabled?: boolean;
+}
+
+async function readOnlySkillStatus(args: DirectRunArgs): Promise<{
+  skills: CliSkillEntry[];
+  summary: { total: number; bundled: number; managed: number; workspace: number; disabled: number };
+}> {
+  const root = await findPackageRoot();
+  const dirs = [
+    { source: "bundled" as const, dir: path.join(root, "resources", "skills") },
+    { source: "managed" as const, dir: path.join(getUserDataDir(), "skills") },
+    { source: "workspace" as const, dir: path.join(path.resolve(args.cwd), ".cowork", "skills") },
+  ];
+  const byId = new Map<string, CliSkillEntry>();
+  for (const entry of dirs) {
+    const skills = await scanSkillDir(entry.dir, entry.source);
+    for (const skill of skills) byId.set(skill.id, skill);
+  }
+  const skills = [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+  return {
+    skills,
+    summary: {
+      total: skills.length,
+      bundled: skills.filter((skill) => skill.source === "bundled").length,
+      managed: skills.filter((skill) => skill.source === "managed").length,
+      workspace: skills.filter((skill) => skill.source === "workspace").length,
+      disabled: skills.filter((skill) => skill.disabled).length,
+    },
+  };
+}
+
+async function scanSkillDir(
+  dir: string,
+  source: CliSkillEntry["source"],
+): Promise<CliSkillEntry[]> {
+  let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const skills: CliSkillEntry[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    try {
+      if (entry.isFile() && entry.name.endsWith(".json")) {
+        const parsed = JSON.parse(await fs.readFile(fullPath, "utf8")) as Any;
+        const id = String(parsed.id || path.basename(entry.name, ".json")).trim();
+        const name = String(parsed.name || id).trim();
+        if (!id || !name) continue;
+        skills.push({
+          id,
+          name,
+          description: typeof parsed.description === "string" ? parsed.description : undefined,
+          category: typeof parsed.category === "string" ? parsed.category : undefined,
+          prompt: typeof parsed.prompt === "string" ? parsed.prompt : undefined,
+          disabled: parsed.enabled === false || parsed.disabled === true,
+          filePath: fullPath,
+          source,
+        });
+        continue;
+      }
+      if (entry.isDirectory()) {
+        const skillMd = path.join(fullPath, "SKILL.md");
+        const text = await fs.readFile(skillMd, "utf8");
+        const id = path.basename(fullPath);
+        const frontmatter = parseSkillMarkdownFrontmatter(text);
+        skills.push({
+          id,
+          name: frontmatter.name || id,
+          description: frontmatter.description,
+          category: frontmatter.category,
+          prompt: text,
+          filePath: skillMd,
+          source,
+        });
+      }
+    } catch {
+      // Ignore unreadable or malformed entries; audit reports only parseable skills.
+    }
+  }
+  return skills;
+}
+
+function parseSkillMarkdownFrontmatter(text: string): Record<string, string> {
+  if (!text.startsWith("---")) return {};
+  const end = text.indexOf("\n---", 3);
+  if (end < 0) return {};
+  const block = text.slice(3, end);
+  const result: Record<string, string> = {};
+  for (const line of block.split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) continue;
+    result[match[1]] = match[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return result;
+}
+
+function validateBuiltinToolsSettings(value: unknown): ReturnType<typeof BuiltinToolsSettingsManager.loadSettings> {
+  const defaults = BuiltinToolsSettingsManager.getDefaultSettings();
+  if (!value || typeof value !== "object") throw new Error("Invalid built-in tools settings in backup.");
+  const raw = value as Any;
+  if (!raw.categories || typeof raw.categories !== "object") {
+    throw new Error("Invalid built-in tools settings: missing categories.");
+  }
+  const next = {
+    ...defaults,
+    ...raw,
+    categories: {
+      ...defaults.categories,
+      ...raw.categories,
+    },
+    toolOverrides: typeof raw.toolOverrides === "object" && raw.toolOverrides ? raw.toolOverrides : {},
+    toolTimeouts: typeof raw.toolTimeouts === "object" && raw.toolTimeouts ? raw.toolTimeouts : {},
+    toolAutoApprove: typeof raw.toolAutoApprove === "object" && raw.toolAutoApprove ? raw.toolAutoApprove : {},
+    runCommandApprovalMode: raw.runCommandApprovalMode === "per_command" ? "per_command" : defaults.runCommandApprovalMode,
+    codexRuntimeMode: raw.codexRuntimeMode === "acpx" ? "acpx" : "native",
+  } as ReturnType<typeof BuiltinToolsSettingsManager.loadSettings>;
+
+  for (const [name, category] of Object.entries(next.categories)) {
+    if (!category || typeof category !== "object") throw new Error(`Invalid tool category in backup: ${name}`);
+    if (typeof category.enabled !== "boolean") throw new Error(`Invalid enabled flag for tool category: ${name}`);
+    if (!["high", "normal", "low"].includes(category.priority)) {
+      throw new Error(`Invalid priority for tool category: ${name}`);
+    }
+  }
+  return next;
+}
+
+function disableRestoredMcpServers(settings: Any): Any {
+  return {
+    ...settings,
+    servers: Array.isArray(settings.servers)
+      ? settings.servers.map((server: Any) => ({
+          ...server,
+          enabled: false,
+          lastError: "Restored by CLI backup restore; disabled until re-enabled.",
+        }))
+      : [],
+  };
+}
+
+function sanitizeLimit(raw: unknown): number | undefined {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return Math.min(2000, Math.floor(value));
+}
+
+function sanitizeDays(raw: unknown): number | undefined {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return Math.min(36500, Math.floor(value));
+}
+
+function formatDoctor(payload: Record<string, unknown>): string {
+  const providers = Array.isArray(payload.configuredProviders)
+    ? payload.configuredProviders as Array<{ name?: string; type?: string }>
+    : [];
+  return [
+    "CoWork CLI doctor",
+    "- runtime: local direct runner",
+    "- control plane: not required for local CLI",
+    `- cwd: ${payload.cwd || process.cwd()}`,
+    `- workspaces: ${payload.workspaceCount ?? 0}`,
+    `- current provider: ${payload.currentProvider || "unknown"} (${payload.currentModel || "default model"})`,
+    providers.length
+      ? `- configured providers: ${providers.map((provider) => provider.name || provider.type).join(", ")}`
+      : "- configured providers: none found",
+  ].join("\n");
+}
+
+function formatTaskEventLine(event: {
+  timestamp?: number;
+  ts?: number;
+  type: string;
+  legacyType?: string;
+  payload?: unknown;
+}): string {
+  const at = new Date(event.ts || event.timestamp || Date.now()).toISOString();
+  const type = event.legacyType || event.type;
+  return `${at}  ${type}  ${summarizeEventPayload(event.payload)}`;
+}
+
+function summarizeEventPayload(payload: unknown): string {
+  if (!payload || typeof payload !== "object") return "";
+  const obj = payload as Record<string, unknown>;
+  const candidates = [
+    obj.message,
+    obj.content,
+    obj.text,
+    obj.summary,
+    obj.error,
+    obj.path,
+    obj.tool,
+    obj.name,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) return truncate(candidate.trim(), 240);
+  }
+  try {
+    return truncate(JSON.stringify(obj), 240);
+  } catch {
+    return "";
+  }
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, Math.max(0, max - 1))}...` : value;
+}
+
+function writeLine(args: DirectRunArgs, message: string): void {
+  const text = message.trim();
+  if (!text) return;
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({ message: text })}\n`);
+  } else {
+    process.stdout.write(`${text}\n`);
+  }
+}
+
+function writeEvent(
+  args: DirectRunArgs,
+  event: Record<string, unknown>,
+  text: string,
+): void {
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(event)}\n`);
+  } else {
+    writeLine(args, text);
+  }
+}
+
+function writeError(args: DirectRunArgs, message: string, taskId?: string): void {
+  const text = message.trim();
+  if (!text) return;
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({ type: "error", taskId, message: text })}\n`);
+  } else {
+    process.stderr.write(`${text}\n`);
+  }
+}
+
+function stringifyMessage(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  return JSON.stringify(value);
+}
+
+function hasProviderEnv(): boolean {
+  return Boolean(
+    process.env.OPENAI_API_KEY ||
+      process.env.ANTHROPIC_API_KEY ||
+      process.env.GEMINI_API_KEY ||
+      process.env.OPENROUTER_API_KEY,
+  );
+}
+
+function formatError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  if (process.env.COWORK_CLI_DEBUG === "1" || process.env.COWORK_CLI_DEBUG === "true") {
+    return error.stack || error.message;
+  }
+  return error.message;
+}
+
+function installCliLogFilter(): () => void {
+  if (process.env.COWORK_CLI_DEBUG === "1" || process.env.COWORK_CLI_DEBUG === "true") {
+    return () => {};
+  }
+
+  const original = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+  };
+  const noisyPrefixes = [
+    "[AgentDaemon]",
+    "[AppearanceManager]",
+    "[DatabaseManager]",
+    "[GuardrailManager]",
+    "[LLM:",
+    "[MCP",
+    "[MemoryFeaturesManager]",
+    "[MemoryService]",
+    "[OpenAI]",
+    "[PersonalityManager]",
+    "[SearchProviderFactory]",
+    "[SecureSettingsRepository]",
+    "[TaskExecutor]",
+    "[TaskQueueManager]",
+    "[ToolRegistry]",
+    "[VoiceSettingsManager]",
+  ];
+
+  const shouldSuppress = (items: unknown[]): boolean => {
+    const text = items.map(formatLogItem).join(" ");
+    return (
+      text === "Agent daemon shutdown complete" ||
+      noisyPrefixes.some((prefix) => text.startsWith(prefix))
+    );
+  };
+
+  console.log = (...items: unknown[]) => {
+    if (!shouldSuppress(items)) original.log(...items);
+  };
+  console.warn = (...items: unknown[]) => {
+    if (!shouldSuppress(items)) original.warn(...items);
+  };
+  console.error = (...items: unknown[]) => {
+    if (!shouldSuppress(items)) original.error(...items);
+  };
+
+  return () => {
+    console.log = original.log;
+    console.warn = original.warn;
+    console.error = original.error;
+  };
+}
+
+function formatLogItem(item: unknown): string {
+  if (typeof item === "string") return item;
+  try {
+    return JSON.stringify(item);
+  } catch {
+    return String(item);
+  }
+}
+
+function shouldRunEntrypoint(): boolean {
+  if (typeof require !== "undefined" && require.main === module) return true;
+  if (!process.versions.electron) return false;
+  return path.basename(process.argv[1] || "") === "direct-run.js";
+}
+
+if (shouldRunEntrypoint()) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -1,0 +1,109 @@
+import type { ControlPlaneFrame } from "./control-plane-client";
+
+export interface WorkspaceLike {
+  id?: string;
+  name?: string;
+  path?: string;
+}
+
+export interface TaskLike {
+  id?: string;
+  title?: string;
+  status?: string;
+  workspaceId?: string;
+}
+
+export interface ApprovalLike {
+  id?: string;
+  taskId?: string;
+  taskTitle?: string;
+  type?: string;
+  description?: string;
+  requestedAt?: number;
+}
+
+export function printJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function formatWorkspace(workspace: WorkspaceLike): string {
+  const id = workspace.id || "unknown";
+  const name = workspace.name || "Workspace";
+  const workspacePath = workspace.path ? `  ${workspace.path}` : "";
+  return `${id}  ${name}${workspacePath}`;
+}
+
+export function formatTask(task: TaskLike): string {
+  const id = task.id || "unknown";
+  const status = task.status || "unknown";
+  const title = task.title || "Untitled task";
+  return `${id}  [${status}]  ${title}`;
+}
+
+export function formatApproval(approval: ApprovalLike): string {
+  const id = approval.id || "unknown";
+  const type = approval.type || "approval";
+  const task = approval.taskTitle || approval.taskId || "unknown task";
+  const description = approval.description ? `  ${approval.description}` : "";
+  return `${id}  [${type}]  ${task}${description}`;
+}
+
+export function buildTaskTitle(prompt: string): string {
+  const compact = prompt.replace(/\s+/g, " ").trim();
+  if (!compact) return "CLI task";
+  return compact.length > 80 ? `${compact.slice(0, 77)}...` : compact;
+}
+
+export function extractArrayPayload<T>(payload: unknown, key: string): T[] {
+  if (Array.isArray(payload)) return payload as T[];
+  if (!payload || typeof payload !== "object") return [];
+  const value = (payload as Record<string, unknown>)[key];
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+export function formatTaskEventFrame(frame: ControlPlaneFrame): string | null {
+  if (frame.type !== "event") return null;
+  const payload = frame.payload && typeof frame.payload === "object" ? (frame.payload as Record<string, unknown>) : {};
+  const inner = payload.event && typeof payload.event === "object" ? (payload.event as Record<string, unknown>) : {};
+  const eventName = frame.event || "event";
+  const kind = stringValue(payload.kind) || stringValue(payload.type) || stringValue(inner.kind) || stringValue(inner.type);
+  const message =
+    stringValue(payload.message) ||
+    stringValue(payload.text) ||
+    stringValue(payload.summary) ||
+    stringValue(inner.message) ||
+    stringValue(inner.text) ||
+    stringValue(inner.summary);
+  const status = stringValue(payload.status) || stringValue(inner.status);
+  const taskId = stringValue(payload.taskId) || stringValue(inner.taskId);
+
+  if (message) {
+    return taskId ? `${eventName} ${taskId}: ${message}` : `${eventName}: ${message}`;
+  }
+  if (kind || status) {
+    const label = [kind, status].filter(Boolean).join("/");
+    return taskId ? `${eventName} ${taskId}: ${label}` : `${eventName}: ${label}`;
+  }
+  if (eventName === "heartbeat") return null;
+  return taskId ? `${eventName} ${taskId}` : eventName;
+}
+
+export function isTerminalTaskFrame(frame: ControlPlaneFrame, taskId?: string): boolean {
+  if (frame.type !== "event") return false;
+  if (frame.event === "task.completed" || frame.event === "task.failed") return matchesTask(frame, taskId);
+  const payload = frame.payload && typeof frame.payload === "object" ? (frame.payload as Record<string, unknown>) : {};
+  const inner = payload.event && typeof payload.event === "object" ? (payload.event as Record<string, unknown>) : {};
+  const status = stringValue(payload.status) || stringValue(inner.status);
+  return matchesTask(frame, taskId) && (status === "completed" || status === "failed" || status === "cancelled");
+}
+
+export function matchesTask(frame: ControlPlaneFrame, taskId?: string): boolean {
+  if (!taskId) return true;
+  const payload = frame.payload && typeof frame.payload === "object" ? (frame.payload as Record<string, unknown>) : {};
+  const inner = payload.event && typeof payload.event === "object" ? (payload.event as Record<string, unknown>) : {};
+  return stringValue(payload.taskId) === taskId || stringValue(inner.taskId) === taskId;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/src/cli/local-control-plane-discovery.ts
+++ b/src/cli/local-control-plane-discovery.ts
@@ -1,0 +1,256 @@
+import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalControlPlaneDiscoveryResult {
+  url?: string;
+  token?: string;
+  source?: string;
+  error?: string;
+}
+
+interface StoredControlPlaneSettings {
+  enabled?: boolean;
+  host?: string;
+  port?: number;
+  token?: string;
+}
+
+interface SecureSettingsRow {
+  encrypted_data: string;
+  checksum: string;
+}
+
+const MACHINE_ID_FILE = ".cowork-machine-id";
+
+export function discoverLocalControlPlane(profileName?: string): LocalControlPlaneDiscoveryResult {
+  const dirs = discoverUserDataDirs(profileName);
+  const errors: string[] = [];
+
+  for (const dir of dirs) {
+    const descriptor = readLocalConnectionDescriptor(dir);
+    if (descriptor.token) return descriptor;
+    if (descriptor.error) errors.push(descriptor.error);
+
+    const legacy = readLegacySettings(dir);
+    if (legacy.token) return legacy;
+    if (legacy.error) errors.push(legacy.error);
+
+    const db = readDatabaseSettings(dir);
+    if (db.token) return db;
+    if (db.error) errors.push(db.error);
+  }
+
+  return {
+    error:
+      errors.find((error) => error.includes("OS keychain")) ||
+      errors[0] ||
+      "No local GUI control-plane token was found.",
+  };
+}
+
+function readLocalConnectionDescriptor(userDataDir: string): LocalControlPlaneDiscoveryResult {
+  const filePath = path.join(userDataDir, "control-plane-local.json");
+  if (!fs.existsSync(filePath)) return {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as {
+      url?: string;
+      token?: string;
+      pid?: number;
+    };
+    const token = typeof parsed.token === "string" ? parsed.token.trim() : "";
+    const url = typeof parsed.url === "string" && parsed.url.trim() ? parsed.url.trim() : "";
+    if (!token || !url) return { error: `Invalid local control-plane descriptor at ${filePath}` };
+    if (typeof parsed.pid === "number" && parsed.pid > 0 && !isProcessRunning(parsed.pid)) {
+      return { error: `Stale local control-plane descriptor at ${filePath}` };
+    }
+    return { url, token, source: filePath };
+  } catch (error) {
+    return { error: `Failed to read ${filePath}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+export function discoverUserDataDirs(profileName?: string): string[] {
+  const roots = process.env.COWORK_USER_DATA_DIR
+    ? [process.env.COWORK_USER_DATA_DIR]
+    : Array.from(new Set([getPlatformElectronUserDataRoot(), path.join(os.homedir(), ".cowork")].filter(Boolean) as string[]));
+  const dirs: string[] = [];
+  for (const root of roots) {
+    dirs.push(root);
+    const normalized = normalizeProfileId(profileName || process.env.COWORK_PROFILE || process.env.COWORK_PROFILE_ID || "");
+    if (normalized && normalized !== "default") {
+      dirs.push(path.join(root, "profiles", normalized));
+    }
+    const profilesDir = path.join(root, "profiles");
+    try {
+      for (const entry of fs.readdirSync(profilesDir, { withFileTypes: true })) {
+        if (entry.isDirectory()) dirs.push(path.join(profilesDir, entry.name));
+      }
+    } catch {
+      // No profiles directory.
+    }
+  }
+  return Array.from(new Set(dirs.map((dir) => path.resolve(dir))));
+}
+
+function readLegacySettings(userDataDir: string): LocalControlPlaneDiscoveryResult {
+  const settingsPath = path.join(userDataDir, "control-plane-settings.json");
+  if (!fs.existsSync(settingsPath)) return {};
+  try {
+    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as StoredControlPlaneSettings;
+    return normalizeSettings(settings, settingsPath);
+  } catch (error) {
+    return { error: `Failed to read ${settingsPath}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+function readDatabaseSettings(userDataDir: string): LocalControlPlaneDiscoveryResult {
+  const dbPath = path.join(userDataDir, "cowork-os.db");
+  if (!fs.existsSync(dbPath)) return {};
+
+  let db: Any | undefined;
+  try {
+    // Loaded dynamically so `cowork --help` and tests do not need SQLite.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const Database = require("better-sqlite3");
+    const openedDb = new Database(dbPath, { readonly: true, fileMustExist: true });
+    db = openedDb;
+    const row = openedDb
+      .prepare("SELECT encrypted_data, checksum FROM secure_settings WHERE category = ?")
+      .get("controlplane") as SecureSettingsRow | undefined;
+    if (!row) return {};
+    const decrypted = decryptSecureSettings(row, userDataDir);
+    const settings = JSON.parse(decrypted) as StoredControlPlaneSettings;
+    return normalizeSettings(settings, dbPath);
+  } catch (error) {
+    const cliFallback = readDatabaseSettingsWithSqliteCli(dbPath, userDataDir);
+    if (cliFallback.token || cliFallback.error) return cliFallback;
+    const message = error instanceof Error ? error.message : String(error);
+    return { error: `Failed to read local GUI control-plane settings at ${dbPath}: ${message}` };
+  } finally {
+    try {
+      db?.close?.();
+    } catch {
+      // Best-effort close.
+    }
+  }
+}
+
+function readDatabaseSettingsWithSqliteCli(
+  dbPath: string,
+  userDataDir: string,
+): LocalControlPlaneDiscoveryResult {
+  try {
+    const output = execFileSync(
+      "sqlite3",
+      [
+        "-separator",
+        "\t",
+        dbPath,
+        "SELECT encrypted_data, checksum FROM secure_settings WHERE category = 'controlplane' LIMIT 1;",
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
+    if (!output) return {};
+    const [encryptedData, checksum] = output.split("\t");
+    if (!encryptedData || !checksum) return { error: `Invalid sqlite3 output for ${dbPath}` };
+    const decrypted = decryptSecureSettings({ encrypted_data: encryptedData, checksum }, userDataDir);
+    return normalizeSettings(JSON.parse(decrypted) as StoredControlPlaneSettings, dbPath);
+  } catch (error) {
+    return { error: `Failed sqlite3 fallback for ${dbPath}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+function normalizeSettings(
+  settings: StoredControlPlaneSettings,
+  source: string,
+): LocalControlPlaneDiscoveryResult {
+  const token = typeof settings.token === "string" ? settings.token.trim() : "";
+  if (!token) return { error: `No control-plane token in ${source}` };
+  if (settings.enabled === false) {
+    return { error: `Control plane is disabled in ${source}` };
+  }
+  const host = typeof settings.host === "string" && settings.host.trim() ? settings.host.trim() : "127.0.0.1";
+  const port = typeof settings.port === "number" && Number.isFinite(settings.port) ? settings.port : 18789;
+  return {
+    url: `ws://${host}:${port}`,
+    token,
+    source,
+  };
+}
+
+function decryptSecureSettings(row: SecureSettingsRow, userDataDir: string): string {
+  const encryptedData = row.encrypted_data;
+  if (encryptedData.startsWith("app:")) {
+    const parts = encryptedData.slice(4).split(":");
+    if (parts.length !== 3) throw new Error("Invalid app-encrypted settings format");
+    const [ivBase64, authTagBase64, encrypted] = parts;
+    const key = deriveAppKey(userDataDir);
+    const decipher = crypto.createDecipheriv("aes-256-gcm", key, Buffer.from(ivBase64, "base64"));
+    decipher.setAuthTag(Buffer.from(authTagBase64, "base64"));
+    let decrypted = decipher.update(encrypted, "base64", "utf8");
+    decrypted += decipher.final("utf8");
+    verifyChecksum(decrypted, row.checksum);
+    return decrypted;
+  }
+  if (encryptedData.startsWith("os:")) {
+    throw new Error(
+      "settings are encrypted with the Electron OS keychain. Open CoWork OS settings and copy the Control Plane token once, or run `cowork login --token <token>`.",
+    );
+  }
+  verifyChecksum(encryptedData, row.checksum);
+  return encryptedData;
+}
+
+function verifyChecksum(data: string, expected: string): void {
+  const actual = crypto.createHash("sha256").update(data).digest("hex");
+  if (actual !== expected) throw new Error("settings checksum mismatch");
+}
+
+function deriveAppKey(userDataDir: string): Buffer {
+  const appSalt = "cowork-os-secure-settings-v1";
+  const machineId = readMachineIdentifier(userDataDir);
+  return crypto.pbkdf2Sync(appSalt, machineId, 100000, 32, "sha512");
+}
+
+function readMachineIdentifier(userDataDir: string): string {
+  const machineIdPath = path.join(userDataDir, MACHINE_ID_FILE);
+  try {
+    if (fs.existsSync(machineIdPath)) {
+      const value = fs.readFileSync(machineIdPath, "utf8").trim();
+      if (value) return value;
+    }
+  } catch {
+    // Use path-derived fallback below.
+  }
+  return [userDataDir, machineIdPath, "cowork-os-secure-settings-fallback-v2"].join(":");
+}
+
+function getPlatformElectronUserDataRoot(): string | undefined {
+  const home = os.homedir();
+  if (process.platform === "darwin") return path.join(home, "Library", "Application Support", "cowork-os");
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+    return path.join(appData, "cowork-os");
+  }
+  const configHome = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
+  return path.join(configHome, "cowork-os");
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeProfileId(input: string): string {
+  const normalized = input.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/-+/g, "-");
+  return normalized.replace(/^[-_.]+|[-_.]+$/g, "").slice(0, 64);
+}
+
+type Any = Record<string, any>;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,1540 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import readline from "node:readline/promises";
+import {
+  ControlPlaneClient,
+  ControlPlaneRequestError,
+  type ControlPlaneFrame,
+} from "./control-plane-client";
+import {
+  createDefaultConfig,
+  loadCliConfig,
+  removeProfileToken,
+  resolveConnection,
+  saveCliConfig,
+  upsertProfile,
+  type CliConfig,
+  type ResolvedConnection,
+} from "./config-store";
+import {
+  buildTaskTitle,
+  extractArrayPayload,
+  formatApproval,
+  formatTask,
+  formatTaskEventFrame,
+  formatWorkspace,
+  isTerminalTaskFrame,
+  matchesTask,
+  printJson,
+  type ApprovalLike,
+  type TaskLike,
+  type WorkspaceLike,
+} from "./format";
+import { discoverLocalControlPlane } from "./local-control-plane-discovery";
+import { promptMarker, renderWelcomeScreen } from "./terminal-ui";
+
+type Any = Record<string, any>;
+
+interface ParsedArgs {
+  command: string;
+  rest: string[];
+  flags: Map<string, string | boolean>;
+}
+
+interface CommandContext {
+  parsed: ParsedArgs;
+  config: CliConfig;
+  connection: ResolvedConnection;
+  json: boolean;
+  discoveryError?: string;
+  discoverySource?: string;
+  autoDiscovered?: boolean;
+}
+
+const VALUE_FLAGS = new Set([
+  "--url",
+  "--token",
+  "--profile",
+  "--device-name",
+  "--workspace-id",
+  "--workspace",
+  "--cwd",
+  "--limit",
+  "--model",
+  "--api-key",
+  "--base-url",
+  "--provider",
+  "--name",
+  "--title",
+  "--permission-mode",
+  "--session-id",
+  "--days",
+  "--output",
+  "--query",
+  "--category",
+  "--tool",
+  "--rule-id",
+  "--task-id",
+  "--transport",
+  "--command",
+  "--format",
+]);
+
+const METHODS = {
+  HEALTH: "health",
+  STATUS: "status",
+  CONFIG_GET: "config.get",
+  LLM_CONFIGURE: "llm.configure",
+  WORKSPACE_LIST: "workspace.list",
+  WORKSPACE_CREATE: "workspace.create",
+  TASK_CREATE: "task.create",
+  TASK_CANCEL: "task.cancel",
+  TASK_LIST: "task.list",
+  TASK_EVENTS: "task.events",
+  TASK_GET: "task.get",
+  APPROVAL_LIST: "approval.list",
+  APPROVAL_RESPOND: "approval.respond",
+} as const;
+
+export async function main(argv = process.argv.slice(2)): Promise<number> {
+  const parsed = parseArgs(argv);
+  if (parsed.command === "help" || hasFlag(parsed, "--help") || hasFlag(parsed, "-h")) {
+    usage();
+    return 0;
+  }
+  if (hasFlag(parsed, "--version") || hasFlag(parsed, "-v")) {
+    const config = loadCliConfig();
+    const baseConnection = resolveConnection({
+      config,
+      profile: getFlag(parsed, "--profile"),
+      url: getFlag(parsed, "--url"),
+      token: getFlag(parsed, "--token"),
+    });
+    return version({
+      parsed,
+      config,
+      connection: baseConnection,
+      json: hasFlag(parsed, "--json"),
+    });
+  }
+  if (!parsed.command) {
+    return interactive(argv);
+  }
+
+  const config = loadCliConfig();
+  const baseConnection = resolveConnection({
+    config,
+    profile: getFlag(parsed, "--profile"),
+    url: getFlag(parsed, "--url"),
+    token: getFlag(parsed, "--token"),
+  });
+  const { connection, discoveryError, discoverySource, autoDiscovered } =
+    resolveConnectionWithLocalDiscovery(baseConnection, parsed);
+  const ctx: CommandContext = {
+    parsed,
+    config,
+    connection,
+    discoveryError,
+    discoverySource,
+    autoDiscovered,
+    json: hasFlag(parsed, "--json"),
+  };
+
+  try {
+    switch (parsed.command) {
+      case "version":
+      case "--version":
+      case "-v":
+        return await version(ctx);
+      case "status":
+        return await status(ctx);
+      case "doctor":
+        return await doctor(ctx);
+      case "login":
+        return login(ctx);
+      case "logout":
+        return logout(ctx);
+      case "whoami":
+        return whoami(ctx);
+      case "config":
+        return configCommand(ctx);
+      case "daemon":
+        return await daemon(ctx);
+      case "workspace":
+      case "workspaces":
+        return await workspace(ctx);
+      case "run":
+        return await runTask(ctx);
+      case "tail":
+        return await tail(ctx);
+      case "approvals":
+        return await approvals(ctx);
+      case "approve":
+        return await respondApproval(ctx, true);
+      case "reject":
+        return await respondApproval(ctx, false);
+      case "providers":
+      case "provider":
+        return await providers(ctx);
+      case "sessions":
+      case "session":
+        return await sessions(ctx);
+      case "tasks":
+      case "task":
+        return await tasks(ctx);
+      case "logs":
+      case "log":
+        return await logs(ctx);
+      case "tools":
+      case "tool":
+        return await tools(ctx);
+      case "mcp":
+        return await mcp(ctx);
+      case "skills":
+      case "skill":
+        return await skills(ctx);
+      case "models":
+      case "model":
+        return await models(ctx);
+      case "backup":
+        return await backup(ctx);
+      case "security":
+        return await security(ctx);
+      case "prompt-size":
+        return await promptSize(ctx);
+      case "prompt-preview":
+        return await promptPreview(ctx);
+      case "completions":
+      case "completion":
+        return completions(ctx);
+      case "dashboard":
+        return await dashboard(ctx);
+      case "open":
+        return await openCommand(ctx);
+      default:
+        process.stderr.write(`Unknown command: ${parsed.command}\n\n`);
+        usage();
+        return 1;
+    }
+  } catch (error) {
+    return handleError(error);
+  }
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const flags = new Map<string, string | boolean>();
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      if (VALUE_FLAGS.has(arg)) {
+        const value = argv[i + 1];
+        if (!value || value.startsWith("--")) {
+          flags.set(arg, "");
+        } else {
+          flags.set(arg, value);
+          i += 1;
+        }
+      } else {
+        flags.set(arg, true);
+      }
+      continue;
+    }
+    if (arg.startsWith("-") && arg !== "-") {
+      flags.set(arg, true);
+      continue;
+    }
+    positional.push(arg);
+  }
+  const [command = "", ...rest] = positional;
+  return { command, rest, flags };
+}
+
+export function parseInteractiveCommand(input: string): string[] {
+  const trimmed = input.trim();
+  if (!trimmed) return [];
+  if (!trimmed.startsWith("/")) return ["run", trimmed];
+  const commandLine = trimmed.slice(1).trim();
+  if (!commandLine) return [];
+  if (commandLine === "exit" || commandLine === "quit") return ["exit"];
+  if (commandLine === "?") return ["help"];
+  return splitCommandLine(commandLine);
+}
+
+async function interactive(initialArgv: string[]): Promise<number> {
+  const globalFlags = initialArgv;
+  printBanner();
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: promptMarker(),
+  });
+
+  try {
+    rl.prompt();
+    for await (const line of rl) {
+      const args = parseInteractiveCommand(line);
+      if (args[0] === "exit") break;
+      if (args.length === 0) {
+        rl.prompt();
+        continue;
+      }
+      const code = await main([...globalFlags, ...args]);
+      if (code !== 0) process.stdout.write(`Command exited with code ${code}.\n`);
+      rl.prompt();
+    }
+    return 0;
+  } finally {
+    rl.close();
+  }
+}
+
+function printBanner(): void {
+  process.stdout.write(`${renderWelcomeScreen({ version: getCliVersion() })}\n`);
+}
+
+function getCliVersion(): string {
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "..", "package.json"),
+    path.resolve(__dirname, "..", "..", "package.json"),
+  ];
+  for (const packageJsonPath of candidates) {
+    try {
+      const pkg = require(packageJsonPath) as { version?: string };
+      if (pkg.version) return pkg.version;
+    } catch {
+      // Try the next layout; source and dist have different __dirname depth.
+    }
+  }
+  return "dev";
+}
+
+function splitCommandLine(input: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const ch of input) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (escaped) current += "\\";
+  if (current) args.push(current);
+  return args;
+}
+
+function resolveConnectionWithLocalDiscovery(
+  connection: ResolvedConnection,
+  parsed: ParsedArgs,
+): {
+  connection: ResolvedConnection;
+  discoveryError?: string;
+  discoverySource?: string;
+  autoDiscovered?: boolean;
+} {
+  if (connection.token || hasFlag(parsed, "--no-discover")) return { connection };
+  const discovered = discoverLocalControlPlane(getFlag(parsed, "--profile") || connection.profileName);
+  if (discovered.token) {
+    return {
+      connection: {
+        ...connection,
+        url: getFlag(parsed, "--url") || discovered.url || connection.url,
+        token: discovered.token,
+      },
+      discoverySource: discovered.source,
+      autoDiscovered: true,
+    };
+  }
+  return { connection, discoveryError: discovered.error };
+}
+
+async function doctor(ctx: CommandContext): Promise<number> {
+  if (!hasFlag(ctx.parsed, "--remote")) {
+    return runDirectCommandProcess(ctx, ["--doctor"]);
+  }
+
+  const checks: string[] = [];
+  checks.push(`profile: ${ctx.connection.profileName}`);
+  checks.push(`url: ${ctx.connection.url}`);
+  checks.push(`token: ${ctx.connection.token ? "configured" : "missing"}`);
+  if (ctx.autoDiscovered && ctx.discoverySource) checks.push(`discovered: ${ctx.discoverySource}`);
+
+  if (!ctx.connection.token) {
+    printLinesOrJson(ctx, { ok: false, checks }, [
+      "CoWork CLI doctor",
+      ...checks.map((line) => `- ${line}`),
+      "",
+      "Missing token. Run:",
+      "  cowork login --token <control-plane-token>",
+    ]);
+    return 1;
+  }
+
+  const client = await connectedClient(ctx);
+  try {
+    const health = await client.request(METHODS.HEALTH);
+    const config = await client.request(METHODS.CONFIG_GET);
+    printLinesOrJson(ctx, { ok: true, checks, health, config }, [
+      "CoWork CLI doctor",
+      ...checks.map((line) => `- ${line}`),
+      "- control plane: reachable",
+      ...formatConfigWarnings(config),
+    ]);
+    return 0;
+  } finally {
+    client.close();
+  }
+}
+
+async function version(ctx: CommandContext): Promise<number> {
+  return runDirectCommandProcess(ctx, ["--version"]);
+}
+
+async function status(ctx: CommandContext): Promise<number> {
+  return runDirectCommandProcess(ctx, ["--status"]);
+}
+
+function login(ctx: CommandContext): number {
+  const url = getFlag(ctx.parsed, "--url") || ctx.connection.url;
+  const token = getFlag(ctx.parsed, "--token") || process.env.COWORK_CONTROL_PLANE_TOKEN || "";
+  const profile = getFlag(ctx.parsed, "--profile") || ctx.connection.profileName || "local";
+  if (!token) {
+    process.stderr.write("Missing token. Provide --token or set COWORK_CONTROL_PLANE_TOKEN.\n");
+    return 1;
+  }
+  const next = upsertProfile(ctx.config, profile, { url, token }, true);
+  saveCliConfig(next);
+  printLinesOrJson(ctx, { ok: true, profile, url }, [
+    `Saved profile "${profile}".`,
+    `Control plane: ${url}`,
+  ]);
+  return 0;
+}
+
+function logout(ctx: CommandContext): number {
+  const profile = getFlag(ctx.parsed, "--profile") || ctx.connection.profileName || "local";
+  saveCliConfig(removeProfileToken(ctx.config, profile));
+  printLinesOrJson(ctx, { ok: true, profile }, [`Removed stored token for profile "${profile}".`]);
+  return 0;
+}
+
+function whoami(ctx: CommandContext): number {
+  if (!hasFlag(ctx.parsed, "--remote")) {
+    printLinesOrJson(ctx, { profile: ctx.connection.profileName, runtime: "local", controlPlaneRequired: false }, [
+      `Profile: ${ctx.connection.profileName}`,
+      "Runtime: local",
+      "Control Plane: not required for local CLI commands",
+    ]);
+    return 0;
+  }
+
+  printLinesOrJson(ctx, { ...ctx.connection, autoDiscovered: ctx.autoDiscovered, discoverySource: ctx.discoverySource }, [
+    `Profile: ${ctx.connection.profileName}`,
+    `URL: ${ctx.connection.url}`,
+    `Token: ${ctx.connection.token ? (ctx.autoDiscovered ? "auto-discovered" : "configured") : "missing"}`,
+    ...(ctx.discoverySource ? [`Source: ${ctx.discoverySource}`] : []),
+    ...(!ctx.connection.token && ctx.discoveryError ? [`Auto-discovery: ${ctx.discoveryError}`] : []),
+  ]);
+  return ctx.connection.token ? 0 : 1;
+}
+
+function configCommand(ctx: CommandContext): number {
+  if (ctx.parsed.rest[0] === "reset") {
+    saveCliConfig(createDefaultConfig());
+    process.stdout.write("Reset CoWork CLI config.\n");
+    return 0;
+  }
+  printJson(ctx.config);
+  return 0;
+}
+
+async function daemon(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "status";
+  if (sub === "status") {
+    return doctor({ ...ctx, parsed: { ...ctx.parsed, command: "doctor", rest: [] } });
+  }
+  if (sub !== "start") {
+    process.stderr.write("Usage: cowork daemon status | cowork daemon start [--background]\n");
+    return 1;
+  }
+
+  const packageRoot = path.resolve(__dirname, "..", "..");
+  const daemonBin = path.join(packageRoot, "bin", "coworkd-node.js");
+  const args = ["--print-control-plane-token", ...ctx.parsed.rest.slice(1)];
+  if (hasFlag(ctx.parsed, "--background")) {
+    const child = spawn(process.execPath, [daemonBin, ...args], {
+      cwd: packageRoot,
+      detached: true,
+      stdio: "ignore",
+      env: process.env,
+    });
+    child.unref();
+    process.stdout.write("Started CoWork daemon in the background.\n");
+    process.stdout.write("Check logs from your process manager, or run foreground mode to read the token.\n");
+    return 0;
+  }
+  const child = spawn(process.execPath, [daemonBin, ...args], {
+    cwd: packageRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+  return new Promise((resolve) => child.on("close", (code) => resolve(code ?? 0)));
+}
+
+async function workspace(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "list";
+  if (!hasFlag(ctx.parsed, "--remote")) {
+    if (sub === "list") {
+      return runDirectCommandProcess(ctx, ["--workspace-list"]);
+    }
+    if (sub === "create") {
+      const target = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--cwd") || process.cwd();
+      const resolved = path.resolve(target);
+      const name = getFlag(ctx.parsed, "--name") || path.basename(resolved) || "Workspace";
+      return runDirectCommandProcess(ctx, ["--workspace-create", "--cwd", resolved, "--name", name]);
+    }
+    process.stderr.write("Usage: cowork workspace list | cowork workspace create [path] [--name <name>]\n");
+    return 1;
+  }
+
+  const client = await connectedClient(ctx);
+  try {
+    if (sub === "list") {
+      const payload = await client.request(METHODS.WORKSPACE_LIST);
+      const workspaces = extractArrayPayload<WorkspaceLike>(payload, "workspaces");
+      printLinesOrJson(ctx, payload, workspaces.length ? workspaces.map(formatWorkspace) : ["No workspaces configured."]);
+      return 0;
+    }
+    if (sub === "create") {
+      const target = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--cwd") || process.cwd();
+      const resolved = path.resolve(target);
+      const name = getFlag(ctx.parsed, "--name") || path.basename(resolved) || "Workspace";
+      const payload = await client.request(METHODS.WORKSPACE_CREATE, { name, path: resolved });
+      printLinesOrJson(ctx, payload, [`Created workspace: ${formatWorkspace((payload as Any).workspace || {})}`]);
+      return 0;
+    }
+    process.stderr.write("Usage: cowork workspace list | cowork workspace create [path] [--name <name>]\n");
+    return 1;
+  } finally {
+    client.close();
+  }
+}
+
+async function runTask(ctx: CommandContext): Promise<number> {
+  const prompt = ctx.parsed.rest.join(" ").trim();
+  if (!prompt) {
+    process.stderr.write('Usage: cowork run "task prompt" [--cwd <path>] [--workspace-id <id>] [--shell] [--detach]\n');
+    return 1;
+  }
+  if (isLikelyCommandPrompt(prompt) && !hasFlag(ctx.parsed, "--force")) {
+    process.stderr.write(
+      `"${prompt}" looks like a CLI command. Did you mean \`cowork ${prompt}\`?\nUse \`cowork run --force ${prompt}\` to run it as a task.\n`,
+    );
+    return 1;
+  }
+  if (!hasFlag(ctx.parsed, "--remote")) {
+    if (hasFlag(ctx.parsed, "--detach")) {
+      return await runDirectDetachedTaskProcess(ctx, prompt);
+    }
+    return runDirectTaskProcess(ctx, prompt);
+  }
+  const client = await connectedClient(ctx);
+  try {
+    const cwd = path.resolve(getFlag(ctx.parsed, "--cwd") || process.cwd());
+    const workspaceId = await resolveWorkspaceId(client, ctx, cwd);
+    const params: Record<string, unknown> = {
+      workspaceId,
+      title: getFlag(ctx.parsed, "--title") || buildTaskTitle(prompt),
+      prompt,
+      ...(hasFlag(ctx.parsed, "--shell") ? { shellAccess: true } : {}),
+      ...(getFlag(ctx.parsed, "--permission-mode") ? { permissionMode: getFlag(ctx.parsed, "--permission-mode") } : {}),
+    };
+    const created = await client.request(METHODS.TASK_CREATE, params, 30000);
+    const task = ((created as Any).task || {}) as TaskLike;
+    const taskId = String((created as Any).taskId || task.id || "");
+    if (ctx.json || hasFlag(ctx.parsed, "--no-follow")) {
+      printJson(created);
+      return 0;
+    }
+    if (hasFlag(ctx.parsed, "--detach")) {
+      process.stdout.write(`Created detached task: ${taskId}  ${task.title || buildTaskTitle(prompt)}\n`);
+      process.stdout.write(`Tail: cowork tasks attach ${taskId} --remote\n`);
+      process.stdout.write(`Cancel: cowork tasks cancel ${taskId} --remote\n`);
+      return 0;
+    }
+    process.stdout.write(`Created task: ${formatTask(task)}\n`);
+    process.stdout.write(`Tail: cowork tail ${taskId}\n\n`);
+    return await streamTask(client, taskId, Number(getFlag(ctx.parsed, "--limit") || 200));
+  } finally {
+    client.close();
+  }
+}
+
+function runDirectTaskProcess(ctx: CommandContext, prompt: string): Promise<number> {
+  return runDirectCommandProcess(ctx, buildDirectTaskArgs(ctx, prompt));
+}
+
+async function runDirectDetachedTaskProcess(ctx: CommandContext, prompt: string): Promise<number> {
+  const runtime = resolveDirectRuntime();
+  const readyFile = path.join(os.tmpdir(), `cowork-cli-detached-${randomUUID()}.json`);
+  const directRunArgs = [
+    ...buildDirectTaskArgs(ctx, prompt),
+    "--detached-worker",
+    "--ready-file",
+    readyFile,
+    ...(ctx.json ? ["--json"] : []),
+  ];
+  const child = spawn(runtime.executable, [runtime.scriptPath, ...directRunArgs], {
+    cwd: path.resolve(getFlag(ctx.parsed, "--cwd") || process.cwd()),
+    detached: true,
+    stdio: "ignore",
+    env: runtime.usesElectron
+      ? { ...process.env, ELECTRON_RUN_AS_NODE: "1", COWORK_HEADLESS: "1" }
+      : { ...process.env, COWORK_HEADLESS: "1" },
+  });
+  child.unref();
+  const ready = await waitForDetachedReadyFile(readyFile, 30000);
+  if (ctx.json) {
+    printJson({ type: "detached_task", ...ready, pid: child.pid || null });
+    return 0;
+  }
+  if (ready?.taskId) {
+    process.stdout.write(`Created detached task: ${ready.taskId}  ${ready.title || prompt}\n`);
+    process.stdout.write(`Tail: cowork tasks attach ${ready.taskId}\n`);
+    process.stdout.write(`Cancel: cowork tasks cancel ${ready.taskId}\n`);
+  } else {
+    process.stdout.write("Started detached task runner. Task id was not available before timeout.\n");
+  }
+  return 0;
+}
+
+function buildDirectTaskArgs(ctx: CommandContext, prompt: string): string[] {
+  return [
+    "--prompt",
+    prompt,
+    "--cwd",
+    path.resolve(getFlag(ctx.parsed, "--cwd") || process.cwd()),
+    ...(getFlag(ctx.parsed, "--title") ? ["--title", getFlag(ctx.parsed, "--title")!] : []),
+    ...(getFlag(ctx.parsed, "--workspace-id")
+      ? ["--workspace-id", getFlag(ctx.parsed, "--workspace-id")!]
+      : []),
+    ...(hasFlag(ctx.parsed, "--shell") ? ["--shell"] : []),
+  ];
+}
+
+async function waitForDetachedReadyFile(
+  readyFile: string,
+  timeoutMs: number,
+): Promise<{ taskId?: string; title?: string; status?: string; workspaceId?: string } | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const text = await fs.readFile(readyFile, "utf8");
+      await fs.unlink(readyFile).catch(() => {});
+      const parsed = JSON.parse(text) as { taskId?: string; title?: string; status?: string; workspaceId?: string };
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  return null;
+}
+
+function runDirectCommandProcess(ctx: CommandContext, directArgs: string[]): Promise<number> {
+  const runtime = resolveDirectRuntime();
+  const directRunArgs = [...directArgs, ...(ctx.json ? ["--json"] : [])];
+  const args = [runtime.scriptPath, ...directRunArgs];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(runtime.executable, args, {
+      cwd: path.resolve(getFlag(ctx.parsed, "--cwd") || process.cwd()),
+      stdio: "inherit",
+      env: runtime.usesElectron
+        ? { ...process.env, ELECTRON_RUN_AS_NODE: "1", COWORK_HEADLESS: "1" }
+        : { ...process.env, COWORK_HEADLESS: "1" },
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (signal === "SIGINT") resolve(130);
+      else if (signal === "SIGTERM") resolve(143);
+      else resolve(code ?? 0);
+    });
+  });
+}
+
+function resolveDirectRuntime(): {
+  executable: string;
+  scriptPath: string;
+  appPath: string;
+  usesElectron: boolean;
+} {
+  const scriptPath = path.join(__dirname, "direct-run.js");
+  const appPath = path.resolve(__dirname, "..", "..", "..");
+  try {
+    const electronBinary = require("electron");
+    if (typeof electronBinary === "string" && electronBinary.trim()) {
+      return { executable: electronBinary, scriptPath, appPath, usesElectron: true };
+    }
+  } catch {
+    // Fall back to the current Node process.
+  }
+  return { executable: process.execPath, scriptPath, appPath, usesElectron: false };
+}
+
+async function tail(ctx: CommandContext): Promise<number> {
+  const taskId = ctx.parsed.rest[0];
+  if (!taskId) {
+    process.stderr.write("Usage: cowork tail <taskId> [--limit <n>] [--json]\n");
+    return 1;
+  }
+  if (!hasFlag(ctx.parsed, "--remote")) {
+    return runDirectCommandProcess(ctx, [
+      "--tail",
+      "--task-id",
+      taskId,
+      "--limit",
+      String(parseLimit(ctx, 200)),
+    ]);
+  }
+
+  const client = await connectedClient(ctx);
+  try {
+    return await streamTask(client, taskId, Number(getFlag(ctx.parsed, "--limit") || 200), ctx.json);
+  } finally {
+    client.close();
+  }
+}
+
+async function approvals(ctx: CommandContext): Promise<number> {
+  if (!hasFlag(ctx.parsed, "--remote")) {
+    return runDirectCommandProcess(ctx, ["--approvals-list", "--limit", String(parseLimit(ctx, 100))]);
+  }
+
+  const client = await connectedClient(ctx);
+  try {
+    const payload = await client.request(METHODS.APPROVAL_LIST, { limit: parseLimit(ctx, 100), offset: 0 });
+    const rows = extractArrayPayload<ApprovalLike>(payload, "approvals");
+    printLinesOrJson(ctx, payload, rows.length ? rows.map(formatApproval) : ["No pending approvals."]);
+    return 0;
+  } finally {
+    client.close();
+  }
+}
+
+async function respondApproval(ctx: CommandContext, approved: boolean): Promise<number> {
+  const approvalId = ctx.parsed.rest[0];
+  if (!approvalId) {
+    process.stderr.write(`Usage: cowork ${approved ? "approve" : "reject"} <approvalId>\n`);
+    return 1;
+  }
+  if (!hasFlag(ctx.parsed, "--remote")) {
+    return runLocalApprovalResponseProcess(ctx, approvalId, approved);
+  }
+
+  const client = await connectedClient(ctx);
+  try {
+    const payload = await client.request(METHODS.APPROVAL_RESPOND, { approvalId, approved });
+    printLinesOrJson(ctx, payload, [`${approved ? "Approved" : "Rejected"} approval ${approvalId}.`]);
+    return 0;
+  } finally {
+    client.close();
+  }
+}
+
+function runLocalApprovalResponseProcess(
+  ctx: CommandContext,
+  approvalId: string,
+  approved: boolean,
+): Promise<number> {
+  const runtime = resolveDirectRuntime();
+  if (!runtime.usesElectron) {
+    process.stderr.write(
+      "Local approval response requires the Electron runtime. Use the desktop app or rerun with --remote.\n",
+    );
+    return Promise.resolve(1);
+  }
+
+  const args = [
+    runtime.appPath,
+    "--cowork-cli-approval-response",
+    "--approval-id",
+    approvalId,
+    approved ? "--approved" : "--rejected",
+  ];
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const child = spawn(runtime.executable, args, {
+      cwd: process.cwd(),
+      stdio: "ignore",
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: "" },
+    });
+    const finish = (code: number) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (code === 0) {
+        process.stdout.write(
+          `Sent ${approved ? "approval" : "rejection"} ${approvalId} to the running CoWork OS app.\n`,
+        );
+      }
+      resolve(code);
+    };
+    const timeout = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // Best-effort.
+      }
+      process.stderr.write(
+        "No running CoWork OS desktop app accepted the local approval response. Open the app, then retry, or use --remote.\n",
+      );
+      finish(1);
+    }, 4000);
+    child.on("error", reject);
+    child.on("close", (code) => finish(code ?? 0));
+  });
+}
+
+async function providers(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "list";
+  if (!hasFlag(ctx.parsed, "--remote") && sub === "fallback") {
+    const action = ctx.parsed.rest[1] || "list";
+    if (action === "list") return runDirectCommandProcess(ctx, ["--providers-fallback-list"]);
+    if (action === "add") {
+      const providerType = ctx.parsed.rest[2] || getFlag(ctx.parsed, "--provider");
+      if (!providerType) {
+        process.stderr.write("Usage: cowork providers fallback add <provider> [--model <model>]\n");
+        return 1;
+      }
+      return runDirectCommandProcess(ctx, [
+        "--providers-fallback-add",
+        "--provider",
+        providerType,
+        ...(getFlag(ctx.parsed, "--model") ? ["--model", getFlag(ctx.parsed, "--model")!] : []),
+      ]);
+    }
+    if (action === "remove") {
+      const providerType = ctx.parsed.rest[2] || getFlag(ctx.parsed, "--provider");
+      if (!providerType) {
+        process.stderr.write("Usage: cowork providers fallback remove <provider>\n");
+        return 1;
+      }
+      return runDirectCommandProcess(ctx, ["--providers-fallback-remove", "--provider", providerType]);
+    }
+    process.stderr.write("Usage: cowork providers fallback list|add|remove\n");
+    return 1;
+  }
+  if (!hasFlag(ctx.parsed, "--remote") && (sub === "list" || sub === "status")) {
+    return runDirectCommandProcess(ctx, ["--providers-list"]);
+  }
+  if (!hasFlag(ctx.parsed, "--remote") && sub === "configure") {
+    const providerType = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--provider");
+    if (!providerType) {
+      process.stderr.write("Usage: cowork providers configure <provider> [--api-key <key>] [--model <model>] [--base-url <url>]\n");
+      return 1;
+    }
+    return runDirectCommandProcess(ctx, [
+      "--providers-configure",
+      "--provider",
+      providerType,
+      ...(getFlag(ctx.parsed, "--api-key") || providerEnvKey(providerType)
+        ? ["--api-key", getFlag(ctx.parsed, "--api-key") || providerEnvKey(providerType)]
+        : []),
+      ...(getFlag(ctx.parsed, "--model") ? ["--model", getFlag(ctx.parsed, "--model")!] : []),
+      ...(getFlag(ctx.parsed, "--base-url") ? ["--base-url", getFlag(ctx.parsed, "--base-url")!] : []),
+    ]);
+  }
+
+  const client = await connectedClient(ctx);
+  try {
+    if (sub === "list" || sub === "status") {
+      const config = await client.request(METHODS.CONFIG_GET);
+      const llm = (config as Any).llm || {};
+      printLinesOrJson(ctx, llm, formatProviders(llm));
+      return 0;
+    }
+    if (sub === "configure") {
+      const providerType = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--provider");
+      if (!providerType) {
+        process.stderr.write("Usage: cowork providers configure <provider> [--api-key <key>] [--model <model>] [--base-url <url>]\n");
+        return 1;
+      }
+      const apiKey = getFlag(ctx.parsed, "--api-key") || providerEnvKey(providerType);
+      const model = getFlag(ctx.parsed, "--model");
+      const baseUrl = getFlag(ctx.parsed, "--base-url");
+      const payload = await client.request(METHODS.LLM_CONFIGURE, {
+        providerType,
+        ...(apiKey ? { apiKey } : {}),
+        ...(model ? { model } : {}),
+        ...(baseUrl ? { settings: { baseUrl } } : {}),
+      });
+      printLinesOrJson(ctx, payload, [`Configured provider "${providerType}".`]);
+      return 0;
+    }
+    process.stderr.write("Usage: cowork providers list | cowork providers configure <provider>\n");
+    return 1;
+  } finally {
+    client.close();
+  }
+}
+
+async function sessions(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "list";
+  if (sub === "list") return runDirectCommandProcess(ctx, ["--sessions-list", "--limit", String(parseLimit(ctx, 50))]);
+  if (sub === "show") {
+    const id = ctx.parsed.rest[1];
+    if (!id) return usageError("Usage: cowork sessions show <sessionId>");
+    return runDirectCommandProcess(ctx, ["--sessions-show", "--session-id", id, "--limit", String(parseLimit(ctx, 200))]);
+  }
+  if (sub === "export") {
+    const id = ctx.parsed.rest[1];
+    if (!id) return usageError("Usage: cowork sessions export <sessionId> [--output <file>]");
+    return runDirectCommandProcess(ctx, [
+      "--sessions-export",
+      "--session-id",
+      id,
+      ...(getFlag(ctx.parsed, "--output") ? ["--output", getFlag(ctx.parsed, "--output")!] : []),
+      "--limit",
+      String(parseLimit(ctx, 1000)),
+    ]);
+  }
+  if (sub === "rename") {
+    const id = ctx.parsed.rest[1];
+    const name = ctx.parsed.rest.slice(2).join(" ").trim() || getFlag(ctx.parsed, "--name");
+    if (!id || !name) return usageError("Usage: cowork sessions rename <sessionId> <name>");
+    return runDirectCommandProcess(ctx, ["--sessions-rename", "--session-id", id, "--name", name]);
+  }
+  if (sub === "delete") {
+    const id = ctx.parsed.rest[1];
+    if (!id) return usageError("Usage: cowork sessions delete <sessionId> --yes");
+    return runDirectCommandProcess(ctx, ["--sessions-delete", "--session-id", id, ...(hasFlag(ctx.parsed, "--yes") ? ["--yes"] : [])]);
+  }
+  if (sub === "prune") {
+    return runDirectCommandProcess(ctx, [
+      "--sessions-prune",
+      "--days",
+      String(parseDays(ctx, 30)),
+      ...(hasFlag(ctx.parsed, "--yes") ? ["--yes"] : []),
+    ]);
+  }
+  process.stderr.write("Usage: cowork sessions list|show|export|rename|delete|prune\n");
+  return 1;
+}
+
+async function tasks(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "list";
+  if (!hasFlag(ctx.parsed, "--remote")) {
+    if (sub === "list") {
+      return runDirectCommandProcess(ctx, [
+        "--tasks-list",
+        "--limit",
+        String(parseLimit(ctx, 50)),
+        ...(hasFlag(ctx.parsed, "--active") ? ["--active"] : []),
+        ...(hasFlag(ctx.parsed, "--cli") ? ["--cli"] : []),
+      ]);
+    }
+    if (sub === "cancel") {
+      const taskId = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--task-id");
+      if (!taskId) return usageError("Usage: cowork tasks cancel <taskId>");
+      return runDirectCommandProcess(ctx, ["--tasks-cancel", "--task-id", taskId]);
+    }
+    if (sub === "attach") {
+      const taskId = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--task-id");
+      if (!taskId) return usageError("Usage: cowork tasks attach <taskId>");
+      return runDirectCommandProcess(ctx, [
+        "--tasks-attach",
+        "--task-id",
+        taskId,
+        "--limit",
+        String(parseLimit(ctx, 200)),
+      ]);
+    }
+    if (sub === "stale") {
+      return runDirectCommandProcess(ctx, ["--tasks-stale", "--limit", String(parseLimit(ctx, 100))]);
+    }
+    if (sub === "cleanup") {
+      return runDirectCommandProcess(ctx, [
+        "--tasks-cleanup",
+        ...(hasFlag(ctx.parsed, "--interrupted-cli") ? ["--interrupted-cli"] : []),
+        ...(hasFlag(ctx.parsed, "--yes") ? ["--yes"] : []),
+        "--limit",
+        String(parseLimit(ctx, 1000)),
+      ]);
+    }
+    return usageError("Usage: cowork tasks list|cancel|attach|stale|cleanup");
+  }
+
+  const client = await connectedClient(ctx);
+  try {
+    if (sub === "list") {
+      const payload = await client.request(METHODS.TASK_LIST, { limit: parseLimit(ctx, 50), offset: 0 });
+      const rows = extractArrayPayload<TaskLike>(payload, "tasks");
+      const filtered = hasFlag(ctx.parsed, "--active")
+        ? rows.filter((task) => !["completed", "failed", "cancelled"].includes(String(task.status || "")))
+        : rows;
+      printLinesOrJson(ctx, payload, filtered.length ? filtered.map(formatTask) : ["No matching remote tasks found."]);
+      return 0;
+    }
+    if (sub === "cancel") {
+      const taskId = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--task-id");
+      if (!taskId) return usageError("Usage: cowork tasks cancel <taskId> --remote");
+      const payload = await client.request(METHODS.TASK_CANCEL, { taskId });
+      printLinesOrJson(ctx, payload, [`Cancelled task ${taskId}.`]);
+      return 0;
+    }
+    if (sub === "attach") {
+      const taskId = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--task-id");
+      if (!taskId) return usageError("Usage: cowork tasks attach <taskId> --remote");
+      return await streamTask(client, taskId, parseLimit(ctx, 200), ctx.json);
+    }
+    return usageError("Remote usage: cowork tasks list|cancel|attach --remote");
+  } finally {
+    client.close();
+  }
+}
+
+async function logs(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "latest";
+  if (sub === "latest") return runDirectCommandProcess(ctx, ["--logs-latest", "--limit", String(parseLimit(ctx, 80))]);
+  if (sub === "tail") return runDirectCommandProcess(ctx, ["--logs-tail", "--limit", String(parseLimit(ctx, 80))]);
+  if (sub === "grep") {
+    const query = ctx.parsed.rest.slice(1).join(" ").trim() || getFlag(ctx.parsed, "--query");
+    if (!query) return usageError("Usage: cowork logs grep <query>");
+    return runDirectCommandProcess(ctx, ["--logs-grep", "--query", query, "--limit", String(parseLimit(ctx, 80))]);
+  }
+  process.stderr.write("Usage: cowork logs latest|tail|grep\n");
+  return 1;
+}
+
+async function tools(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "list";
+  if (sub === "list") return runDirectCommandProcess(ctx, ["--tools-list"]);
+  if (sub === "info" || sub === "enable" || sub === "disable") {
+    const target = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--category") || getFlag(ctx.parsed, "--tool");
+    if (!target) return usageError(`Usage: cowork tools ${sub} <category-or-tool>`);
+    return runDirectCommandProcess(ctx, [`--tools-${sub}`, "--name", target]);
+  }
+  process.stderr.write("Usage: cowork tools list|info|enable|disable\n");
+  return 1;
+}
+
+async function mcp(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "list";
+  if (sub === "list") return runDirectCommandProcess(ctx, ["--mcp-list"]);
+  if (sub === "add") {
+    const name = getFlag(ctx.parsed, "--name") || ctx.parsed.rest[1];
+    if (!name) return usageError("Usage: cowork mcp add --name <name> (--command <cmd> | --url <url>)");
+    return runDirectCommandProcess(ctx, [
+      "--mcp-add",
+      "--name",
+      name,
+      ...(getFlag(ctx.parsed, "--transport") ? ["--transport", getFlag(ctx.parsed, "--transport")!] : []),
+      ...(getFlag(ctx.parsed, "--command") ? ["--command", getFlag(ctx.parsed, "--command")!] : []),
+      ...(getFlag(ctx.parsed, "--url") ? ["--url", getFlag(ctx.parsed, "--url")!] : []),
+      "--cwd",
+      path.resolve(getFlag(ctx.parsed, "--cwd") || process.cwd()),
+    ]);
+  }
+  if (sub === "remove" || sub === "enable" || sub === "disable" || sub === "test") {
+    const id = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--name");
+    if (!id && sub !== "test") return usageError(`Usage: cowork mcp ${sub} <serverId>`);
+    return runDirectCommandProcess(ctx, [`--mcp-${sub}`, ...(id ? ["--name", id] : [])]);
+  }
+  process.stderr.write("Usage: cowork mcp list|add|remove|enable|disable|test\n");
+  return 1;
+}
+
+async function skills(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "list";
+  if (sub === "list") return runDirectCommandProcess(ctx, ["--skills-list", "--limit", String(parseLimit(ctx, 200))]);
+  if (sub === "info") {
+    const id = ctx.parsed.rest.slice(1).join(" ").trim();
+    if (!id) return usageError("Usage: cowork skills info <skillId-or-name>");
+    return runDirectCommandProcess(ctx, ["--skills-info", "--name", id]);
+  }
+  if (sub === "audit") return runDirectCommandProcess(ctx, ["--skills-audit"]);
+  process.stderr.write("Usage: cowork skills list|info|audit\n");
+  return 1;
+}
+
+async function models(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "list";
+  if (sub === "list") return runDirectCommandProcess(ctx, ["--models-list", "--limit", String(parseLimit(ctx, 100))]);
+  process.stderr.write("Usage: cowork models list\n");
+  return 1;
+}
+
+async function backup(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "create";
+  if (sub === "create") {
+    return runDirectCommandProcess(ctx, [
+      "--backup-create",
+      ...(getFlag(ctx.parsed, "--output") ? ["--output", getFlag(ctx.parsed, "--output")!] : []),
+      "--limit",
+      String(parseLimit(ctx, 500)),
+      ...(hasFlag(ctx.parsed, "--include-secrets") ? ["--include-secrets"] : []),
+      ...(hasFlag(ctx.parsed, "--yes") ? ["--yes"] : []),
+    ]);
+  }
+  if (sub === "restore") {
+    const file = ctx.parsed.rest[1] || getFlag(ctx.parsed, "--output");
+    if (!file) return usageError("Usage: cowork backup restore <backup.json> [--dry-run] [--yes]");
+    return runDirectCommandProcess(ctx, [
+      "--backup-restore",
+      "--output",
+      file,
+      ...(hasFlag(ctx.parsed, "--dry-run") ? ["--dry-run"] : []),
+      ...(hasFlag(ctx.parsed, "--yes") ? ["--yes"] : []),
+    ]);
+  }
+  process.stderr.write("Usage: cowork backup create|restore\n");
+  return 1;
+}
+
+async function security(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "audit";
+  if (sub === "audit") return runDirectCommandProcess(ctx, ["--security-audit"]);
+  if (sub === "rules") {
+    const action = ctx.parsed.rest[1] || "list";
+    if (action === "list") {
+      return runDirectCommandProcess(ctx, [
+        "--security-rules-list",
+        ...(getFlag(ctx.parsed, "--workspace-id") ? ["--workspace-id", getFlag(ctx.parsed, "--workspace-id")!] : []),
+      ]);
+    }
+    if (action === "remove") {
+      const ruleId = ctx.parsed.rest[2] || getFlag(ctx.parsed, "--rule-id");
+      if (!ruleId) return usageError("Usage: cowork security rules remove <ruleId> --yes");
+      return runDirectCommandProcess(ctx, ["--security-rules-remove", "--rule-id", ruleId, ...(hasFlag(ctx.parsed, "--yes") ? ["--yes"] : [])]);
+    }
+  }
+  process.stderr.write("Usage: cowork security audit | cowork security rules list|remove\n");
+  return 1;
+}
+
+async function promptSize(ctx: CommandContext): Promise<number> {
+  const text = ctx.parsed.rest.join(" ").trim();
+  if (!text) return usageError("Usage: cowork prompt-size <prompt text>");
+  return runDirectCommandProcess(ctx, ["--prompt-size", "--prompt", text]);
+}
+
+async function promptPreview(ctx: CommandContext): Promise<number> {
+  const text = ctx.parsed.rest.join(" ").trim();
+  if (!text) return usageError("Usage: cowork prompt-preview <prompt text>");
+  return runDirectCommandProcess(ctx, ["--prompt-preview", "--prompt", text]);
+}
+
+function completions(ctx: CommandContext): number {
+  const shell = ctx.parsed.rest[0] || getFlag(ctx.parsed, "--shell") || "zsh";
+  process.stdout.write(renderCompletions(shell));
+  return 0;
+}
+
+async function dashboard(ctx: CommandContext): Promise<number> {
+  const sub = ctx.parsed.rest[0] || "open";
+  if (sub === "status") return runDirectCommandProcess(ctx, ["--dashboard-status"]);
+  if (sub !== "open") return usageError("Usage: cowork dashboard [open|status]");
+  return launchDesktopApp([]);
+}
+
+async function openCommand(ctx: CommandContext): Promise<number> {
+  const target = ctx.parsed.rest[0] || "dashboard";
+  if (target === "dashboard") return launchDesktopApp([]);
+  if (target === "task") {
+    const taskId = ctx.parsed.rest[1];
+    if (!taskId) return usageError("Usage: cowork open task <taskId>");
+    return launchDesktopApp([`cowork://task/${taskId}`]);
+  }
+  return usageError("Usage: cowork open dashboard | cowork open task <taskId>");
+}
+
+async function connectedClient(ctx: CommandContext): Promise<ControlPlaneClient> {
+  if (!ctx.connection.token) {
+    const reason = ctx.discoveryError ? `\nAuto-discovery: ${ctx.discoveryError}` : "";
+    throw new Error(
+      [
+        "No local CoWork GUI/control-plane connection is available yet.",
+        reason,
+        "Fix:",
+        "  1. Make sure CoWork OS is running with Control Plane enabled.",
+        "  2. Or run `cowork login --token <control-plane-token>` once.",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  const client = createClient(ctx);
+  try {
+    await client.connect();
+  } catch (error) {
+    client.close();
+    if (ctx.autoDiscovered) {
+      const source = ctx.discoverySource ? `\nDiscovered from: ${ctx.discoverySource}` : "";
+      throw new Error(
+        [
+          `Found local CoWork GUI settings for ${ctx.connection.url}, but the Control Plane is not reachable.`,
+          source,
+          `Connection error: ${error instanceof Error ? error.message : String(error)}`,
+          "Fix:",
+          "  1. In the CoWork OS desktop app, enable/start Control Plane, or restart the app after this update.",
+          "  2. Then run `cowork doctor`.",
+          "  3. As a fallback, run `cowork login --token <control-plane-token>` once.",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      );
+    }
+    throw error;
+  }
+  return client;
+}
+
+function createClient(ctx: CommandContext): ControlPlaneClient {
+  return new ControlPlaneClient({
+    url: ctx.connection.url,
+    token: ctx.connection.token,
+    deviceName: getFlag(ctx.parsed, "--device-name") || "cowork-cli",
+  });
+}
+
+async function resolveWorkspaceId(client: ControlPlaneClient, ctx: CommandContext, cwd: string): Promise<string> {
+  const explicit = getFlag(ctx.parsed, "--workspace-id");
+  if (explicit) return explicit;
+  const named = getFlag(ctx.parsed, "--workspace");
+  const payload = await client.request(METHODS.WORKSPACE_LIST);
+  const workspaces = extractArrayPayload<WorkspaceLike>(payload, "workspaces");
+  const match = workspaces.find((workspace) => {
+    if (named && workspace.name === named) return true;
+    return workspace.path ? path.resolve(workspace.path) === cwd : false;
+  });
+  if (match?.id) return match.id;
+  if (hasFlag(ctx.parsed, "--no-create-workspace")) {
+    throw new Error(`No workspace found for ${cwd}. Run: cowork workspace create ${cwd}`);
+  }
+  const created = await client.request(METHODS.WORKSPACE_CREATE, {
+    name: named || path.basename(cwd) || "Workspace",
+    path: cwd,
+  });
+  const workspace = (created as Any).workspace as WorkspaceLike | undefined;
+  if (!workspace?.id) throw new Error("Workspace creation succeeded but no workspace id was returned.");
+  process.stdout.write(`Created workspace: ${formatWorkspace(workspace)}\n`);
+  return workspace.id;
+}
+
+async function streamTask(
+  client: ControlPlaneClient,
+  taskId: string,
+  limit: number,
+  json = false,
+): Promise<number> {
+  const history = await client.request(METHODS.TASK_EVENTS, { taskId, limit: sanitizeLimit(limit, 200) });
+  const events = extractArrayPayload<ControlPlaneFrame>(history, "events");
+  for (const event of events) {
+    if (json) {
+      printJson(event);
+      continue;
+    }
+    const line = formatTaskEventFrame({ type: "event", event: "task.event", payload: event });
+    if (line) process.stdout.write(`${line}\n`);
+  }
+  const existingTerminal = events.some((event) =>
+    isTerminalTaskFrame({ type: "event", event: "task.event", payload: event }, taskId),
+  );
+  if (existingTerminal) return 0;
+
+  return new Promise((resolve) => {
+    const cleanup = client.onEvent((frame) => {
+      if (!matchesTask(frame, taskId)) return;
+      if (json) {
+        printJson(frame);
+      } else {
+        const line = formatTaskEventFrame(frame);
+        if (line) process.stdout.write(`${line}\n`);
+      }
+      if (isTerminalTaskFrame(frame, taskId)) {
+        cleanup();
+        resolve(frame.event === "task.failed" ? 1 : 0);
+      }
+    });
+    const onSignal = () => {
+      cleanup();
+      resolve(130);
+    };
+    process.once("SIGINT", onSignal);
+    process.once("SIGTERM", onSignal);
+  });
+}
+
+function printLinesOrJson(ctx: CommandContext, jsonValue: unknown, lines: string[]): void {
+  if (ctx.json) {
+    printJson(jsonValue);
+    return;
+  }
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+function formatConfigWarnings(config: unknown): string[] {
+  const warnings = extractArrayPayload<string>(config, "warnings");
+  if (warnings.length === 0) return ["- config: ready"];
+  return ["- warnings:", ...warnings.map((warning) => `  - ${warning}`)];
+}
+
+function formatProviders(llm: Any): string[] {
+  const providers = Array.isArray(llm.providers) ? llm.providers : [];
+  const lines = [
+    `Current provider: ${llm.currentProvider || "unknown"}`,
+    `Current model: ${llm.currentModel || "default"}`,
+  ];
+  for (const provider of providers) {
+    lines.push(`${provider.type || "unknown"}  ${provider.configured ? "configured" : "missing"}`);
+  }
+  return lines;
+}
+
+function parseLimit(ctx: CommandContext, fallback: number, flag = "--limit"): number {
+  return sanitizeLimit(Number(getFlag(ctx.parsed, flag) || fallback), fallback);
+}
+
+function parseDays(ctx: CommandContext, fallback: number): number {
+  const value = Number(getFlag(ctx.parsed, "--days") || fallback);
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(36500, Math.floor(value)));
+}
+
+function sanitizeLimit(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(2000, Math.floor(value)));
+}
+
+function providerEnvKey(providerType: string): string {
+  const upper = providerType.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+  return process.env[`${upper}_API_KEY`] || "";
+}
+
+const RESERVED_RUN_PROMPTS = new Set([
+  "doctor",
+  "status",
+  "version",
+  "workspace",
+  "workspaces",
+  "tasks",
+  "task",
+  "tail",
+  "approvals",
+  "providers",
+  "provider",
+  "sessions",
+  "session",
+  "logs",
+  "log",
+  "tools",
+  "tool",
+  "mcp",
+  "skills",
+  "skill",
+  "models",
+  "model",
+  "backup",
+  "security",
+  "dashboard",
+  "open",
+]);
+
+function isLikelyCommandPrompt(prompt: string): boolean {
+  const normalized = prompt.trim().toLowerCase();
+  return Boolean(normalized) && RESERVED_RUN_PROMPTS.has(normalized);
+}
+
+function usageError(message: string): number {
+  process.stderr.write(`${message}\n`);
+  return 1;
+}
+
+function launchDesktopApp(extraArgs: string[]): Promise<number> {
+  const runtime = resolveDirectRuntime();
+  if (!runtime.usesElectron) {
+    process.stderr.write("Launching the desktop app requires the Electron runtime from this installation.\n");
+    return Promise.resolve(1);
+  }
+  return new Promise((resolve, reject) => {
+    const child = spawn(runtime.executable, [runtime.appPath, ...extraArgs], {
+      cwd: process.cwd(),
+      detached: true,
+      stdio: "ignore",
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: "" },
+    });
+    child.on("error", reject);
+    child.unref();
+    process.stdout.write("Opened CoWork OS desktop app.\n");
+    resolve(0);
+  });
+}
+
+function renderCompletions(shell: string): string {
+  const commands = [
+    "doctor",
+    "status",
+    "version",
+    "workspace",
+    "run",
+    "tail",
+    "approvals",
+    "approve",
+    "reject",
+    "providers",
+    "sessions",
+    "tasks",
+    "logs",
+    "tools",
+    "mcp",
+    "skills",
+    "models",
+    "backup",
+    "security",
+    "prompt-size",
+    "prompt-preview",
+    "dashboard",
+    "open",
+    "completions",
+  ];
+  if (shell === "bash") {
+    return [
+      "_cowork_complete() {",
+      `  COMPREPLY=( $(compgen -W "${commands.join(" ")}" -- "\${COMP_WORDS[1]}") )`,
+      "}",
+      "complete -F _cowork_complete cowork",
+      "",
+    ].join("\n");
+  }
+  if (shell === "fish") {
+    return commands.map((command) => `complete -c cowork -f -a ${command}`).join("\n") + "\n";
+  }
+  return [
+    "#compdef cowork",
+    `_arguments '1:command:(${commands.join(" ")})' '*::arg:_files'`,
+    "",
+  ].join("\n");
+}
+
+function getFlag(parsed: ParsedArgs, flag: string): string | undefined {
+  const value = parsed.flags.get(flag);
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function hasFlag(parsed: ParsedArgs, flag: string): boolean {
+  return parsed.flags.has(flag);
+}
+
+function handleError(error: unknown): number {
+  if (error instanceof ControlPlaneRequestError) {
+    const code = error.code ? ` [${error.code}]` : "";
+    process.stderr.write(`Control plane error${code}: ${error.message}\n`);
+    return 1;
+  }
+  if (error instanceof Error) {
+    process.stderr.write(`${error.message}\n`);
+    return 1;
+  }
+  process.stderr.write(`${String(error)}\n`);
+  return 1;
+}
+
+function usage(): void {
+  process.stdout.write(
+    [
+      "CoWork OS CLI",
+      "",
+      "Local-first commands do not require the desktop Control Plane. Use --remote only when you intentionally want the WebSocket control-plane path.",
+      "",
+      "Usage:",
+      "  cowork",
+      "  cowork version",
+      "  cowork status",
+      "  cowork doctor",
+      "  cowork login --token <token> [--url ws://127.0.0.1:18789]",
+      "  cowork daemon start [--background]",
+      "  cowork workspace list",
+      "  cowork workspace create [path]",
+      '  cowork run "task prompt" [--cwd <path>] [--workspace-id <id>] [--shell] [--detach] [--force]',
+      '  cowork run "task prompt" --remote [--url <ws-url>] [--token <token>]',
+      "  cowork tail <taskId>",
+      "  cowork tasks list [--active] [--cli]",
+      "  cowork tasks cancel <taskId>",
+      "  cowork tasks attach <taskId>",
+      "  cowork tasks stale",
+      "  cowork tasks cleanup --interrupted-cli --yes",
+      "  cowork approvals",
+      "  cowork approve <approvalId>",
+      "  cowork reject <approvalId>",
+      "  cowork providers list",
+      "  cowork providers configure <provider> [--api-key <key>] [--model <model>]",
+      "  cowork providers fallback list|add|remove",
+      "  cowork sessions list|show|export|rename|delete|prune",
+      "  cowork logs latest|tail|grep",
+      "  cowork tools list|info|enable|disable",
+      "  cowork mcp list|add|remove|enable|disable|test",
+      "  cowork skills list|info|audit",
+      "  cowork models list",
+      "  cowork backup create|restore",
+      "  cowork security audit",
+      "  cowork security rules list|remove",
+      "  cowork prompt-size <prompt text>",
+      "  cowork prompt-preview <prompt text>",
+      "  cowork completions zsh|bash|fish",
+      "  cowork dashboard [open|status]",
+      "  cowork open dashboard | cowork open task <taskId>",
+      "",
+      "Global flags:",
+      "  --profile <name>       Use a saved CLI profile",
+      "  --url <ws-url>          Override control-plane URL for --remote commands",
+      "  --token <token>         Override control-plane token for --remote commands",
+      "  --json                  Print JSON output",
+      "",
+      "Remote env:",
+      "  COWORK_CONTROL_PLANE_URL",
+      "  COWORK_CONTROL_PLANE_TOKEN",
+    ].join("\n"),
+  );
+}
+
+if (typeof require !== "undefined" && require.main === module) {
+  main().then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/src/cli/terminal-ui.ts
+++ b/src/cli/terminal-ui.ts
@@ -1,0 +1,148 @@
+import os from "node:os";
+
+const ANSI = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  italic: "\x1b[3m",
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+  gray: "\x1b[90m",
+  white: "\x1b[97m",
+  bgInput: "\x1b[48;5;236m",
+} as const;
+
+const BRAND = "\x1b[38;5;44m";
+const ACCENT = "\x1b[38;5;50m";
+const WARN = "\x1b[38;5;214m";
+
+export interface WelcomeScreenOptions {
+  version?: string;
+  cwd?: string;
+  provider?: string;
+  model?: string;
+  width?: number;
+  color?: boolean;
+}
+
+export function renderWelcomeScreen(options: WelcomeScreenOptions = {}): string {
+  const width = Math.max(76, Math.min(options.width ?? process.stdout.columns ?? 120, 160));
+  const color = options.color ?? shouldColor();
+  const version = options.version || "dev";
+  const cwd = formatCwd(options.cwd || process.cwd());
+  const provider = options.provider || "local runtime";
+  const model = options.model || "configure a provider";
+  const boxWidth = width - 4;
+  const leftWidth = Math.max(30, Math.min(44, Math.floor(boxWidth * 0.32)));
+  const rightWidth = boxWidth - leftWidth - 1;
+  const rightLines = [
+    styled("Getting started", WARN, color),
+    "Type a task and press Enter to run it",
+    styled("/doctor", ACCENT, color) + " checks runtime and providers",
+    styled("/providers list", ACCENT, color) + " shows model setup",
+    styled("/workspace list", ACCENT, color) + " shows local workspaces",
+    styled("/exit", ACCENT, color) + " leaves CoWork OS",
+  ];
+  const leftLines = [
+    center(styled("Welcome back", ANSI.bold + ANSI.white, color), leftWidth),
+    "",
+    center(styled("╔═╗ ╔═╗ ╦ ╦ ╔═╗ ╦═╗ ╦╔═", BRAND, color), leftWidth),
+    center(styled("║   ║ ║ ║║║ ║ ║ ╠╦╝ ╠╩╗", BRAND, color), leftWidth),
+    center(styled("╚═╝ ╚═╝ ╚╩╝ ╚═╝ ╩╚═ ╩ ╩", BRAND, color), leftWidth),
+    center(styled("╔═╗ ╔═╗", BRAND, color), leftWidth),
+    center(styled("║ ║ ╚═╗", BRAND, color), leftWidth),
+    center(styled("╚═╝ ╚═╝", BRAND, color), leftWidth),
+    "",
+    center(styled(`${model} · ${provider}`, ANSI.gray, color), leftWidth),
+    center(styled(cwd, ANSI.gray, color), leftWidth),
+  ];
+
+  const bodyHeight = Math.max(leftLines.length, rightLines.length, 10);
+  const title = ` CoWork OS ${version} `;
+  const top =
+    styled("╭", BRAND, color) +
+    styled("─".repeat(2), BRAND, color) +
+    styled(title, ANSI.bold + BRAND, color) +
+    styled("─".repeat(Math.max(0, boxWidth - visibleLength(title) - 2)), BRAND, color) +
+    styled("╮", BRAND, color);
+  const bottom = styled("╰" + "─".repeat(boxWidth) + "╯", BRAND, color);
+  const rows = [top];
+  for (let i = 0; i < bodyHeight; i++) {
+    const left = padVisible(leftLines[i] || "", leftWidth);
+    const right = padVisible(rightLines[i] || "", rightWidth - 2);
+    rows.push(
+      styled("│", BRAND, color) +
+        left +
+        styled("│", BRAND, color) +
+        " " +
+        right +
+        " " +
+        styled("│", BRAND, color),
+    );
+  }
+  rows.push(bottom);
+  rows.push("");
+  rows.push(styled("─".repeat(width), ANSI.gray, color));
+  rows.push(renderShortcutFooter(width, color));
+  return rows.join("\n");
+}
+
+export function renderPromptLine(width = process.stdout.columns ?? 100, color = shouldColor()): string {
+  const marker = styled("❯", ANSI.bold + ACCENT, color);
+  const input = `${marker} `;
+  return styled(padVisible(input, width), ANSI.bgInput, color);
+}
+
+export function promptMarker(color = shouldColor()): string {
+  return styled("❯ ", ANSI.bold + ACCENT, color);
+}
+
+function renderShortcutFooter(width: number, color: boolean): string {
+  const left = " ? for shortcuts  ·  / for commands  ·  @ for files ";
+  const right = " ● ready · /effort ";
+  const gap = Math.max(1, width - visibleLength(left) - visibleLength(right));
+  return styled(left, ANSI.gray, color) + " ".repeat(gap) + styled(right, ANSI.gray, color);
+}
+
+function formatCwd(cwd: string): string {
+  const home = os.homedir();
+  const compact = cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd;
+  return compact.length > 42 ? `…${compact.slice(-41)}` : compact;
+}
+
+function center(input: string, width: number): string {
+  const len = visibleLength(input);
+  if (len >= width) return truncateVisible(input, width);
+  const left = Math.floor((width - len) / 2);
+  return `${" ".repeat(left)}${input}${" ".repeat(width - len - left)}`;
+}
+
+function padVisible(input: string, width: number): string {
+  const truncated = truncateVisible(input, width);
+  return `${truncated}${" ".repeat(Math.max(0, width - visibleLength(truncated)))}`;
+}
+
+function truncateVisible(input: string, width: number): string {
+  if (visibleLength(input) <= width) return input;
+  const plain = stripAnsi(input);
+  if (plain.length <= width) return input;
+  return `${plain.slice(0, Math.max(0, width - 1))}…`;
+}
+
+function visibleLength(input: string): number {
+  return stripAnsi(input).length;
+}
+
+function stripAnsi(input: string): string {
+  return input.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function styled(input: string, code: string, color: boolean): string {
+  return color ? `${code}${input}${ANSI.reset}` : input;
+}
+
+function shouldColor(): boolean {
+  if (process.env.NO_COLOR) return false;
+  if (process.env.FORCE_COLOR) return true;
+  return Boolean(process.stdout.isTTY);
+}

--- a/src/electron/agent/daemon.ts
+++ b/src/electron/agent/daemon.ts
@@ -48,6 +48,7 @@ import {
   Workspace,
   WorkspacePermissions,
   AgentConfig,
+  CliTaskOwnership,
   AgentType,
   ActivityActorType,
   ActivityType,
@@ -161,6 +162,10 @@ import { buildEntropySweepPrompt, collectBlastRadiusPaths } from "./post-task-en
 import { OrchestrationGraphEngine, type OrchestrationGraphNodeInput } from "./orchestration/OrchestrationGraphEngine";
 import { OrchestrationGraphRepository } from "./orchestration/OrchestrationGraphRepository";
 import { MCPClientManager } from "../mcp/client/MCPClientManager";
+
+export interface AgentDaemonOptions {
+  startupRecovery?: boolean;
+}
 
 const log = createLogger("AgentDaemon");
 
@@ -440,7 +445,10 @@ export class AgentDaemon extends EventEmitter {
   private static readonly TRANSIENT_RETRY_ERROR_REGEX =
     /^Transient provider error\.\s*Retry\s+\d+\/\d+\s+in\s+\d+s\./i;
 
-  constructor(private dbManager: DatabaseManager) {
+  constructor(
+    private dbManager: DatabaseManager,
+    private options: AgentDaemonOptions = {},
+  ) {
     super();
     const db = dbManager.getDatabase();
     this.taskRepo = new TaskRepository(db);
@@ -538,6 +546,32 @@ export class AgentDaemon extends EventEmitter {
       typeof message === "string" &&
       AgentDaemon.TRANSIENT_RETRY_ERROR_REGEX.test(message.trim())
     );
+  }
+
+  private isStaleAttachedCliTask(task: Task): boolean {
+    if (isTerminalTaskStatus(task.status)) return false;
+    const cli = this.getCliTaskOwnership(task);
+    if (!cli || cli.mode !== "attached" || cli.endedAt) return false;
+    if (this.isPidAlive(cli.pid)) return false;
+    const lastSeenAt = cli.lastSeenAt || cli.startedAt || task.updatedAt || task.createdAt;
+    return Date.now() - lastSeenAt > 30_000;
+  }
+
+  private getCliTaskOwnership(task: Task): CliTaskOwnership | undefined {
+    const cli = task.agentConfig?.cli;
+    if (!cli || cli.owner !== "cowork-run" || typeof cli.runId !== "string") return undefined;
+    return cli;
+  }
+
+  private isPidAlive(pid: unknown): boolean {
+    if (typeof pid !== "number" || !Number.isFinite(pid) || pid <= 0) return false;
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      return code === "EPERM";
+    }
   }
 
   setTeamOrchestrator(orchestrator: AgentTeamOrchestrator | null): void {
@@ -951,6 +985,11 @@ export class AgentDaemon extends EventEmitter {
   async initialize(): Promise<void> {
     this.orchestrationGraphEngine.start();
 
+    if (this.options.startupRecovery === false) {
+      await this.queueManager.initialize([], []);
+      return;
+    }
+
     // Hard-switch migration: eagerly normalize active/incomplete task events to timeline v2.
     const activeAndIncompleteTasks = this.taskRepo.findByStatus([
       "queued",
@@ -981,6 +1020,20 @@ export class AgentDaemon extends EventEmitter {
       for (const task of inconsistentPersistedTasks) {
         this.taskRepo.update(task.id, {
           status: deriveCanonicalTaskStatus(task),
+        });
+      }
+    }
+
+    const staleAttachedCliTasks = activeAndIncompleteTasks.filter((task) =>
+      this.isStaleAttachedCliTask(task),
+    );
+    if (staleAttachedCliTasks.length > 0) {
+      console.warn(
+        `[AgentDaemon] Cancelling ${staleAttachedCliTasks.length} stale attached CLI task(s) whose owner process exited`,
+      );
+      for (const task of staleAttachedCliTasks) {
+        this.cancelTaskRecord(task.id, "CLI task owner exited before completion", {
+          completedAt: Date.now(),
         });
       }
     }

--- a/src/electron/control-plane/handlers.ts
+++ b/src/electron/control-plane/handlers.ts
@@ -7,6 +7,7 @@
 import { app, ipcMain, BrowserWindow } from "electron";
 import { randomUUID } from "crypto";
 import * as fs from "fs/promises";
+import * as fsSync from "fs";
 import os from "os";
 import path from "path";
 import { z } from "zod";
@@ -141,6 +142,40 @@ function getEverydayAgentService(deps: ControlPlaneMethodDeps): EverydayAgentSer
     everydayAgentService = new EverydayAgentService(deps.dbManager.getDatabase());
   }
   return everydayAgentService;
+}
+
+function isLoopbackHost(host: string): boolean {
+  const value = host.trim().toLowerCase();
+  return value === "127.0.0.1" || value === "localhost" || value === "::1" || value === "[::1]";
+}
+
+function writeLocalControlPlaneConnectionFile(settings: {
+  host: string;
+  port: number;
+  token: string;
+}): void {
+  if (!settings.token || !isLoopbackHost(settings.host)) return;
+  try {
+    const filePath = path.join(getUserDataDir(), "control-plane-local.json");
+    const payload = {
+      version: 1,
+      url: `ws://${settings.host}:${settings.port}`,
+      token: settings.token,
+      pid: process.pid,
+      updatedAt: Date.now(),
+    };
+    fsSync.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    try {
+      fsSync.chmodSync(filePath, 0o600);
+    } catch {
+      // Best-effort on platforms without POSIX permissions.
+    }
+  } catch (error) {
+    console.warn("[ControlPlane] Failed to write local CLI connection file:", error);
+  }
 }
 
 function toNodePlatform(platform?: string): "ios" | "android" | "macos" | "linux" | "windows" {
@@ -2265,6 +2300,11 @@ export async function startControlPlaneFromSettings(
       }
       const addr = controlPlaneServer.getAddress();
       const tailscale = getExposureStatus();
+      writeLocalControlPlaneConnectionFile({
+        host: settings.host,
+        port: settings.port,
+        token: settings.token,
+      });
       return {
         ok: true,
         address: addr || undefined,
@@ -2375,6 +2415,13 @@ export async function startControlPlaneFromSettings(
     }
 
     const address = controlPlaneServer?.getAddress();
+    if (address && settings.enabled) {
+      writeLocalControlPlaneConnectionFile({
+        host: settings.host,
+        port: settings.port,
+        token: settings.token,
+      });
+    }
     return {
       ok: true,
       address: address || undefined,

--- a/src/electron/database/repositories.ts
+++ b/src/electron/database/repositories.ts
@@ -2677,6 +2677,21 @@ export class ApprovalRepository {
     return rows.map((row) => this.mapRowToApproval(row));
   }
 
+  findPending(limit = 100): ApprovalRequest[] {
+    const safeLimit =
+      typeof limit === "number" && Number.isFinite(limit) && limit > 0
+        ? Math.min(1000, Math.floor(limit))
+        : 100;
+    const stmt = this.db.prepare(`
+      SELECT * FROM approvals
+      WHERE status = 'pending'
+      ORDER BY requested_at ASC
+      LIMIT ?
+    `);
+    const rows = stmt.all(safeLimit) as Any[];
+    return rows.map((row) => this.mapRowToApproval(row));
+  }
+
   private mapRowToApproval(row: Any): ApprovalRequest {
     return {
       id: row.id,

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1087,6 +1087,72 @@ registerTaskDeeplinkProtocol();
 applyApplicationIdentity();
 applyStableUserDataPath();
 
+const CLI_DIRECT_RUN_FLAG = "--cowork-cli-direct-run";
+const CLI_APPROVAL_RESPONSE_FLAG = "--cowork-cli-approval-response";
+
+function isCliDirectRunMode(): boolean {
+  return process.argv.includes(CLI_DIRECT_RUN_FLAG);
+}
+
+function getCliDirectRunArgv(): string[] {
+  const index = process.argv.indexOf(CLI_DIRECT_RUN_FLAG);
+  return index >= 0 ? process.argv.slice(index + 1) : [];
+}
+
+function getArgValueFrom(argv: string[], flag: string): string | undefined {
+  const index = argv.indexOf(flag);
+  if (index < 0) return undefined;
+  const value = argv[index + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function getCliApprovalResponseArgv(argv: string[]): { approvalId: string; approved: boolean } | null {
+  if (!argv.includes(CLI_APPROVAL_RESPONSE_FLAG)) return null;
+  const approvalId = getArgValueFrom(argv, "--approval-id") || "";
+  if (!approvalId) return null;
+  return {
+    approvalId,
+    approved: argv.includes("--approved"),
+  };
+}
+
+async function handleCliApprovalResponse(request: { approvalId: string; approved: boolean }): Promise<void> {
+  if (!agentDaemon) {
+    logger.warn("CLI approval response received before agent daemon was ready");
+    return;
+  }
+  const result = await agentDaemon.respondToApproval(request.approvalId, request.approved);
+  logger.info(
+    `CLI approval response ${request.approved ? "approved" : "rejected"} ${request.approvalId}: ${result}`,
+  );
+}
+
+async function runCliDirectMode(): Promise<void> {
+  try {
+    process.env.COWORK_HEADLESS = "1";
+    await app.whenReady();
+    const directRunPath = path.join(app.getAppPath(), "dist", "cli", "cli", "direct-run.js");
+    if (!fsSync.existsSync(directRunPath)) {
+      throw new Error(
+        `CoWork CLI runtime is missing at ${directRunPath}. Run npm run build:cli or reinstall CoWork OS.`,
+      );
+    }
+    // oxlint-disable-next-line typescript-eslint(no-require-imports)
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const directRun = require(directRunPath) as { main: (argv: string[]) => Promise<number> };
+    const code = await directRun.main(getCliDirectRunArgv());
+    app.quit();
+    process.exit(code);
+  } catch (error) {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    app.quit();
+    process.exit(1);
+  }
+}
+
+if (isCliDirectRunMode()) {
+  void runCliDirectMode();
+} else {
 // Ensure only one CoWork OS instance runs at a time.
 // Without this, a second instance can mark in-flight tasks as "orphaned" (failed) and contend on the DB.
 const gotTheLock = app.requestSingleInstanceLock();
@@ -1142,6 +1208,11 @@ if (!gotTheLock) {
 
   app.on("second-instance", (_event, argv) => {
     if (HEADLESS) return;
+    const approvalResponse = getCliApprovalResponseArgv(argv);
+    if (approvalResponse) {
+      void handleCliApprovalResponse(approvalResponse);
+      return;
+    }
     const taskId = extractTaskDeeplinkArg(argv);
     if (taskId) {
       openTaskDeeplink(taskId);
@@ -1154,6 +1225,12 @@ if (!gotTheLock) {
     // If the window was closed (but app kept running), recreate it.
     createWindow();
   });
+
+  const startupApprovalResponse = getCliApprovalResponseArgv(process.argv);
+  if (startupApprovalResponse) {
+    logger.warn("CLI approval response requested, but no existing CoWork OS instance accepted it");
+    app.exit(1);
+  }
 
   function createWindow() {
     const isMac = process.platform === "darwin";
@@ -4395,3 +4472,4 @@ if (!gotTheLock) {
     return validEntries;
   });
 } // single-instance guard
+} // CLI direct-run guard

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2128,6 +2128,8 @@ export interface AgentConfig {
   sideChatTurnContext?: string;
   /** Internal scheduled-job identifier used to prevent duplicate cron task creation after restarts. */
   scheduledJobId?: string;
+  /** Internal ownership metadata for tasks launched from the standalone CLI. */
+  cli?: CliTaskOwnership;
   /** User-selected integration mentions for soft tool-routing guidance. */
   integrationMentions?: IntegrationMentionSelection[];
   /** Optional origin channel that created the task (used for channel-aware gating) */
@@ -2343,6 +2345,19 @@ export interface AgentConfig {
    * Defined after `ResearchWorkflowConfig` in this file.
    */
   researchWorkflow?: ResearchWorkflowConfig;
+}
+
+export interface CliTaskOwnership {
+  owner: "cowork-run";
+  runId: string;
+  pid: number;
+  startedAt: number;
+  cwd: string;
+  mode: "attached" | "detached";
+  interruptPolicy: "cancel" | "detach";
+  lastSeenAt?: number;
+  endedAt?: number;
+  exitCode?: number;
 }
 
 /**

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "dist/cli",
+    "rootDir": "src",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@shared/*": ["src/shared/*"]
+    }
+  },
+  "include": ["src/cli/**/*", "src/shared/global-any.d.ts"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- add the new cowork npm bin and TypeScript CLI build target
- implement interactive, remote, and local direct-run CLI paths
- add CLI task ownership, stale attached-task cleanup, pending approval listing, and local Control Plane discovery support
- document the CLI surface in docs/cli.md

## Validation
- npm run build:cli
- npx vitest run src/cli/__tests__/main.test.ts src/cli/__tests__/terminal-ui.test.ts src/cli/__tests__/local-control-plane-discovery.test.ts src/cli/__tests__/config-store.test.ts src/cli/__tests__/format.test.ts
- npm run build:electron