### PR TITLE
feat(security): migrate scan helpers to Codex Security pack

### DIFF
--- a/docs/codex-security-scans.md
+++ b/docs/codex-security-scans.md
@@ -5,9 +5,9 @@ CoWork OS ships a bundled **Codex Security** plugin pack for defensive repositor
 Access it from **Settings > Customize > Codex Security**, or invoke one of its slash commands in the composer:
 
 ```text
-/codex-security:security-scan Run a security scan on this repository
-/codex-security:security-diff-scan Review this branch diff for security regressions
-/codex-security:deep-security-scan Run a deep repository-wide security scan
+/security-scan Run a security scan on this repository
+/security-diff-scan Review this branch diff for security regressions
+/deep-security-scan Run a deep repository-wide security scan
 ```
 
 The pack is bundled at:
@@ -20,11 +20,11 @@ Packaged desktop/server builds include the whole pack under Electron resources a
 
 ## Scan Modes
 
-| Mode | Skill | Scope |
-|------|-------|-------|
-| Repository scan | `codex-security:security-scan` | Repository-wide or scoped-path scan |
-| Diff scan | `codex-security:security-diff-scan` | Git revision, branch, commit, staged, or unstaged diff review |
-| Deep scan | `codex-security:deep-security-scan` | Repository-wide multi-pass scan with six independent discovery workers per round |
+| Mode | Slash command | Skill ID | Scope |
+|------|---------------|----------|-------|
+| Repository scan | `/security-scan` | `codex-security:security-scan` | Repository-wide or scoped-path scan |
+| Diff scan | `/security-diff-scan` | `codex-security:security-diff-scan` | Git revision, branch, commit, staged, or unstaged diff review |
+| Deep scan | `/deep-security-scan` | `codex-security:deep-security-scan` | Repository-wide multi-pass scan with six independent discovery workers per round |
 
 The top-level skills preserve the upstream Codex Security phase model:
 
@@ -56,23 +56,15 @@ The pack uses directory-backed skills via `skillDirectories` in `cowork.plugin.j
 
 Directory-backed skills read `SKILL.md` and relative `references/`, `scripts/`, `assets/`, and `agents/` files from their pack directory. CoWork uses the manifest definition first, then `SKILL.md` frontmatter, then a title generated from the skill ID for display metadata.
 
-## Orchestration Tools
+## Skill Orchestration
 
-CoWork exposes a small set of internal helper tools only while a task is recognized as a Codex Security scan task:
+Codex Security scan orchestration now lives in the bundled plugin-pack skills rather than hidden built-in tools. The `/security-scan`, `/security-diff-scan`, and `/deep-security-scan` entrypoints read their own `SKILL.md` instructions, references, and scripts from `resources/plugin-packs/codex-security/`.
 
-| Tool | Purpose |
-|------|---------|
-| `security_scan_prepare` | Create a scan directory, generate `rank_input.csv`, and copy it to `deep_review_input.csv` |
-| `security_scan_create_worker_dirs` | Create the six standard worker directories for a deep discovery round |
-| `security_scan_check_worker_artifacts` | Verify required worker files and JSONL parse validity |
-| `security_scan_merge_deep_round` | Merge deterministic deep-scan candidate inventories after all six workers finish |
-| `security_scan_validate_report` | Run the bundled report validator and render `report.html` |
-
-These tools are not general-purpose file tools. They are hidden from normal tasks and their handlers reject calls outside Codex Security scan tasks.
+The skill runtime uses normal workspace-scoped tools for reading, searching, command execution, file creation, sub-agent coordination, and report writing. There are no `security_scan_*` built-in tool handlers to call directly.
 
 ## Artifact Layout
 
-`security_scan_prepare` writes artifacts under the active workspace by default:
+Scan skills should write artifacts under the active workspace by default:
 
 ```text
 <repo>/.cowork/security-scans/<repo-name>/<scan-id>/
@@ -116,15 +108,15 @@ repository_coverage_ledger.md
 
 The JSONL files are parsed before a worker is considered usable. Malformed JSONL makes that worker unusable for the round merge.
 
-## Deep Scan Merge Rules
+## Deep Scan Reconciliation
 
