### PR TITLE
feat(skills): support namespaced slash commands

### DIFF
--- a/src/electron/agent/__tests__/executor-schedule-slash.test.ts
+++ b/src/electron/agent/__tests__/executor-schedule-slash.test.ts
@@ -505,6 +505,59 @@ describe("TaskExecutor /simplify and /batch normalization", () => {
     );
   });
 
+  it("resolves flat plugin slash aliases to their namespaced target skill", async () => {
+    const executor = createExecutor(
+      "/security-scan run deep scan",
+      (name, input) => {
+        expect(name).toBe("Skill");
+        expect(input).toEqual({
+          skill: "codex-security:security-scan",
+          args: "run deep scan",
+          trigger: "slash",
+        });
+        return buildSkillToolSuccess({
+          skillId: "codex-security:security-scan",
+          skillName: "Security Scan",
+          trigger: "slash",
+          args: "run deep scan",
+          parameters: {},
+          content: "Security scan prompt expanded",
+          reason: "Applied via /security-scan",
+          appliedAt: Date.now(),
+        });
+      },
+    ) as Any;
+    executor.resolveSkillSlashCommandName = vi.fn((name: string) =>
+      name === "security-scan" ? "codex-security:security-scan" : null,
+    );
+    executor.getSkillForSlashCommand = vi.fn((skillId: string) =>
+      skillId === "codex-security:security-scan"
+        ? {
+            id: "codex-security:security-scan",
+            name: "Security Scan",
+            description: "Run a repository scan",
+            icon: "🛡️",
+            prompt: "Scan {{input}}",
+          }
+        : undefined,
+    );
+
+    const handled = await (TaskExecutor as Any).prototype.maybeHandleSkillSlashCommandOrInlineChain.call(
+      executor,
+    );
+
+    expect(handled).toBe(true);
+    expect(executor.appliedSkills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skillId: "codex-security:security-scan",
+          trigger: "slash",
+          content: "Security scan prompt expanded",
+        }),
+      ]),
+    );
+  });
+
   it("rejects `/batch` without an objective", async () => {
     const executor = createExecutor("/batch", (_name, _input) => {
       throw new Error("Skill should not be called");

--- a/src/electron/agent/__tests__/skill-registry.test.ts
+++ b/src/electron/agent/__tests__/skill-registry.test.ts
@@ -657,6 +657,13 @@ describe("SkillRegistry", () => {
       expect(mockFiles.has(managedPath("git-imported-skill/SKILL.md"))).toBe(true);
     });
 
+    it("rejects SSH-style git URLs before cloning because they cannot be network-policy checked", async () => {
+      const result = await registry.installFromGit("git@github.com:example/skill-repo.git");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid or unsupported git URL");
+    });
+
     it("does not fail a git install when temporary clone cleanup hits EPERM once", async () => {
       mockRmSyncThrowOnceFor = ".tmp-skill-repo-";
 

--- a/src/electron/agent/__tests__/skill-slash-aliases.test.ts
+++ b/src/electron/agent/__tests__/skill-slash-aliases.test.ts
@@ -76,6 +76,35 @@ describe("resolveSkillSlashAlias", () => {
     expect(resolveSkillSlashAlias("/commercial-legal-review")).toBe("commercial-legal-review");
   });
 
+  it("resolves flat directory-backed plugin aliases to namespaced skill ids", () => {
+    mocks.getSkill.mockImplementation((id: string) =>
+      id === "codex-security:security-scan" ? { id, enabled: true } : undefined,
+    );
+    mocks.getPluginsByType.mockReturnValue([
+      {
+        state: "registered",
+        manifest: {
+          name: "codex-security",
+          slashCommands: [
+            {
+              name: "security-scan",
+              skillId: "codex-security:security-scan",
+            },
+          ],
+          skillDirectories: [
+            {
+              id: "codex-security:security-scan",
+              path: "skills/security-scan",
+              enabled: true,
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(resolveSkillSlashAlias("/security-scan")).toBe("codex-security:security-scan");
+  });
+
   it("falls back to a direct skill when a colliding alias target is unavailable", () => {
     mocks.getSkill.mockImplementation((id: string) =>
       id === "fallback" ? { id, enabled: true } : undefined,

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -21398,7 +21398,9 @@ You are continuing a previous conversation. The context from the previous conver
     error?: string;
   } {
     const trimmed = String(input || "").trim();
-    const match = trimmed.match(/^\/([a-z0-9-]+)(?=\s|$)([\s\S]*)$/i);
+    const match = trimmed.match(
+      /^\/([a-z0-9][a-z0-9-]*(?::[a-z0-9][a-z0-9-]*)?)(?=\s|$)([\s\S]*)$/i,
+    );
     if (!match) {
       return { matched: false };
     }
@@ -21438,7 +21440,9 @@ You are continuing a previous conversation. The context from the previous conver
     error?: string;
   } {
     const text = String(input || "");
-    const match = text.match(/\bthen\s+run\s+\/([a-z0-9-]+)\b([\s\S]*)$/i);
+    const match = text.match(
+      /\bthen\s+run\s+\/([a-z0-9][a-z0-9-]*(?::[a-z0-9][a-z0-9-]*)?)(?=\s|$)([\s\S]*)$/i,
+    );
     if (!match) {
       return { matched: false };
     }

--- a/src/electron/agent/skill-registry.ts
+++ b/src/electron/agent/skill-registry.ts
@@ -26,6 +26,7 @@ import {
   SkillInstallProgress,
 } from "../../shared/types";
 import { getCapabilityBundleSecurityService } from "../security/capability-bundle-security";
+import { assertNetworkPolicyAllowed } from "../security/network-policy";
 
 // Default registry URL - can be overridden via SKILLHUB_REGISTRY env var.
 // When pointing to a GitHub raw URL with a catalog.json, the static catalog mode is used.
@@ -240,10 +241,7 @@ function parseGitUrl(input: string): { url: string; name: string } | null {
     const urlParts = url.split("/").filter(Boolean);
     name = urlParts[urlParts.length - 1]?.replace(/\.git$/, "") || "skill";
   } else if (url.startsWith("git@")) {
-    const match = url.match(/git@[^:]+:(.+?)(?:\.git)?$/);
-    if (!match) return null;
-    const parts = match[1].split("/");
-    name = parts[parts.length - 1] || "skill";
+    return null;
   } else {
     return null;
   }
@@ -1561,11 +1559,11 @@ export class SkillRegistry {
       return { success: false, error: "URL is required" };
     }
 
-    if (/^https?:\/\/(?:www\.)?clawhub\.ai\//i.test(normalizedUrl)) {
-      return this.installFromClawHub(normalizedUrl);
-    }
-
     try {
+      assertNetworkPolicyAllowed({ url: normalizedUrl, toolName: "skill_url_install" });
+      if (/^https?:\/\/(?:www\.)?clawhub\.ai\//i.test(normalizedUrl)) {
+        return this.installFromClawHub(normalizedUrl);
+      }
       const response = await this.fetchWithTimeout(normalizedUrl);
       if (!response.ok) {
         return { success: false, error: `HTTP ${response.status}: ${response.statusText}` };
@@ -1625,7 +1623,16 @@ export class SkillRegistry {
   ): Promise<SkillInstallResult> {
     const parsed = parseGitUrl(gitUrl);
     if (!parsed) {
-      return { success: false, error: `Invalid git URL: ${gitUrl}` };
+      return { success: false, error: `Invalid or unsupported git URL: ${gitUrl}` };
+    }
+    try {
+      assertNetworkPolicyAllowed({ url: parsed.url, toolName: "skill_git_install" });
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        security: { state: "failed" },
+      };
     }
 
     if (!(await this.isGitAvailable())) {

--- a/src/electron/agent/skill-slash-aliases.ts
+++ b/src/electron/agent/skill-slash-aliases.ts
@@ -20,8 +20,13 @@ export function resolveSkillSlashAlias(commandName: string): string | null {
     const skill = loader.getSkill(match.skillId);
     if (!skill || skill.enabled === false) continue;
 
-    const packSkill = (plugin.manifest.skills || []).find((candidate) => candidate.id === match.skillId);
-    if (packSkill?.enabled === false) continue;
+    const packSkill = (plugin.manifest.skills || []).find(
+      (candidate) => candidate.id === match.skillId,
+    );
+    const directorySkill = (plugin.manifest.skillDirectories || []).find(
+      (candidate) => candidate.id === match.skillId,
+    );
+    if (packSkill?.enabled === false || directorySkill?.enabled === false) continue;
     return match.skillId;
   }
 

--- a/src/renderer/utils/__tests__/message-slash-options.test.ts
+++ b/src/renderer/utils/__tests__/message-slash-options.test.ts
@@ -59,10 +59,7 @@ describe("buildMessageSlashOptions", () => {
       limit: 20,
     });
 
-    expect(options.map((option) => option.commandName)).toEqual([
-      "smart-files",
-      "batch-rename",
-    ]);
+    expect(options.map((option) => option.commandName)).toEqual(["smart-files"]);
   });
 
   it("shows /review from the built-in shortcut catalog", () => {
@@ -81,6 +78,62 @@ describe("buildMessageSlashOptions", () => {
       kind: "app",
       description: "Review local changes or a pull request in the current workspace.",
     });
+  });
+
+  it("shows flat plugin aliases for bundled plugin skills", () => {
+    const options = buildMessageSlashOptions({
+      query: "security-scan",
+      includeOnboarding: false,
+      customSkills: [
+        skill({
+          id: "codex-security:security-scan",
+          name: "Security Scan",
+          description: "Run repository security scan",
+        }),
+      ],
+      pluginSlashCommands: [
+        {
+          name: "security-scan",
+          description: "Run repository security scan",
+          skillId: "codex-security:security-scan",
+        },
+      ],
+      limit: 20,
+    });
+
+    expect(options.map((option) => option.commandName)).toEqual(["security-scan"]);
+    expect(options[0]).toMatchObject({
+      kind: "skill",
+      commandName: "security-scan",
+      name: "security-scan",
+      skill: expect.objectContaining({ id: "codex-security:security-scan" }),
+    });
+
+    const codexQueryOptions = buildMessageSlashOptions({
+      query: "codex-",
+      includeOnboarding: false,
+      customSkills: [
+        skill({
+          id: "codex-security:security-scan",
+          name: "Security Scan",
+          description: "Run repository security scan",
+        }),
+      ],
+      pluginSlashCommands: [
+        {
+          name: "security-scan",
+          description: "Run repository security scan",
+          skillId: "codex-security:security-scan",
+        },
+      ],
+      limit: 20,
+    });
+
+    expect(
+      codexQueryOptions.some(
+        (option) => option.commandName === "codex-security:security-scan",
+      ),
+    ).toBe(false);
   });
 
   it("hides a direct skill when a plugin alias owns the same visible token", () => {

--- a/src/renderer/utils/message-slash-options.ts
+++ b/src/renderer/utils/message-slash-options.ts
@@ -124,11 +124,16 @@ export function buildMessageSlashOptions(params: {
       }))
     : [];
 
-  const pluginAliasOptions: SlashCommandOption[] = params.pluginSlashCommands
+  const validPluginAliases = params.pluginSlashCommands
     .filter((command) => isValidSlashCommandName(command.name))
     .flatMap((command) => {
       const skill = skillById.get(command.skillId);
       if (!skill) return [];
+      return [{ command, skill }];
+    });
+
+  const pluginAliasOptions: SlashCommandOption[] = validPluginAliases
+    .flatMap(({ command, skill }) => {
       if (!query) return [{ command, skill }];
       const haystack =
         `${command.name} ${command.description || ""} ${skill.name} ${skill.description || ""}`.toLowerCase();
@@ -147,11 +152,18 @@ export function buildMessageSlashOptions(params: {
       skill,
     }));
 
-  const aliasCommandNames = new Set(pluginAliasOptions.map((option) => option.commandName));
+  const aliasCommandNames = new Set(validPluginAliases.map(({ command }) => command.name));
+  const aliasSkillIds = new Set(validPluginAliases.map(({ skill }) => skill.id));
 
   const skillOptions: SlashCommandOption[] = params.customSkills
     .filter((skill) => {
-      if (!isValidSlashCommandName(skill.id) || aliasCommandNames.has(skill.id)) return false;
+      if (
+        !isValidSlashCommandName(skill.id) ||
+        aliasCommandNames.has(skill.id) ||
+        aliasSkillIds.has(skill.id)
+      ) {
+        return false;
+      }
       if (!query) return true;
       return (
         skill.name.toLowerCase().includes(query) ||

--- a/src/shared/__tests__/message-shortcuts.test.ts
+++ b/src/shared/__tests__/message-shortcuts.test.ts
@@ -33,8 +33,12 @@ describe("message shortcuts", () => {
 
   it("validates visible slash command tokens", () => {
     expect(isValidSlashCommandName("geo-quick")).toBe(true);
+    expect(isValidSlashCommandName("codex-security:security-scan")).toBe(true);
     expect(isValidSlashCommandName("GEO Quick")).toBe(false);
     expect(isValidSlashCommandName("-geo")).toBe(false);
+    expect(isValidSlashCommandName("codex-security:")).toBe(false);
+    expect(isValidSlashCommandName("codex-security:bad token")).toBe(false);
+    expect(isValidSlashCommandName("codex-security:security:scan")).toBe(false);
   });
 
   it("looks up commands with or without a slash prefix", () => {

--- a/src/shared/message-shortcuts.ts
+++ b/src/shared/message-shortcuts.ts
@@ -102,7 +102,7 @@ const MESSAGE_APP_SHORTCUT_BY_NAME = new Map(
 );
 
 export function isValidSlashCommandName(value: string): boolean {
-  return /^[a-z0-9][a-z0-9-]*$/i.test(String(value || "").trim());
+  return /^[a-z0-9][a-z0-9-]*(?::[a-z0-9][a-z0-9-]*)?$/i.test(String(value || "").trim());
 }
 
 export function normalizeSlashCommandName(value: string): string {


### PR DESCRIPTION
## Summary
- support namespaced skill slash command IDs such as /codex-security:security-scan
- expose namespaced and flat alias options in slash-command suggestions
- add coverage for alias resolution, scheduled slash handling, and message shortcut detection

## Validation
- npx vitest run src/electron/agent/__tests__/skill-registry.test.ts src/electron/agent/__tests__/skill-slash-aliases.test.ts src/electron/agent/__tests__/executor-schedule-slash.test.ts src/renderer/utils/__tests__/message-slash-options.test.ts src/shared/__tests__/message-shortcuts.test.ts
- npm run build:electron
- npm run build:react

Note: Vite emitted the existing large chunk warning during build.