### PR TITLE
fix(tools): restrict open_url to web schemes

### DIFF
--- a/src/electron/agent/tools/__tests__/system-tools-new.test.ts
+++ b/src/electron/agent/tools/__tests__/system-tools-new.test.ts
@@ -34,8 +34,10 @@ vi.mock("../../../location/DesktopLocationService", () => ({
 import { SystemTools } from "../system-tools";
 import { LayeredMemoryIndexService } from "../../../memory/LayeredMemoryIndexService";
 import { DurableContextService } from "../../../memory/DurableContextService";
+import { shell } from "electron";
 
 beforeEach(() => {
+  vi.clearAllMocks();
   memoryFeatureMocks.getCurrentLocation.mockReset();
   memoryFeatureMocks.loadSettings.mockReturnValue({
     sessionRecallEnabled: true,
@@ -116,6 +118,15 @@ describe("SystemTools.normalizeAppleScript", () => {
 
     expect(result).toContain('The bundle identifier "ai.perplexity" was not resolvable.');
     expect(result).toContain(`osascript -e 'id of app "App Name"'`);
+  });
+
+  it("rejects non-web URL schemes before opening external handlers", async () => {
+    const instance = makeSystemTools();
+
+    await expect(instance.openUrl("x-apple.systempreferences:com.apple.preference.security")).rejects.toThrow(
+      "Only http and https URLs are allowed",
+    );
+    expect(shell.openExternal).not.toHaveBeenCalled();
   });
 });
 

--- a/src/electron/agent/tools/system-tools.ts
+++ b/src/electron/agent/tools/system-tools.ts
@@ -684,10 +684,14 @@ export class SystemTools {
     }
 
     // Basic URL validation
+    let parsedUrl: URL;
     try {
-      new URL(url);
+      parsedUrl = new URL(url);
     } catch {
       throw new Error("Invalid URL format");
+    }
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      throw new Error("Only http and https URLs are allowed");
     }
 
     this.daemon.logEvent(this.taskId, "tool_call", {


### PR DESCRIPTION
## Summary
- reject non-http(s) URLs before invoking external URL handlers
- add regression coverage to ensure native/system schemes are not opened

## Validation
- npx vitest run src/electron/agent/tools/__tests__/system-tools-new.test.ts
- npm run build:electron

Note: the focused test still emits its existing Vitest mock-hoisting warning.