-Deep Security Scan requires exactly six usable workers per completed round. A round is not mergeable if:
+Deep Security Scan still expects six independent discovery workers per completed round. A round should not be treated as complete if:
 
 - fewer or more than six `worker-*` directories exist
 - any worker is missing a required artifact
 - any worker has malformed JSONL in `work_ledger.jsonl`, `raw_candidates.jsonl`, or `deduped_candidates.jsonl`
 
-The deterministic merge writes:
+When the skill reconciles completed worker output, it should write:
 
 ```text
 artifacts/deep_merge/round-XX_candidate_inventory.jsonl
@@ -132,27 +124,26 @@ artifacts/deep_merge/round-XX_candidate_inventory.md
 artifacts/deep_merge/canonical_candidate_inventory.jsonl
 ```
 
-The merge uses exact candidate keys as a bookkeeping aid only. The Codex Security skill still performs semantic remediation-subsumption merging before final validation and reporting.
+Exact candidate keys are a bookkeeping aid only. The Codex Security skill still performs semantic remediation-subsumption merging before final validation and reporting.
 
 ## Workspace Safety
 
-Security scan helpers are workspace-scoped:
+Security scan workflows remain workspace-scoped:
 
-- `repo_root`, `artifact_root`, `scan_dir`, and `worker_dir` must resolve inside the active workspace.
+- `repo_root`, `artifact_root`, `scan_dir`, and `worker_dir` should resolve inside the active workspace.
 - `artifact_root` defaults to `.cowork/security-scans/<repo-name>` inside the target repository.
 - `scan_id` may contain only letters, numbers, dot, underscore, or dash.
 - `scope` for scoped-path scans must be a relative path inside the repository.
 - Deep scans are repository-wide only. Use repository or scoped-path mode for narrower scans.
-- The helper tools do not run for non-Codex-Security tasks even if a model tries to call them by name.
 
 Imported third-party packs still use the normal imported-capability security gate. The bundled Codex Security pack is treated as first-party bundled content, packaged with the app, and loaded through normal plugin-pack discovery.
 
 ## Validation Commands
 
-Use these focused checks after changing Codex Security scan orchestration, the bundled pack manifest, directory-backed skill loading, or scan tool gating:
+Use these focused checks after changing Codex Security scan orchestration, the bundled pack manifest, or directory-backed skill loading:
 
 ```bash
-npx vitest run src/electron/security-scans/__tests__/SecurityScanOrchestrator.test.ts src/electron/agent/tools/__tests__/registry-tool-catalog.test.ts src/electron/extensions/__tests__/codex-security-plugin-pack-manifest.test.ts
+npx vitest run src/electron/agent/tools/__tests__/registry-tool-catalog.test.ts src/electron/extensions/__tests__/codex-security-plugin-pack-manifest.test.ts
 npm run build:electron
 ```
 
@@ -168,9 +159,8 @@ npm run skills:check
 | Area | Files |
 |------|-------|
 | Bundled pack | `resources/plugin-packs/codex-security/` |
-| Scan orchestration | `src/electron/security-scans/SecurityScanOrchestrator.ts` |
-| Tool definitions and handlers | `src/electron/agent/tools/registry.ts` |
-| Task-level tool gating | `src/electron/agent/executor.ts` |
+| Scan orchestration | `resources/plugin-packs/codex-security/skills/**/SKILL.md` and pack scripts/references |
+| Tool catalog behavior | `src/electron/agent/tools/registry.ts` |
 | Directory-backed pack skills | `src/electron/extensions/registry.ts`, `src/electron/extensions/types.ts` |
 | Pack discovery/loading | `src/electron/extensions/loader.ts`, `src/electron/ipc/plugin-pack-handlers.ts` |
 | Packaged resource inclusion | `package.json` `build.extraResources` |

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -8,6 +8,7 @@ This documentation covers the security architecture of CoWork OS, an AI-powered 
 2. [Trust Boundaries](./trust-boundaries.md) - Understanding workspace, channel, and network boundaries
 3. [Configuration Guide](./configuration-guide.md) - How to configure security settings
 4. [Best Practices](./best-practices.md) - Recommended security settings and practices
+5. [June 2026 Security Hardening](./security-hardening-2026-06.md) - Deep scan finding closures and defense-in-depth changes
 
 ## Quick Start
 

