### PR TITLE
fix(dev): harden Electron dev codesign helper

### DIFF
--- a/scripts/codesign_electron_dev.mjs
+++ b/scripts/codesign_electron_dev.mjs
@@ -87,6 +87,18 @@ function checkCurrentSignature() {
 }
 
 export function selectSigningPlan(currentSig, identity, signingEnabled = false) {
+  if (currentSig === "invalid") {
+    return {
+      action: "sign",
+      message: identity
+        ? `Electron.app signature is invalid; signing with: ${identity}`
+        : "Electron.app signature is invalid; applying an ad-hoc development signature.",
+      signingIdentity: identity || "-",
+      timestamp: Boolean(identity),
+      useEntitlements: Boolean(identity),
+    };
+  }
+
   if (!signingEnabled) {
     return {
       action: "skip",
@@ -111,6 +123,7 @@ export function selectSigningPlan(currentSig, identity, signingEnabled = false) 
         : "No signing identity configured; applying an ad-hoc development signature.",
     signingIdentity: identity || "-",
     timestamp: Boolean(identity),
+    useEntitlements: Boolean(identity),
   };
 }
 
@@ -139,7 +152,7 @@ export function main(env = process.env) {
     return 0;
   }
 
-  const entitlementsArgs = existsSync(ENTITLEMENTS)
+  const entitlementsArgs = plan.useEntitlements && existsSync(ENTITLEMENTS)
     ? ["--entitlements", ENTITLEMENTS]
     : [];
   const timestampArgs = plan.timestamp ? ["--timestamp"] : [];

--- a/tests/codesign-electron-dev.test.ts
+++ b/tests/codesign-electron-dev.test.ts
@@ -23,6 +23,16 @@ describe("codesign_electron_dev", () => {
     });
   });
 
+  it("repairs an invalid Electron.app signature by default", () => {
+    expect(selectSigningPlan("invalid", null)).toEqual({
+      action: "sign",
+      message: "Electron.app signature is invalid; applying an ad-hoc development signature.",
+      signingIdentity: "-",
+      timestamp: false,
+      useEntitlements: false,
+    });
+  });
+
   it("enables signing with an explicit toggle", () => {
     expect(isSigningEnabled({ COWORK_CODESIGN_ENABLE: "1" })).toBe(true);
   });
@@ -37,6 +47,7 @@ describe("codesign_electron_dev", () => {
       message: "Replacing existing team signature with an ad-hoc development signature.",
       signingIdentity: "-",
       timestamp: false,
+      useEntitlements: false,
     });
   });
 
@@ -53,6 +64,7 @@ describe("codesign_electron_dev", () => {
       message: "Signing Electron.app with: Apple Development: Example (TEAMID1234)",
       signingIdentity: "Apple Development: Example (TEAMID1234)",
       timestamp: true,
+      useEntitlements: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- make the Electron dev codesign helper tolerate missing or partial Info.plist metadata
- add regression coverage for the helper behavior

## Validation
- npx vitest run tests/codesign-electron-dev.test.ts