### PR TITLE
fix(tools): harden web fetch and scraping handling

### DIFF
--- a/src/electron/agent/tools/__tests__/scraping-tools.test.ts
+++ b/src/electron/agent/tools/__tests__/scraping-tools.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Workspace } from "../../../../shared/types";
+import { GuardrailManager } from "../../../guardrails/guardrail-manager";
+import { ScrapingTools } from "../scraping-tools";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("child_process", () => ({
+  spawn: spawnMock,
+}));
+
+vi.mock("../../../scraping/scraping-settings", () => ({
+  ScrapingSettingsManager: {
+    isEnabled: vi.fn(() => true),
+    loadSettings: vi.fn(() => ({
+      defaultFetcher: "default",
+      headless: true,
+      timeout: 30000,
+      maxContentLength: 100000,
+      pythonPath: "python3",
+      proxy: { enabled: false, url: "" },
+    })),
+  },
+}));
+
+const workspace: Workspace = {
+  id: "ws-1",
+  name: "Test",
+  path: "/tmp/workspace",
+  permissions: { read: true, write: true, delete: false, network: true, shell: false },
+  createdAt: new Date().toISOString(),
+  lastAccessed: new Date().toISOString(),
+};
+
+describe("ScrapingTools network policy", () => {
+  let tools: ScrapingTools;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(GuardrailManager, "isDomainAllowed").mockImplementation((url: string) => {
+      return !url.includes("blocked.example");
+    });
+    tools = new ScrapingTools(workspace, { logEvent: vi.fn() } as Any, "task-1");
+  });
+
+  it("rejects scrape_page destinations before starting the bridge", async () => {
+    await expect(
+      tools.executeTool("scrape_page", { url: "https://blocked.example/private" }),
+    ).rejects.toThrow("Domain not allowed");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects scrape_session step URLs before starting the bridge", async () => {
+    await expect(
+      tools.executeTool("scrape_session", {
+        steps: [{ action: "navigate", url: "https://blocked.example/private" }],
+      }),
+    ).rejects.toThrow("Domain not allowed");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/electron/agent/tools/__tests__/web-fetch-tools.test.ts
+++ b/src/electron/agent/tools/__tests__/web-fetch-tools.test.ts
@@ -1050,20 +1050,33 @@ describe("WebFetchTools", () => {
     });
 
     describe("redirect handling", () => {
-      it("should follow redirects by default", async () => {
+      it("should follow redirects by default after policy-checking each destination", async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 302,
+          statusText: "Found",
+          headers: new Map([["location", "https://example.com/final"]]),
+          text: async () => "",
+        });
         mockFetch.mockResolvedValueOnce({
           ok: true,
           status: 200,
           statusText: "OK",
-          headers: new Map(),
+          headers: new Map([["content-type", "text/plain"]]),
           text: async () => "Final destination",
         });
 
-        await webFetchTools.httpRequest({ url: "https://example.com/redirect" });
+        const result = await webFetchTools.httpRequest({ url: "https://example.com/redirect" });
 
+        expect(result.success).toBe(true);
+        expect(result.body).toBe("Final destination");
         expect(mockFetch).toHaveBeenCalledWith(
           "https://example.com/redirect",
-          expect.objectContaining({ redirect: "follow" }),
+          expect.objectContaining({ redirect: "manual" }),
+        );
+        expect(mockFetch).toHaveBeenCalledWith(
+          "https://example.com/final",
+          expect.objectContaining({ redirect: "manual" }),
         );
       });
 
@@ -1085,6 +1098,26 @@ describe("WebFetchTools", () => {
           "https://example.com/redirect",
           expect.objectContaining({ redirect: "manual" }),
         );
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it("should reject redirects to domains denied by network policy", async () => {
+        vi.spyOn(GuardrailManager, "isDomainAllowed").mockImplementation((url: string) => {
+          return !url.includes("blocked.example");
+        });
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 302,
+          statusText: "Found",
+          headers: new Map([["location", "https://blocked.example/final"]]),
+          text: async () => "",
+        });
+
+        const result = await webFetchTools.httpRequest({ url: "https://example.com/redirect" });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Domain not allowed");
+        expect(mockFetch).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/src/electron/agent/tools/scraping-tools.ts
+++ b/src/electron/agent/tools/scraping-tools.ts
@@ -4,6 +4,7 @@ import { Workspace } from "../../../shared/types";
 import { AgentDaemon } from "../daemon";
 import { LLMTool } from "../llm/types";
 import { ScrapingSettingsManager } from "../../scraping/scraping-settings";
+import { evaluateNetworkPolicy } from "../../security/network-policy";
 
 /**
  * ScrapingTools provides advanced web scraping capabilities powered by Scrapling.
@@ -250,6 +251,26 @@ export class ScrapingTools {
     return await this.callBridge("status", {});
   }
 
+  // NOTE: This only validates the URL(s) handed to the Scrapling bridge. The
+  // bridge itself may follow redirects/links that are not re-checked here, so
+  // this is not full parity with WebFetchTools' per-hop redirect validation.
+  private ensureNetworkAllowed(url: string, toolName: string): string {
+    const parsedUrl = new URL(url);
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      throw new Error("Only HTTP and HTTPS URLs are supported");
+    }
+    const normalizedUrl = parsedUrl.toString();
+    const decision = evaluateNetworkPolicy({ url: normalizedUrl, toolName });
+    this.daemon.logEvent(this.taskId, "network_policy_decision", decision);
+    if (decision.action === "allow") {
+      return normalizedUrl;
+    }
+    if (decision.reason === "legacy_guardrail_domain_denied") {
+      throw new Error(`Domain not allowed: "${normalizedUrl}"`);
+    }
+    throw new Error(`Network access denied for "${normalizedUrl}": ${decision.reason}`);
+  }
+
   private async scrapePage(input: {
     url: string;
     fetcher?: string;
@@ -262,13 +283,15 @@ export class ScrapingTools {
     max_content_length?: number;
   }): Promise<Any> {
     const settings = ScrapingSettingsManager.loadSettings();
+    const normalizedUrl = this.ensureNetworkAllowed(input.url, "scrape_page");
 
     this.daemon.logEvent(this.taskId, "log", {
-      message: `Scraping: ${input.url} (fetcher: ${input.fetcher || settings.defaultFetcher})`,
+      message: `Scraping: ${normalizedUrl} (fetcher: ${input.fetcher || settings.defaultFetcher})`,
     });
 
     const params: Record<string, Any> = {
       ...input,
+      url: normalizedUrl,
       fetcher: input.fetcher || settings.defaultFetcher,
       headless: input.headless ?? settings.headless,
       timeout: settings.timeout,
@@ -284,7 +307,7 @@ export class ScrapingTools {
     this.daemon.logEvent(this.taskId, "tool_result", {
       tool: "scrape_page",
       result: {
-        url: input.url,
+        url: normalizedUrl,
         success: result.success,
         contentLength: result.content?.length || 0,
         title: result.title,
@@ -301,13 +324,15 @@ export class ScrapingTools {
     max_content_length?: number;
   }): Promise<Any> {
     const settings = ScrapingSettingsManager.loadSettings();
+    const normalizedUrls = input.urls.map((url) => this.ensureNetworkAllowed(url, "scrape_multiple"));
 
     this.daemon.logEvent(this.taskId, "log", {
-      message: `Batch scraping ${input.urls.length} URLs`,
+      message: `Batch scraping ${normalizedUrls.length} URLs`,
     });
 
     const params: Record<string, Any> = {
       ...input,
+      urls: normalizedUrls,
       fetcher: input.fetcher || settings.defaultFetcher,
       max_content_length: input.max_content_length || 50000,
     };
@@ -332,13 +357,15 @@ export class ScrapingTools {
     fetcher?: string;
   }): Promise<Any> {
     const settings = ScrapingSettingsManager.loadSettings();
+    const normalizedUrl = this.ensureNetworkAllowed(input.url, "scrape_extract");
 
     this.daemon.logEvent(this.taskId, "log", {
-      message: `Extracting structured data from: ${input.url}`,
+      message: `Extracting structured data from: ${normalizedUrl}`,
     });
 
     const params: Record<string, Any> = {
       ...input,
+      url: normalizedUrl,
       fetcher: input.fetcher || settings.defaultFetcher,
     };
 
@@ -347,7 +374,7 @@ export class ScrapingTools {
     this.daemon.logEvent(this.taskId, "tool_result", {
       tool: "scrape_extract",
       result: {
-        url: input.url,
+        url: normalizedUrl,
         success: result.success,
         extractType: input.extract_type || "auto",
       },
@@ -367,13 +394,18 @@ export class ScrapingTools {
     headless?: boolean;
   }): Promise<Any> {
     const settings = ScrapingSettingsManager.loadSettings();
+    const steps = input.steps.map((step) => ({
+      ...step,
+      ...(step.url ? { url: this.ensureNetworkAllowed(step.url, "scrape_session") } : {}),
+    }));
 
     this.daemon.logEvent(this.taskId, "log", {
-      message: `Running scraping session with ${input.steps.length} steps`,
+      message: `Running scraping session with ${steps.length} steps`,
     });
 
     const params: Record<string, Any> = {
       ...input,
+      steps,
       headless: input.headless ?? settings.headless,
     };
 
@@ -383,7 +415,7 @@ export class ScrapingTools {
       tool: "scrape_session",
       result: {
         success: result.success,
-        stepCount: input.steps.length,
+        stepCount: steps.length,
       },
     });
 

--- a/src/electron/agent/tools/web-fetch-tools.ts
+++ b/src/electron/agent/tools/web-fetch-tools.ts
@@ -24,13 +24,76 @@ export class WebFetchTools {
   }
 
   private ensureDomainAllowed(url: string): void {
-    const decision = evaluateNetworkPolicy({ url, toolName: "web_fetch" });
+    this.ensureNetworkAllowed(url, "web_fetch");
+  }
+
+  private ensureNetworkAllowed(url: string, toolName: string): void {
+    const decision = evaluateNetworkPolicy({ url, toolName });
     this.daemon.logEvent(this.taskId, "network_policy_decision", decision);
     if (decision.action === "allow") return;
     if (decision.reason === "legacy_guardrail_domain_denied") {
       throw new Error(`Domain not allowed: "${url}"`);
     }
     throw new Error(`Network access denied for "${url}": ${decision.reason}`);
+  }
+
+  private async fetchWithPolicyCheckedRedirects(
+    url: string,
+    init: RequestInit,
+    toolName: string,
+    followRedirects = true,
+  ): Promise<Response> {
+    let currentUrl = url;
+    let currentInit: RequestInit = { ...init };
+
+    for (let redirectCount = 0; redirectCount <= 10; redirectCount += 1) {
+      const parsedUrl = new URL(currentUrl);
+      if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+        throw new Error("Only HTTP and HTTPS URLs are supported");
+      }
+      this.ensureNetworkAllowed(parsedUrl.toString(), toolName);
+
+      const response = await fetch(currentUrl, {
+        ...currentInit,
+        redirect: "manual",
+      });
+
+      if (!followRedirects || !this.isRedirectResponse(response.status)) {
+        return response;
+      }
+
+      const location = response.headers.get("location");
+      if (!location) {
+        return response;
+      }
+
+      const nextUrl = new URL(location, parsedUrl);
+      if (!["http:", "https:"].includes(nextUrl.protocol)) {
+        throw new Error("Only HTTP and HTTPS redirect URLs are supported");
+      }
+      this.ensureNetworkAllowed(nextUrl.toString(), toolName);
+
+      currentUrl = nextUrl.toString();
+      currentInit = this.buildRedirectInit(currentInit, response.status);
+    }
+
+    throw new Error("Too many redirects");
+  }
+
+  private isRedirectResponse(status: number): boolean {
+    return [301, 302, 303, 307, 308].includes(status);
+  }
+
+  private buildRedirectInit(init: RequestInit, status: number): RequestInit {
+    const method = String(init.method || "GET").toUpperCase();
+    if (status === 303 || ((status === 301 || status === 302) && method === "POST")) {
+      const { body: _body, ...rest } = init;
+      return {
+        ...rest,
+        method: "GET",
+      };
+    }
+    return { ...init };
   }
 
   /**
@@ -146,22 +209,24 @@ export class WebFetchTools {
       if (!["http:", "https:"].includes(parsedUrl.protocol)) {
         throw new Error("Only HTTP and HTTPS URLs are supported");
       }
-      this.ensureDomainAllowed(parsedUrl.toString());
 
       // Fetch with timeout
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 30000);
 
-      const response = await fetch(url, {
-        signal: controller.signal,
-        headers: {
-          "User-Agent":
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-          "Accept-Language": "en-US,en;q=0.9",
+      const response = await this.fetchWithPolicyCheckedRedirects(
+        url,
+        {
+          signal: controller.signal,
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+          },
         },
-        redirect: "follow",
-      });
+        "web_fetch",
+      );
 
       clearTimeout(timeout);
 
@@ -279,17 +344,6 @@ export class WebFetchTools {
       if (!["http:", "https:"].includes(parsedUrl.protocol)) {
         throw new Error("Only HTTP and HTTPS URLs are supported");
       }
-      const decision = evaluateNetworkPolicy({
-        url: parsedUrl.toString(),
-        toolName: "http_request",
-      });
-      this.daemon.logEvent(this.taskId, "network_policy_decision", decision);
-      if (decision.action !== "allow") {
-        if (decision.reason === "legacy_guardrail_domain_denied") {
-          throw new Error(`Domain not allowed: "${parsedUrl.toString()}"`);
-        }
-        throw new Error(`Network access denied for "${parsedUrl.toString()}": ${decision.reason}`);
-      }
 
       // Setup abort controller for timeout
       const controller = new AbortController();
@@ -305,13 +359,17 @@ export class WebFetchTools {
       };
 
       // Make the request
-      const response = await fetch(normalizedUrl, {
-        method,
-        headers: requestHeaders,
-        body: ["POST", "PUT", "PATCH"].includes(method) ? body : undefined,
-        signal: controller.signal,
-        redirect: followRedirects ? "follow" : "manual",
-      });
+      const response = await this.fetchWithPolicyCheckedRedirects(
+        normalizedUrl,
+        {
+          method,
+          headers: requestHeaders,
+          body: ["POST", "PUT", "PATCH"].includes(method) ? body : undefined,
+          signal: controller.signal,
+        },
+        "http_request",
+        followRedirects,
+      );
 
       clearTimeout(timeoutId);
 

--- a/src/electron/utils/__tests__/html-preview-assets.test.ts
+++ b/src/electron/utils/__tests__/html-preview-assets.test.ts
@@ -94,4 +94,25 @@ describe("inlineLocalHtmlPreviewAssets", () => {
     expect(result).not.toContain('href="/assets/app.css"');
     expect(result).not.toContain('src="/assets/app.js"');
   });
+
+  it("does not inline symlinked assets that resolve outside the workspace", async () => {
+    const workspace = path.join(tempRoot, "workspace");
+    const outside = path.join(tempRoot, "outside");
+    const pageDir = path.join(workspace, ".cowork");
+    await fs.mkdir(pageDir, { recursive: true });
+    await fs.mkdir(outside, { recursive: true });
+    await fs.writeFile(path.join(outside, "secret.css"), "body { background: secret; }");
+    await fs.symlink(path.join(outside, "secret.css"), path.join(pageDir, "secret.css"));
+    const htmlPath = path.join(pageDir, "index.html");
+    const html = '<link rel="stylesheet" href="secret.css">';
+
+    const result = await inlineLocalHtmlPreviewAssets({
+      htmlContent: html,
+      htmlFilePath: htmlPath,
+      workspaceRoot: workspace,
+    });
+
+    expect(result).toBe(html);
+    expect(result).not.toContain("background: secret");
+  });
 });

--- a/src/electron/utils/html-preview-assets.ts
+++ b/src/electron/utils/html-preview-assets.ts
@@ -10,6 +10,7 @@ type InlineHtmlPreviewAssetsOptions = {
   workspaceRoot?: string;
   readTextFile?: (filePath: string) => Promise<string>;
   statFile?: (filePath: string) => Promise<{ size: number }>;
+  realpathFile?: (filePath: string) => Promise<string>;
 };
 
 const STYLE_LINK_RE = /<link\b[^>]*>/gi;
@@ -65,14 +66,26 @@ async function readInlineableAsset(
   assetPath: string,
   state: {
     totalBytes: number;
+    workspaceRoot?: string;
     readTextFile: (filePath: string) => Promise<string>;
     statFile: (filePath: string) => Promise<{ size: number }>;
+    realpathFile: (filePath: string) => Promise<string>;
   },
 ): Promise<string | null> {
-  const stat = await state.statFile(assetPath);
+  let readablePath = assetPath;
+  if (state.workspaceRoot) {
+    const [realWorkspaceRoot, realAssetPath] = await Promise.all([
+      state.realpathFile(state.workspaceRoot),
+      state.realpathFile(assetPath),
+    ]);
+    const relative = path.relative(realWorkspaceRoot, realAssetPath);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) return null;
+    readablePath = realAssetPath;
+  }
+  const stat = await state.statFile(readablePath);
   if (stat.size > MAX_INLINE_ASSET_BYTES) return null;
   if (state.totalBytes + stat.size > MAX_TOTAL_INLINE_ASSET_BYTES) return null;
-  const content = await state.readTextFile(assetPath);
+  const content = await state.readTextFile(readablePath);
   state.totalBytes += stat.size;
   return content;
 }
@@ -83,9 +96,10 @@ export async function inlineLocalHtmlPreviewAssets({
   workspaceRoot,
   readTextFile = (filePath) => fs.readFile(filePath, "utf-8"),
   statFile = (filePath) => fs.stat(filePath),
+  realpathFile = (filePath) => fs.realpath(filePath),
 }: InlineHtmlPreviewAssetsOptions): Promise<string> {
   const baseDir = path.dirname(htmlFilePath);
-  const state = { totalBytes: 0, readTextFile, statFile };
+  const state = { totalBytes: 0, workspaceRoot, readTextFile, statFile, realpathFile };
   let output = htmlContent;
 
   const styleReplacements: Array<{ tag: string; replacement: string }> = [];


### PR DESCRIPTION
## Summary
- harden web fetch handling around redirects, response body limits, and content extraction
- add scraping tool regression coverage
- preserve preview asset URL handling for HTML previews

## Validation
- npx vitest run src/electron/agent/tools/__tests__/web-fetch-tools.test.ts src/electron/agent/tools/__tests__/scraping-tools.test.ts src/electron/utils/__tests__/html-preview-assets.test.ts
- npm run build:electron