--- a/resources/plugin-packs/codex-security/cowork.plugin.json
+++ b/resources/plugin-packs/codex-security/cowork.plugin.json
@@ -9,9 +9,9 @@
   "icon": "🛡️",
   "category": "Engineering",
   "tryAsking": [
-    "$codex-security:security-scan Run a security scan on this repository",
-    "$codex-security:security-diff-scan Review this branch diff for security regressions",
-    "$codex-security:deep-security-scan Run a deep repository-wide security scan"
+    "$security-scan Run a security scan on this repository",
+    "$security-diff-scan Review this branch diff for security regressions",
+    "$deep-security-scan Run a deep repository-wide security scan"
   ],
   "skillDirectories": [
     {
@@ -65,17 +65,17 @@
   ],
   "slashCommands": [
     {
-      "name": "codex-security:security-scan",
+      "name": "security-scan",
       "description": "Run a repository-wide or scoped-path Codex Security scan",
       "skillId": "codex-security:security-scan"
     },
     {
-      "name": "codex-security:security-diff-scan",
+      "name": "security-diff-scan",
       "description": "Run a security review of a Git-backed diff",
       "skillId": "codex-security:security-diff-scan"
     },
     {
-      "name": "codex-security:deep-security-scan",
+      "name": "deep-security-scan",
       "description": "Run a deeper multi-pass repository-wide Codex Security scan",
       "skillId": "codex-security:deep-security-scan"
     }

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -5279,24 +5279,12 @@ ${transcript}
           ]
         : []),
     ];
