### PR TITLE
security: harden webhook and MCP auth

### DIFF
--- a/src/electron/gateway/__tests__/webhook-auth.test.ts
+++ b/src/electron/gateway/__tests__/webhook-auth.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { BlueBubblesClient } from "../channels/bluebubbles-client";
+import { FeishuAdapter } from "../channels/feishu";
+import { GoogleChatAdapter } from "../channels/google-chat";
+
+describe("gateway webhook authentication", () => {
+  it("rejects Feishu payloads missing a configured verification token", () => {
+    const adapter = new FeishuAdapter({
+      enabled: true,
+      appId: "app-id",
+      appSecret: "app-secret",
+      verificationToken: "expected-token",
+    });
+
+    expect(() =>
+      (adapter as Any).parseAndVerifyPayload(
+        { headers: {} },
+        JSON.stringify({ type: "event_callback", event: {} }),
+      ),
+    ).toThrow("Feishu verification token is required");
+  });
+
+  it("rejects Feishu payloads missing configured signature headers", () => {
+    const adapter = new FeishuAdapter({
+      enabled: true,
+      appId: "app-id",
+      appSecret: "app-secret",
+      encryptKey: "encrypt-key",
+    });
+
+    expect(() =>
+      (adapter as Any).parseAndVerifyPayload(
+        { headers: {} },
+        JSON.stringify({ type: "event_callback", event: {} }),
+      ),
+    ).toThrow("Feishu signature headers are required");
+  });
+
+  it("requires a BlueBubbles webhook secret", () => {
+    const client = new BlueBubblesClient({
+      serverUrl: "http://127.0.0.1:1234",
+      password: "server-password",
+      webhookSecret: "webhook-secret",
+    });
+
+    expect((client as Any).verifyWebhookRequest({ headers: {} })).toBe(false);
+    expect(
+      (client as Any).verifyWebhookRequest({
+        headers: { "x-cowork-webhook-secret": "webhook-secret" },
+      }),
+    ).toBe(true);
+  });
+
+  it("requires a Google Chat webhook secret", () => {
+    const adapter = new GoogleChatAdapter({
+      enabled: true,
+      serviceAccountKey: {
+        client_email: "bot@example.iam.gserviceaccount.com",
+        private_key: "-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----\\n",
+        project_id: "project",
+      },
+      webhookSecret: "webhook-secret",
+    });
+
+    expect((adapter as Any).verifyWebhookRequest({ headers: {} }, { type: "MESSAGE" })).toBe(false);
+    expect(
+      (adapter as Any).verifyWebhookRequest(
+        { headers: { authorization: "Bearer webhook-secret" } },
+        { type: "MESSAGE" },
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/electron/gateway/channels/bluebubbles-client.ts
+++ b/src/electron/gateway/channels/bluebubbles-client.ts
@@ -23,6 +23,7 @@
 import { EventEmitter } from "events";
 import * as http from "http";
 import * as https from "https";
+import { readWebhookSecret, timingSafeEqualString } from "../../utils/webhook-auth";
 
 /**
  * BlueBubbles message
@@ -128,6 +129,8 @@ export interface BlueBubblesClientOptions {
   webhookPort?: number;
   /** Webhook path */
   webhookPath?: string;
+  /** Shared secret required for webhook requests */
+  webhookSecret?: string;
   /** Poll interval if webhooks not available (ms) */
   pollInterval?: number;
   /** Enable verbose logging */
@@ -276,6 +279,12 @@ export class BlueBubblesClient extends EventEmitter {
       return;
     }
 
+    if (!this.verifyWebhookRequest(req)) {
+      res.writeHead(401);
+      res.end();
+      return;
+    }
+
     let body = "";
     req.on("data", (chunk) => {
       body += chunk.toString();
@@ -293,6 +302,15 @@ export class BlueBubblesClient extends EventEmitter {
         res.end();
       }
     });
+  }
+
+  private verifyWebhookRequest(req: http.IncomingMessage): boolean {
+    const secret = this.options.webhookSecret?.trim();
+    if (!secret) {
+      return false;
+    }
+    const provided = readWebhookSecret(req);
+    return Boolean(provided && timingSafeEqualString(provided, secret));
   }
 
   /**

--- a/src/electron/gateway/channels/bluebubbles.ts
+++ b/src/electron/gateway/channels/bluebubbles.ts
@@ -98,6 +98,7 @@ export class BlueBubblesAdapter implements ChannelAdapter {
         password: this.config.password,
         webhookPort: this.config.enableWebhook ? this.config.webhookPort : undefined,
         webhookPath: this.config.webhookPath,
+        webhookSecret: this.config.webhookSecret || this.config.password,
         pollInterval: this.config.pollInterval,
         verbose: process.env.NODE_ENV === "development",
       });

--- a/src/electron/gateway/channels/feishu.ts
+++ b/src/electron/gateway/channels/feishu.ts
@@ -12,6 +12,7 @@ import {
   StatusHandler,
 } from "./types";
 import { createLogger } from "../../utils/logger";
+import { timingSafeEqualString } from "../../utils/webhook-auth";
 
 const logger = createLogger("FeishuAdapter");
 
@@ -321,11 +322,12 @@ export class FeishuAdapter implements ChannelAdapter {
       const timestamp = String(req.headers["x-lark-request-timestamp"] || "");
       const nonce = String(req.headers["x-lark-request-nonce"] || "");
       const signature = String(req.headers["x-lark-signature"] || "");
-      if (timestamp && nonce && signature) {
-        const expected = computeFeishuSignature(timestamp, nonce, this.config.encryptKey, rawBody);
-        if (expected !== signature) {
-          throw new Error("Feishu signature validation failed");
-        }
+      if (!timestamp || !nonce || !signature) {
+        throw new Error("Feishu signature headers are required");
+      }
+      const expected = computeFeishuSignature(timestamp, nonce, this.config.encryptKey, rawBody);
+      if (!timingSafeEqualString(expected, signature)) {
+        throw new Error("Feishu signature validation failed");
       }
     }
 
@@ -347,12 +349,13 @@ export class FeishuAdapter implements ChannelAdapter {
             typeof (parsed.header as Record<string, unknown>).token === "string"
           ? ((parsed.header as Record<string, unknown>).token as string)
           : undefined;
-    if (
-      this.config.verificationToken &&
-      token &&
-      token !== this.config.verificationToken
-    ) {
-      throw new Error("Feishu verification token mismatch");
+    if (this.config.verificationToken) {
+      if (!token) {
+        throw new Error("Feishu verification token is required");
+      }
+      if (!timingSafeEqualString(token, this.config.verificationToken)) {
+        throw new Error("Feishu verification token mismatch");
+      }
     }
 
     return parsed;

--- a/src/electron/gateway/channels/google-chat.ts
+++ b/src/electron/gateway/channels/google-chat.ts
@@ -14,6 +14,7 @@ import * as https from "https";
 import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
+import { readWebhookSecret, timingSafeEqualString } from "../../utils/webhook-auth";
 import {
   ChannelAdapter,
   ChannelStatus,
@@ -401,6 +402,11 @@ export class GoogleChatAdapter implements ChannelAdapter {
   ): Promise<void> {
     try {
       const event: GoogleChatEvent = JSON.parse(body);
+      if (!this.verifyWebhookRequest(req, event)) {
+        res.writeHead(401);
+        res.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
 
       // Handle different event types
       switch (event.type) {
@@ -444,6 +450,15 @@ export class GoogleChatAdapter implements ChannelAdapter {
       res.writeHead(400);
       res.end(JSON.stringify({ error: "Bad Request" }));
     }
+  }
+
+  private verifyWebhookRequest(req: http.IncomingMessage, event: GoogleChatEvent): boolean {
+    const secret = this.config.webhookSecret?.trim();
+    if (!secret) {
+      return false;
+    }
+    const provided = readWebhookSecret(req) || (typeof event.token === "string" ? event.token.trim() : "");
+    return Boolean(provided && timingSafeEqualString(provided, secret));
   }
 
   /**

--- a/src/electron/gateway/channels/types.ts
+++ b/src/electron/gateway/channels/types.ts
@@ -453,6 +453,8 @@ export interface BlueBubblesConfig extends ChannelConfig {
   webhookPort?: number;
   /** Webhook path (default: /bluebubbles/webhook) */
   webhookPath?: string;
+  /** Shared secret required on incoming webhook requests */
+  webhookSecret?: string;
   /** Poll interval in ms if webhooks not available (default: 5000) */
   pollInterval?: number;
   /** Response prefix for bot messages */
@@ -612,6 +614,8 @@ export interface GoogleChatConfig extends ChannelConfig {
   webhookPort?: number;
   /** Webhook path (default: /googlechat/webhook) */
   webhookPath?: string;
+  /** Shared secret required on incoming webhook requests */
+  webhookSecret?: string;
   /** Bot display name */
   displayName?: string;
   /** Response prefix for bot replies */

--- a/src/electron/gateway/index.ts
+++ b/src/electron/gateway/index.ts
@@ -30,6 +30,7 @@ import {
   TwitchConfig as _TwitchConfig,
   LineConfig as _LineConfig,
   BlueBubblesConfig as _BlueBubblesConfig,
+  GoogleChatConfig as _GoogleChatConfig,
   EmailConfig as _EmailConfig,
   GatewayEventHandler,
 } from "./channels/types";
@@ -46,6 +47,7 @@ import { MatrixAdapter, createMatrixAdapter } from "./channels/matrix";
 import { TwitchAdapter, createTwitchAdapter } from "./channels/twitch";
 import { LineAdapter, createLineAdapter } from "./channels/line";
 import { BlueBubblesAdapter, createBlueBubblesAdapter } from "./channels/bluebubbles";
+import { createGoogleChatAdapter } from "./channels/google-chat";
 import { EmailAdapter, createEmailAdapter } from "./channels/email";
 import { XAdapter, createXAdapter, type XAdapterConfig } from "./channels/x";
 import {
@@ -632,15 +634,8 @@ export class ChannelGateway {
 
     // Auto-connect if configured
     if (this.config.autoConnect) {
-      const results = await Promise.allSettled([
-        this.connectMicrosoftEmailGraphChannels(),
-        this.router.connectAll(),
-      ]);
-      for (const result of results) {
-        if (result.status === "rejected") {
-          logger.warn("Enabled channel connect group failed:", result.reason);
-        }
-      }
+      await this.connectMicrosoftEmailGraphChannels();
+      await this.router.connectAll();
     }
 
     this.startPendingCleanup();
@@ -659,15 +654,8 @@ export class ChannelGateway {
     if (!this.initialized) {
       await this.initialize();
     }
-    const results = await Promise.allSettled([
-      this.connectMicrosoftEmailGraphChannels(options),
-      this.router.connectAll(options),
-    ]);
-    for (const result of results) {
-      if (result.status === "rejected") {
-        logger.warn("Enabled channel connect group failed:", result.reason);
-      }
-    }
+    await this.connectMicrosoftEmailGraphChannels(options);
+    await this.router.connectAll(options);
   }
 
   /**
@@ -1246,6 +1234,7 @@ export class ChannelGateway {
       ambientMode?: boolean;
       silentUnauthorized?: boolean;
       captureSelfMessages?: boolean;
+      webhookSecret?: string;
     },
   ): Promise<Channel> {
     // Check if BlueBubbles channel already exists
@@ -1263,6 +1252,7 @@ export class ChannelGateway {
         serverUrl,
         password,
         webhookPort,
+        webhookSecret: opts?.webhookSecret || password,
         allowedContacts,
         ...(opts?.ambientMode ? { ambientMode: true } : {}),
         ...(opts?.silentUnauthorized ? { silentUnauthorized: true } : {}),
@@ -1271,6 +1261,47 @@ export class ChannelGateway {
       securityConfig: {
         mode: securityMode,
         allowedUsers: allowedContacts || [],
+        pairingCodeTTL: 300,
+        maxPairingAttempts: 5,
+        rateLimitPerMinute: 30,
+      },
+      status: "disconnected",
+    });
+
+    return channel;
+  }
+
+  /**
+   * Add a new Google Chat channel
+   */
+  async addGoogleChatChannel(
+    name: string,
+    serviceAccountKeyPath: string,
+    projectId?: string,
+    webhookPort: number = 3979,
+    webhookPath: string = "/googlechat/webhook",
+    webhookSecret?: string,
+    securityMode: "open" | "allowlist" | "pairing" = "pairing",
+  ): Promise<Channel> {
+    const existing = this.channelRepo.findByType("googlechat");
+    if (existing) {
+      throw new Error("Google Chat channel already configured. Update or remove it first.");
+    }
+
+    const channel = this.channelRepo.create({
+      type: "googlechat",
+      name,
+      enabled: false,
+      config: {
+        serviceAccountKeyPath,
+        projectId,
+        webhookPort,
+        webhookPath,
+        webhookSecret,
+      },
+      securityConfig: {
+        mode: securityMode,
+        allowedUsers: [],
         pairingCodeTTL: 300,
         maxPairingAttempts: 5,
         rateLimitPerMinute: 30,
@@ -2009,19 +2040,17 @@ export class ChannelGateway {
       .findEnabled()
       .filter((channel) => this.isMicrosoftEmailOAuthChannel(channel));
 
-    await Promise.all(
-      channels.map(async (channel) => {
-        try {
-          await withTimeout(
-            this.connectMicrosoftEmailGraphChannel(channel, options),
-            options.timeoutMs,
-            `Timed out connecting Microsoft Outlook email channel ${channel.id}`,
-          );
-        } catch (error) {
-          console.error("Failed to connect Microsoft Outlook email channel:", error);
-        }
-      }),
-    );
+    for (const channel of channels) {
+      try {
+        await withTimeout(
+          this.connectMicrosoftEmailGraphChannel(channel, options),
+          options.timeoutMs,
+          `Timed out connecting Microsoft Outlook email channel ${channel.id}`,
+        );
+      } catch (error) {
+        console.error("Failed to connect Microsoft Outlook email channel:", error);
+      }
+    }
   }
 
   private async connectMicrosoftEmailGraphChannel(
@@ -2335,10 +2364,29 @@ export class ChannelGateway {
           password: channel.config.password as string,
           webhookPort: channel.config.webhookPort as number | undefined,
           webhookPath: channel.config.webhookPath as string | undefined,
+          webhookSecret: (channel.config.webhookSecret as string | undefined) || (channel.config.password as string),
           pollInterval: channel.config.pollInterval as number | undefined,
           allowedContacts: channel.config.allowedContacts as string[] | undefined,
           responsePrefix: channel.config.responsePrefix as string | undefined,
         });
+
+      case "googlechat":
+        return createGoogleChatAdapter({
+          enabled: channel.enabled,
+          serviceAccountKeyPath: channel.config.serviceAccountKeyPath as string | undefined,
+          serviceAccountKey: channel.config.serviceAccountKey as
+            | _GoogleChatConfig["serviceAccountKey"]
+            | undefined,
+          projectId: channel.config.projectId as string | undefined,
+          webhookPort: channel.config.webhookPort as number | undefined,
+          webhookPath: channel.config.webhookPath as string | undefined,
+          webhookSecret: channel.config.webhookSecret as string | undefined,
+          responsePrefix: channel.config.responsePrefix as string | undefined,
+          deduplicationEnabled: channel.config.deduplicationEnabled as boolean | undefined,
+          autoReconnect: channel.config.autoReconnect as boolean | undefined,
+          maxReconnectAttempts: channel.config.maxReconnectAttempts as number | undefined,
+          pubsubSubscription: channel.config.pubsubSubscription as string | undefined,
+        } as _GoogleChatConfig);
 
       case "email":
         const loomStatePath =

--- a/src/electron/ipc/handlers.ts
+++ b/src/electron/ipc/handlers.ts
@@ -8313,12 +8313,31 @@ export async function setupIpcHandlers(
           ambientMode: validated.ambientMode ?? false,
           silentUnauthorized: validated.silentUnauthorized ?? false,
           captureSelfMessages: validated.captureSelfMessages ?? false,
+          webhookSecret: validated.blueBubblesWebhookSecret,
         },
       );
 
       // Automatically enable and connect BlueBubbles
       gateway.enableChannel(channel.id).catch((err) => {
         logger.error("Failed to enable BlueBubbles channel:", err);
+      });
+
+      return toPublicChannel(channel, "connecting");
+    }
+
+    if (validated.type === "googlechat") {
+      const channel = await gateway.addGoogleChatChannel(
+        validated.name,
+        validated.serviceAccountKeyPath!,
+        validated.projectId,
+        validated.webhookPort ?? 3979,
+        validated.webhookPath || "/googlechat/webhook",
+        validated.webhookSecret,
+        validated.securityMode || "pairing",
+      );
+
+      gateway.enableChannel(channel.id).catch((err) => {
+        logger.error("Failed to enable Google Chat channel:", err);
       });
 
       return toPublicChannel(channel, "connecting");
@@ -11299,11 +11318,12 @@ function setupMCPHandlers(): void {
         Number.isFinite(requestedPort) &&
         requestedPort >= 1024
       ) {
-        await hostServer.startHttp(Math.floor(requestedPort));
+        const { authToken } = await hostServer.startHttp(Math.floor(requestedPort));
         return {
           success: true,
           transport: "http",
           port: hostServer.getHttpPort(),
+          authToken,
         };
       }
 
@@ -11324,6 +11344,7 @@ function setupMCPHandlers(): void {
       running: hostServer.isRunning(),
       transport: hostServer.getTransportMode(),
       port: hostServer.getHttpPort(),
+      authRequired: hostServer.getTransportMode() === "http",
       toolCount: hostServer.hasToolProvider()
         ? MCPClientManager.getInstance().getAllTools().length
         : 0,

--- a/src/electron/mcp/__tests__/MCPHostServer.test.ts
+++ b/src/electron/mcp/__tests__/MCPHostServer.test.ts
@@ -73,4 +73,48 @@ describe("MCPHostServer resources", () => {
     });
     expect(readResponse?.result?.contents?.[0]?.text).toContain('"ok":true');
   });
+
+  it("requires a bearer token for HTTP MCP requests", async () => {
+    const server = MCPHostServer.getInstance();
+    server.setToolProvider({
+      getTools() {
+        return [];
+      },
+      async executeTool() {
+        return {};
+      },
+    });
+
+    const { authToken } = await server.startHttp(0);
+    const port = server.getHttpPort();
+    expect(port).toBeGreaterThan(0);
+
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: MCP_METHODS.TOOLS_LIST,
+    });
+
+    const unauthenticated = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    const authenticated = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${authToken}`,
+      },
+      body,
+    });
+    expect(authenticated.status).toBe(200);
+    await expect(authenticated.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { tools: [] },
+    });
+  });
 });

--- a/src/electron/mcp/host/MCPHostServer.ts
+++ b/src/electron/mcp/host/MCPHostServer.ts
@@ -6,9 +6,11 @@
  */
 
 import { EventEmitter } from "events";
+import { randomBytes } from "crypto";
 import * as http from "http";
 import * as readline from "readline";
 import { createLogger } from "../../utils/logger";
+import { readBearerToken, timingSafeEqualString } from "../../utils/webhook-auth";
 import {
   JSONRPCRequest,
   JSONRPCResponse,
@@ -60,6 +62,7 @@ export class MCPHostServer extends EventEmitter {
   private httpServer: http.Server | null = null;
   private transportMode: "stdio" | "http" | null = null;
   private httpPort: number | null = null;
+  private httpAuthToken: string | null = null;
 
   private constructor() {
     super();
@@ -123,10 +126,13 @@ export class MCPHostServer extends EventEmitter {
     this.emit("started");
   }
 
-  async startHttp(port: number): Promise<void> {
+  async startHttp(port: number): Promise<{ authToken: string }> {
     if (this.running) {
       logger.info("Already running");
-      return;
+      if (this.transportMode !== "http" || !this.httpAuthToken) {
+        throw new Error("MCP host is already running on a non-HTTP transport");
+      }
+      return { authToken: this.httpAuthToken };
     }
     if (!this.toolProvider) {
       throw new Error("Tool provider not set");
@@ -135,18 +141,41 @@ export class MCPHostServer extends EventEmitter {
     this.running = true;
     this.initialized = true;
     this.transportMode = "http";
+    this.httpAuthToken = randomBytes(32).toString("base64url");
 
     this.httpServer = http.createServer(async (req, res) => {
       try {
         if (req.method === "GET" && req.url === "/health") {
           res.writeHead(200, { "content-type": "application/json" });
-          res.end(JSON.stringify({ ok: true, transport: "http", port: this.httpPort }));
+          res.end(
+            JSON.stringify({
+              ok: true,
+              transport: "http",
+              port: this.httpPort,
+              authRequired: true,
+            }),
+          );
           return;
         }
 
         if (req.method !== "POST" || req.url !== "/mcp") {
           res.writeHead(404, { "content-type": "application/json" });
           res.end(JSON.stringify({ error: "Not found" }));
+          return;
+        }
+
+        if (!this.isAllowedHttpRequest(req)) {
+          res.writeHead(401, { "content-type": "application/json" });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 0,
+              error: {
+                code: MCP_ERROR_CODES.INTERNAL_ERROR,
+                message: "Unauthorized",
+              },
+            }),
+          );
           return;
         }
 
@@ -178,12 +207,17 @@ export class MCPHostServer extends EventEmitter {
       this.httpServer?.once("error", reject);
       this.httpServer?.listen(port, "127.0.0.1", () => {
         this.httpServer?.off("error", reject);
+        const address = this.httpServer?.address();
+        if (address && typeof address === "object") {
+          this.httpPort = address.port;
+        }
         resolve();
       });
     });
-    this.httpPort = port;
-    logger.info(`Listening on http://127.0.0.1:${port}/mcp`);
+    this.httpPort = this.httpPort ?? port;
+    logger.info(`Listening on http://127.0.0.1:${this.httpPort}/mcp`);
     this.emit("started");
+    return { authToken: this.httpAuthToken };
   }
 
   /**
@@ -211,6 +245,7 @@ export class MCPHostServer extends EventEmitter {
     this.initialized = false;
     this.transportMode = null;
     this.httpPort = null;
+    this.httpAuthToken = null;
     this.emit("stopped");
 
     logger.info("Stopped");
@@ -229,6 +264,10 @@ export class MCPHostServer extends EventEmitter {
 
   getHttpPort(): number | null {
     return this.httpPort;
+  }
+
+  getHttpAuthToken(): string | null {
+    return this.httpAuthToken;
   }
 
   /**
@@ -509,6 +548,43 @@ export class MCPHostServer extends EventEmitter {
       req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
       req.on("error", reject);
     });
+  }
+
+  private isAllowedHttpRequest(req: http.IncomingMessage): boolean {
+    if (!this.isLoopbackHostHeader(req.headers.host)) {
+      return false;
+    }
+    const origin = typeof req.headers.origin === "string" ? req.headers.origin : "";
+    if (origin && !this.isLoopbackOrigin(origin)) {
+      return false;
+    }
+    const token = readBearerToken(req.headers.authorization);
+    return Boolean(token && this.httpAuthToken && timingSafeEqualString(token, this.httpAuthToken));
+  }
+
+  private isLoopbackHostHeader(hostHeader: string | undefined): boolean {
+    // Host/origin checks are defense-in-depth against DNS rebinding; the bearer
+    // token is the real gate. A missing Host header is allowed (some clients
+    // omit it) because the token is still required below.
+    if (!hostHeader) return true;
+    const host = hostHeader.trim().toLowerCase();
+    return (
+      host === "localhost" ||
+      host.startsWith("localhost:") ||
+      host === "127.0.0.1" ||
+      host.startsWith("127.0.0.1:") ||
+      host === "[::1]" ||
+      host.startsWith("[::1]:") ||
+      host === "::1"
+    );
+  }
+
+  private isLoopbackOrigin(origin: string): boolean {
+    try {
+      return this.isLoopbackHostHeader(new URL(origin).host);
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/src/electron/utils/__tests__/validation.test.ts
+++ b/src/electron/utils/__tests__/validation.test.ts
@@ -11,8 +11,11 @@ import {
   EmailChannelConfigSchema,
   AddEmailChannelSchema,
   AddDiscordChannelSchema,
+  AddBlueBubblesChannelSchema,
+  AddGoogleChatChannelSchema,
   AddFeishuChannelSchema,
   AddWeComChannelSchema,
+  AddChannelSchema,
   PersonalityConfigV2Schema,
 } from "../validation";
 import { z } from "zod";
@@ -390,6 +393,42 @@ describe("GuardrailSettingsSchema", () => {
 });
 
 describe("gateway channel schemas", () => {
+  it("validates a BlueBubbles add-channel request with a webhook secret", () => {
+    const result = AddBlueBubblesChannelSchema.safeParse({
+      type: "bluebubbles",
+      name: "BlueBubbles",
+      blueBubblesServerUrl: "https://bluebubbles.example.test",
+      blueBubblesPassword: "server_password",
+      blueBubblesWebhookPort: 3101,
+      blueBubblesWebhookSecret: "webhook_secret_123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates a Google Chat add-channel request with a required webhook secret", () => {
+    const result = AddGoogleChatChannelSchema.safeParse({
+      type: "googlechat",
+      name: "Google Chat Bot",
+      serviceAccountKeyPath: "/tmp/service-account.json",
+      projectId: "project-123",
+      webhookPort: 3979,
+      webhookPath: "/googlechat/webhook",
+      webhookSecret: "webhook_secret_123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects Google Chat add-channel requests without a webhook secret", () => {
+    const result = AddChannelSchema.safeParse({
+      type: "googlechat",
+      name: "Google Chat Bot",
+      serviceAccountKeyPath: "/tmp/service-account.json",
+      webhookPort: 3979,
+      webhookPath: "/googlechat/webhook",
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("validates a Feishu add-channel request", () => {
     const result = AddFeishuChannelSchema.safeParse({
       type: "feishu",

--- a/src/electron/utils/validation.ts
+++ b/src/electron/utils/validation.ts
@@ -1433,11 +1433,23 @@ export const AddBlueBubblesChannelSchema = z.object({
   blueBubblesServerUrl: z.string().url().min(1).max(500),
   blueBubblesPassword: z.string().min(1).max(500),
   blueBubblesWebhookPort: z.number().int().min(1024).max(65535).optional(),
+  blueBubblesWebhookSecret: z.string().max(500).optional(),
   blueBubblesAllowedContacts: z.array(z.string().max(100)).max(100).optional(),
   securityMode: SecurityModeSchema.optional(),
   ambientMode: z.boolean().optional(),
   silentUnauthorized: z.boolean().optional(),
   captureSelfMessages: z.boolean().optional(),
+});
+
+export const AddGoogleChatChannelSchema = z.object({
+  type: z.literal("googlechat"),
+  name: z.string().min(1).max(MAX_TITLE_LENGTH),
+  serviceAccountKeyPath: z.string().min(1).max(1000),
+  projectId: z.string().max(200).optional(),
+  webhookPort: z.number().int().min(1024).max(65535).optional(),
+  webhookPath: z.string().min(1).max(200).optional(),
+  webhookSecret: z.string().min(1).max(500),
+  securityMode: SecurityModeSchema.optional(),
 });
 
 export const AddXChannelSchema = z.object({
@@ -1855,6 +1867,7 @@ export const AddChannelSchema = z.discriminatedUnion("type", [
   AddTwitchChannelSchema,
   AddLineChannelSchema,
   AddBlueBubblesChannelSchema,
+  AddGoogleChatChannelSchema,
   AddFeishuChannelSchema,
   AddWeComChannelSchema,
   AddXChannelSchema,

--- a/src/electron/utils/webhook-auth.ts
+++ b/src/electron/utils/webhook-auth.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared helpers for authenticating inbound HTTP/webhook requests.
+ *
+ * These back the loopback MCP HTTP transport and the gateway channel webhooks
+ * (BlueBubbles, Google Chat, Feishu, ...). Keep the comparison logic in one
+ * place so the timing-safe semantics can't drift between call sites.
+ */
+
+import { timingSafeEqual } from "crypto";
+import type { IncomingMessage } from "http";
+
+/**
+ * Constant-time string comparison. Returns false (without leaking timing) when
+ * the lengths differ, so callers don't need to length-check first.
+ */
+export function timingSafeEqualString(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  if (actualBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+/** Extract the token from an `Authorization: Bearer <token>` header. */
+export function readBearerToken(header: string | string[] | undefined): string | null {
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) return null;
+  const match = value.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
+}
+
+/**
+ * Read a shared webhook secret from a request, preferring the explicit
+ * `x-cowork-webhook-secret` header and falling back to a bearer token.
+ */
+export function readWebhookSecret(req: IncomingMessage): string | null {
+  const header = req.headers["x-cowork-webhook-secret"];
+  if (typeof header === "string" && header.trim()) {
+    return header.trim();
+  }
+  return readBearerToken(req.headers.authorization);
+}

--- a/src/renderer/components/BlueBubblesSettings.tsx
+++ b/src/renderer/components/BlueBubblesSettings.tsx
@@ -31,6 +31,7 @@ export function BlueBubblesSettings({ onStatusChange }: BlueBubblesSettingsProps
   const [serverUrl, setServerUrl] = useState("");
   const [password, setPassword] = useState("");
   const [webhookPort, setWebhookPort] = useState(3101);
+  const [webhookSecret, setWebhookSecret] = useState("");
   const [allowedContacts, setAllowedContacts] = useState("");
   const [ambientMode, setAmbientMode] = useState(false);
   const [captureSelfMessages, setCaptureSelfMessages] = useState(false);
@@ -64,6 +65,7 @@ export function BlueBubblesSettings({ onStatusChange }: BlueBubblesSettingsProps
           setServerUrl((bbChannel.config.serverUrl as string) || "");
           setPassword((bbChannel.config.password as string) || "");
           setWebhookPort((bbChannel.config.webhookPort as number) || 3101);
+          setWebhookSecret((bbChannel.config.webhookSecret as string) || "");
           const contacts = (bbChannel.config.allowedContacts as string[]) || [];
           setAllowedContacts(contacts.join(", "));
           setAmbientMode(Boolean(bbChannel.config.ambientMode));
@@ -133,6 +135,7 @@ export function BlueBubblesSettings({ onStatusChange }: BlueBubblesSettingsProps
         blueBubblesServerUrl: serverUrl.trim(),
         blueBubblesPassword: password.trim(),
         blueBubblesWebhookPort: webhookPort,
+        blueBubblesWebhookSecret: webhookSecret.trim() || undefined,
         blueBubblesAllowedContacts: contactList.length > 0 ? contactList : undefined,
       });
 
@@ -342,6 +345,20 @@ export function BlueBubblesSettings({ onStatusChange }: BlueBubblesSettingsProps
               onChange={(e) => setWebhookPort(parseInt(e.target.value) || 3101)}
             />
             <p className="settings-hint">Port for receiving notifications (default: 3101)</p>
+          </div>
+
+          <div className="settings-field">
+            <label>Webhook Secret (Optional)</label>
+            <input
+              type="password"
+              className="settings-input"
+              placeholder="Defaults to server password"
+              value={webhookSecret}
+              onChange={(e) => setWebhookSecret(e.target.value)}
+            />
+            <p className="settings-hint">
+              Incoming webhook requests must include this secret or the server password
+            </p>
           </div>
 
           <div className="settings-field">

--- a/src/renderer/components/GoogleChatSettings.tsx
+++ b/src/renderer/components/GoogleChatSettings.tsx
@@ -30,6 +30,7 @@ export function GoogleChatSettings({ onStatusChange }: GoogleChatSettingsProps) 
   const [projectId, setProjectId] = useState("");
   const [webhookPort, setWebhookPort] = useState("3979");
   const [webhookPath, setWebhookPath] = useState("/googlechat/webhook");
+  const [webhookSecret, setWebhookSecret] = useState("");
   const [channelName, setChannelName] = useState("Google Chat Bot");
   const [securityMode, setSecurityMode] = useState<SecurityMode>("pairing");
 
@@ -94,7 +95,7 @@ export function GoogleChatSettings({ onStatusChange }: GoogleChatSettingsProps) 
   }, [channel?.id, loadChannel]);
 
   const handleAddChannel = async () => {
-    if (!serviceAccountKeyPath.trim()) return;
+    if (!serviceAccountKeyPath.trim() || !webhookSecret.trim()) return;
 
     try {
       setSaving(true);
@@ -107,11 +108,13 @@ export function GoogleChatSettings({ onStatusChange }: GoogleChatSettingsProps) 
         projectId: projectId.trim() || undefined,
         webhookPort: parseInt(webhookPort) || 3979,
         webhookPath: webhookPath.trim() || "/googlechat/webhook",
+        webhookSecret: webhookSecret.trim(),
         securityMode,
       });
 
       setServiceAccountKeyPath("");
       setProjectId("");
+      setWebhookSecret("");
       await loadChannel();
     } catch (error: Any) {
       setTestResult({ success: false, error: error.message });
@@ -317,6 +320,20 @@ export function GoogleChatSettings({ onStatusChange }: GoogleChatSettingsProps) 
           </div>
 
           <div className="settings-field">
+            <label>Webhook Secret</label>
+            <input
+              type="password"
+              className="settings-input"
+              placeholder="Shared webhook secret"
+              value={webhookSecret}
+              onChange={(e) => setWebhookSecret(e.target.value)}
+            />
+            <p className="settings-hint">
+              Require incoming Google Chat webhook requests to include this shared secret
+            </p>
+          </div>
+
+          <div className="settings-field">
             <label>Security Mode</label>
             <select
               className="settings-select"
@@ -349,7 +366,7 @@ export function GoogleChatSettings({ onStatusChange }: GoogleChatSettingsProps) 
           <button
             className="button-primary"
             onClick={handleAddChannel}
-            disabled={saving || !serviceAccountKeyPath.trim()}
+            disabled={saving || !serviceAccountKeyPath.trim() || !webhookSecret.trim()}
           >
             {saving ? "Adding..." : "Add Google Chat Bot"}
           </button>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9307,6 +9307,7 @@ export interface AddChannelRequest {
   blueBubblesServerUrl?: string;
   blueBubblesPassword?: string;
   blueBubblesWebhookPort?: number;
+  blueBubblesWebhookSecret?: string;
   blueBubblesAllowedContacts?: string[];
   // Email-specific fields
   emailProtocol?: "imap-smtp" | "loom";
@@ -9342,6 +9343,7 @@ export interface AddChannelRequest {
   serviceAccountKeyPath?: string;
   projectId?: string;
   webhookPath?: string;
+  webhookSecret?: string;
   // Feishu-specific fields
   feishuAppId?: string;
   feishuAppSecret?: string;


### PR DESCRIPTION
## Summary
- require shared-secret validation for BlueBubbles and Google Chat webhooks
- make Feishu token/signature comparisons timing-safe and required when configured
- require bearer auth for local HTTP MCP host requests and surface the generated token through IPC
- add Google Chat add-channel validation/settings support and preserve bounded channel auto-connect behavior

## Validation
- npx vitest run src/electron/gateway/__tests__/webhook-auth.test.ts src/electron/mcp/__tests__/MCPHostServer.test.ts src/electron/utils/__tests__/validation.test.ts
- npm run build:electron
- npm run build:react