-    const securityScanToolsEnabled =
-      /\bcodex-security:|\bCodex Security\b|\bdeep-security-scan\b|\bsecurity-diff-scan\b|\bsecurity-scan\b/i.test(
-        [
-          this.task.title,
-          this.task.prompt,
-          this.task.rawPrompt,
-          this.task.userPrompt,
-        ]
-          .filter((value): value is string => typeof value === "string")
-          .join("\n"),
-      );
     const registry = new ToolRegistry(
       workspace,
       this.daemon,
       this.task.id,
       this.task.agentConfig?.gatewayContext,
       toolRestrictions,
-      securityScanToolsEnabled,
     );
     registry.setWorkspacePathAliasPolicy(this.getEffectiveWorkspacePathAliasPolicy());
     registry.setWebSearchDomainPolicy({

--- a/src/electron/agent/tools/__tests__/registry-tool-catalog.test.ts
+++ b/src/electron/agent/tools/__tests__/registry-tool-catalog.test.ts
@@ -189,11 +189,14 @@ describe("ToolRegistry tool catalog versioning", () => {
     expect(secondTools.some((tool) => tool.name === "mcp_alpha")).toBe(true);
   });
 
-  it("only advertises security scan helpers for Codex Security tasks", () => {
+  it("no longer registers security scan helpers as tools (migrated to codex-security plugin skills)", () => {
     mockBuiltinSettings.version = "security-scan-gating";
     const normalRegistry = new ToolRegistry(createWorkspace(), createDaemon(), "task-normal");
     expect(normalRegistry.getTools().some((tool) => tool.name === "security_scan_prepare")).toBe(false);
 
+    // Even Codex Security tasks no longer get built-in security_scan_* tools; the scan
+    // capability now lives in the codex-security plugin pack (security-scan,
+    // security-diff-scan, deep-security-scan skills).
     const securityRegistry = new ToolRegistry(
       createWorkspace(),
       createDaemon(),
@@ -202,7 +205,7 @@ describe("ToolRegistry tool catalog versioning", () => {
       undefined,
       true,
     );
-    expect(securityRegistry.getTools().some((tool) => tool.name === "security_scan_prepare")).toBe(true);
+    expect(securityRegistry.getTools().some((tool) => tool.name === "security_scan_prepare")).toBe(false);
   });
 
   it("annotates MCP tool descriptions with the source server name", () => {

--- a/src/electron/agent/tools/registry.ts
+++ b/src/electron/agent/tools/registry.ts
@@ -166,7 +166,6 @@ import {
   withToolPromptMetadataList,
 } from "./tool-prompting";
 import { buildBrowserUseDomainApprovalDetails } from "./browser-use-approval-context";
-import { getSecurityScanOrchestrator } from "../../security-scans/SecurityScanOrchestrator";
 
 function sanitizeFilename(raw: string, maxLen = 120): string {
   const base = path.basename(String(raw || "").trim() || "artifact");
@@ -229,14 +228,6 @@ const SUB_AGENT_DEFAULT_DENIED_TOOLS = [
   "resume_agent",
   "orchestrate_agents",
 ];
-
-const SECURITY_SCAN_TOOL_NAMES = new Set([
-  "security_scan_prepare",
-  "security_scan_create_worker_dirs",
-  "security_scan_check_worker_artifacts",
-  "security_scan_merge_deep_round",
-  "security_scan_validate_report",
-]);
 
 const EXTRACTION_SUB_AGENT_ALLOWED_TOOLS = [
   "read_file",
@@ -581,7 +572,6 @@ export class ToolRegistry {
     private taskId: string,
     gatewayContext?: GatewayContextType,
     toolRestrictions?: string[],
-    private readonly securityScanToolsEnabled = false,
   ) {
     this.fileTools = new FileTools(workspace, daemon, taskId);
     this.skillTools = new SkillTools(workspace, daemon, taskId);
@@ -778,7 +768,6 @@ export class ToolRegistry {
       denyAllTools: this.denyAllTools,
       headless: isHeadlessMode(),
       deepWorkMode: this._deepWorkMode,
-      securityScanToolsEnabled: this.securityScanToolsEnabled,
     });
   }
 
@@ -978,24 +967,6 @@ export class ToolRegistry {
   setDeepWorkMode(enabled: boolean): void {
     this._deepWorkMode = enabled;
     this.invalidateToolCaches();
-  }
-
-  private assertSecurityScanToolsEnabled(): void {
-    if (!this.securityScanToolsEnabled) {
-      throw new Error("Codex Security scan tools are only available inside Codex Security skill tasks");
-    }
-  }
-
-  private resolveSecurityScanWorkspacePath(label: string, value: unknown): string {
-    if (typeof value !== "string" || !value.trim()) {
-      throw new Error(`Security scan ${label} is required`);
-    }
-    const resolved = path.resolve(this.workspace.path, value);
-    const workspaceRoot = path.resolve(this.workspace.path);
-    if (resolved !== workspaceRoot && !resolved.startsWith(workspaceRoot + path.sep)) {
-      throw new Error(`Security scan ${label} must be inside the workspace`);
-    }
-    return resolved;
   }
 
   /**
@@ -1376,13 +1347,6 @@ export class ToolRegistry {
 
     // Add meta tools for execution control
     allTools.push(...this.getMetaToolDefinitions());
-    if (!this.securityScanToolsEnabled) {
-      for (let index = allTools.length - 1; index >= 0; index--) {
-        if (SECURITY_SCAN_TOOL_NAMES.has(allTools[index].name)) {
-          allTools.splice(index, 1);
-        }
-      }
-    }
 
     // Collect built-in tool names before adding MCP tools
     const builtinToolNames = new Set(allTools.map((t) => t.name));
@@ -1852,62 +1816,6 @@ export class ToolRegistry {
     register("skill_proposal", async ({ request }) => this.executeSkillProposal(request.input));
     register("glob", async ({ request }) => this.globTools.glob(request.input), readParallelSchedulerSpec);
     register("grep", async ({ request }) => this.grepTools.grep(request.input), readParallelSchedulerSpec);
-    register("security_scan_prepare", async ({ request }) => {
-      const input = request.input || {};
-      this.assertSecurityScanToolsEnabled();
-      return getSecurityScanOrchestrator().prepareScan({
-        repoRoot:
-          typeof input.repo_root === "string"
-            ? this.resolveSecurityScanWorkspacePath("repo_root", input.repo_root)
-            : this.workspace.path,
-        workspaceRoot: this.workspace.path,
-        mode: input.mode,
-        scope: input.scope,
-        base: input.base,
-        head: input.head,
-        diffMode: input.diff_mode,
-        artifactRoot:
-          typeof input.artifact_root === "string"
-            ? this.resolveSecurityScanWorkspacePath("artifact_root", input.artifact_root)
-            : undefined,
-        scanId: input.scan_id,
-        deepRounds: input.deep_rounds,
-      });
-    }, exclusiveSchedulerSpec);
-    register("security_scan_create_worker_dirs", async ({ request }) => {
-      const input = request.input || {};
-      this.assertSecurityScanToolsEnabled();
-      return {
-        worker_dirs: getSecurityScanOrchestrator().createDeepWorkerDirs(
-          this.resolveSecurityScanWorkspacePath("scan_dir", input.scan_dir),
-          input.round,
-          input.worker_count,
-        ),
-      };
-    }, exclusiveSchedulerSpec);
-    register("security_scan_check_worker_artifacts", async ({ request }) =>
-      {
-        this.assertSecurityScanToolsEnabled();
-        return getSecurityScanOrchestrator().checkWorkerArtifacts(
-          this.resolveSecurityScanWorkspacePath("worker_dir", request.input.worker_dir),
-        );
-      }, readParallelSchedulerSpec);
-    register("security_scan_merge_deep_round", async ({ request }) =>
-      {
-        this.assertSecurityScanToolsEnabled();
-        return getSecurityScanOrchestrator().mergeDeepRound(
-          this.resolveSecurityScanWorkspacePath("scan_dir", request.input.scan_dir),
-          request.input.round,
-        );
-      }, exclusiveSchedulerSpec);
-    register("security_scan_validate_report", async ({ request }) =>
-      {
-        this.assertSecurityScanToolsEnabled();
-        return getSecurityScanOrchestrator().validateAndRenderReport(
-          this.resolveSecurityScanWorkspacePath("scan_dir", request.input.scan_dir),
-          request.input.title,
-        );
-      }, exclusiveSchedulerSpec);
     register("edit_file", async ({ request }) => this.editTools.editFile(request.input), exclusiveSchedulerSpec);
     register("count_text", async ({ request }) => this.textTools.countText(request.input));
     register("text_metrics", async ({ request }) => this.textTools.textMetrics(request.input));
@@ -11833,133 +11741,6 @@ ${skillDescriptions}`;
       ...CodeExecTools.getToolDefinitions(),
       // Document parsing
       ...DocumentParserTools.getToolDefinitions(),
-      // Codex Security scan orchestration helpers
-      {
-        name: "security_scan_prepare",
-        description:
-          "Prepare a Codex Security scan artifact directory, generate rank_input.csv and deep_review_input.csv, and return standard scan paths. Use before repository, scoped-path, diff, or deep security scans.",
-        input_schema: {
-          type: "object",
-          properties: {
-            repo_root: {
-              type: "string",
-              description: "Repository root. Defaults to the current workspace path.",
-            },
-            mode: {
-              type: "string",
-              enum: ["repository", "scoped_path", "diff", "deep_repository"],
-              description: "Security scan mode.",
-            },
-            scope: {
-              type: "string",
-              description: "Scoped subdirectory for scoped_path scans.",
-            },
-            base: {
-              type: "string",
-              description: "Base Git revision for diff scans.",
-            },
-            head: {
-              type: "string",
-              description: "Head Git revision for committed diff scans.",
-            },
-            diff_mode: {
-              type: "string",
-              enum: ["revisions", "local-patch"],
-              description: "Diff scan mode. Use local-patch for staged/unstaged working tree scans.",
-            },
-            artifact_root: {
-              type: "string",
-              description:
-                "Optional parent directory for scan artifacts. Defaults to .cowork/security-scans/<repo> under the repository.",
-            },
-            scan_id: {
-              type: "string",
-              description: "Optional explicit scan id. Defaults to <commit>_<timestamp>.",
-            },
-            deep_rounds: {
-              type: "number",
-              description: "Maximum deep discovery rounds, capped at 10. Default: 10.",
-            },
-          },
-          required: ["mode"],
-        },
-      },
-      {
-        name: "security_scan_create_worker_dirs",
-        description:
-          "Create the six standard worker artifact directories for a deep Codex Security discovery round.",
-        input_schema: {
-          type: "object",
-          properties: {
-            scan_dir: {
-              type: "string",
-              description: "Scan directory returned by security_scan_prepare.",
-            },
-            round: {
-              type: "number",
-              description: "Deep discovery round number, starting at 1.",
-            },
-            worker_count: {
-              type: "number",
-              description: "Worker count. Deep Security Scan requires 6; default is 6.",
-            },
-          },
-          required: ["scan_dir", "round"],
-        },
-      },
-      {
-        name: "security_scan_check_worker_artifacts",
-        description:
-          "Check whether a deep security scan worker directory contains the required discovery artifact files.",
-        input_schema: {
-          type: "object",
-          properties: {
-            worker_dir: {
-              type: "string",
-              description: "Worker artifact directory to inspect.",
-            },
-          },
-          required: ["worker_dir"],
-        },
-      },
-      {
-        name: "security_scan_merge_deep_round",
-        description:
-          "Merge deterministic deep-scan round bookkeeping from completed worker deduped_candidates.jsonl files. This is an artifact aid; semantic remediation-subsumption merge is still required by the Codex Security skill.",
-        input_schema: {
-          type: "object",
-          properties: {
-            scan_dir: {
-              type: "string",
-              description: "Scan directory returned by security_scan_prepare.",
-            },
-            round: {
-              type: "number",
-              description: "Deep discovery round number to merge.",
-            },
-          },
-          required: ["scan_dir", "round"],
-        },
-      },
-      {
-        name: "security_scan_validate_report",
-        description:
-          "Run the Codex Security report validator and render report.html from an existing scan_dir/report.md.",
-        input_schema: {
-          type: "object",
-          properties: {
-            scan_dir: {
-              type: "string",
-              description: "Scan directory containing report.md.",
-            },
-            title: {
-              type: "string",
-              description: "Optional HTML title.",
-            },
-          },
-          required: ["scan_dir"],
-        },
-      },
       // Sub-Agent / Parallel Agent tools
       {
         name: "acp_discover",

--- a/src/electron/extensions/__tests__/codex-security-plugin-pack-manifest.test.ts
+++ b/src/electron/extensions/__tests__/codex-security-plugin-pack-manifest.test.ts
@@ -32,6 +32,22 @@ describe("Codex Security plugin pack", () => {
         "codex-security:validation",
       ]),
     );
+    expect(manifest.slashCommands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "security-scan",
+          skillId: "codex-security:security-scan",
+        }),
+        expect.objectContaining({
+          name: "security-diff-scan",
+          skillId: "codex-security:security-diff-scan",
+        }),
+        expect.objectContaining({
+          name: "deep-security-scan",
+          skillId: "codex-security:deep-security-scan",
+        }),
+      ]),
+    );
     for (const skill of manifest.skillDirectories as Array<{ path: string }>) {
       expect(
         fs.existsSync(

--- a/src/electron/extensions/pack-installer.ts
+++ b/src/electron/extensions/pack-installer.ts
@@ -16,6 +16,7 @@ import { promisify } from "util";
 import { app } from "electron";
 import { InstallSecurityOutcome } from "../../shared/types";
 import { getCapabilityBundleSecurityService } from "../security/capability-bundle-security";
+import { assertNetworkPolicyAllowed } from "../security/network-policy";
 import { validateManifest } from "./loader";
 import { PluginManifest } from "./types";
 
@@ -209,10 +210,7 @@ function parseGitUrl(input: string): { url: string; name: string } | null {
   }
   // SSH URL
   else if (url.startsWith("git@")) {
-    const match = url.match(/git@[^:]+:(.+?)(?:\.git)?$/);
-    if (!match) return null;
-    const parts = match[1].split("/");
-    name = parts[parts.length - 1];
+    return null;
   } else {
     return null;
   }
@@ -242,7 +240,12 @@ export async function installFromGit(
   // Parse and validate URL
   const parsed = parseGitUrl(gitUrl);
   if (!parsed) {
-    return { success: false, error: `Invalid git URL: ${gitUrl}` };
+    return { success: false, error: `Invalid or unsupported git URL: ${gitUrl}` };
+  }
+  try {
+    assertNetworkPolicyAllowed({ url: parsed.url, toolName: "plugin_pack_git_install" });
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
 
   // Check git availability
@@ -401,6 +404,7 @@ export async function installFromUrl(
   let tempDir: string | null = null;
 
   try {
+    assertNetworkPolicyAllowed({ url, toolName: "plugin_pack_url_install" });
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 


### PR DESCRIPTION
## Summary
- remove built-in security_scan_* registry tools and their executor enablement flag
- update Codex Security pack metadata, installer behavior, and manifest/catalog tests
- refresh Codex Security docs to point at bundled plugin skills and generated reports

## Validation
- npx vitest run src/electron/agent/tools/__tests__/registry-tool-catalog.test.ts src/electron/extensions/__tests__/codex-security-plugin-pack-manifest.test.ts
- npm run build:electron