### PR TITLE
fix(executor): harden completion guardrails

### DIFF
--- a/src/electron/agent/__tests__/executor-command-requirement.test.ts
+++ b/src/electron/agent/__tests__/executor-command-requirement.test.ts
@@ -14,7 +14,10 @@ describe("TaskExecutor command execution requirement detection", () => {
       "Zscaler is open on my mac",
     ].join("\n");
 
-    const requires = (TaskExecutor as Any).prototype.detectExecutionRequirement.call(fakeThis, prompt);
+    const requires = (TaskExecutor as Any).prototype.detectExecutionRequirement.call(
+      fakeThis,
+      prompt,
+    );
     expect(requires).toBe(true);
   });
 
@@ -40,5 +43,116 @@ describe("TaskExecutor command execution requirement detection", () => {
       "ssh user@10.0.0.5 fails with connection refused. Please troubleshoot.",
     );
     expect(requires).toBe(false);
+  });
+
+  it("does not force shell execution for read-only documentation drift reports", () => {
+    const fakeThis: Any = Object.create((TaskExecutor as Any).prototype);
+    fakeThis.getEffectiveTaskDomain = () => "auto";
+    fakeThis.getEffectiveExecutionMode = () => "execute";
+
+    const prompt = [
+      "Check for documentation drift in CoWork OS.",
+      "Do not edit files.",
+      "Review current repo evidence and report docs that need updates, exact source of truth in code/config, suggested documentation change, and priority.",
+      "Look for stale commands, missing settings, and outdated behavior descriptions.",
+    ].join("\n");
+
+    const requires = (TaskExecutor as Any).prototype.detectExecutionRequirement.call(
+      fakeThis,
+      prompt,
+    );
+    expect(requires).toBe(false);
+  });
+
+  it("still requires shell execution when the prompt explicitly asks to run commands", () => {
+    const fakeThis: Any = Object.create((TaskExecutor as Any).prototype);
+    fakeThis.getEffectiveTaskDomain = () => "auto";
+    fakeThis.getEffectiveExecutionMode = () => "execute";
+
+    const prompt = [
+      "Check CoWork OS build health.",
+      "Run npm run lint and npm run build, then report exact command results.",
+    ].join("\n");
+
+    const requires = (TaskExecutor as Any).prototype.detectExecutionRequirement.call(
+      fakeThis,
+      prompt,
+    );
+    expect(requires).toBe(true);
+  });
+
+  it("does not exempt generic operational audits that explicitly need shell execution", () => {
+    const fakeThis: Any = Object.create((TaskExecutor as Any).prototype);
+    fakeThis.getEffectiveTaskDomain = () => "operations";
+    fakeThis.getEffectiveExecutionMode = () => "execute";
+
+    const prompt = [
+      "Troubleshoot backup health. Do not edit files.",
+      "Run the backup status command and report findings with priority.",
+      "The backup command fails intermittently with timeout errors.",
+    ].join("\n");
+
+    const requires = (TaskExecutor as Any).prototype.detectExecutionRequirement.call(
+      fakeThis,
+      prompt,
+    );
+    expect(requires).toBe(true);
+  });
+
+  it("does not force execution for any task with read-only constraints (daily briefing)", () => {
+    const fakeThis: Any = Object.create((TaskExecutor as Any).prototype);
+    fakeThis.getEffectiveTaskDomain = () => "auto";
+    fakeThis.getEffectiveExecutionMode = () => "execute";
+
+    const prompt = [
+      "Create my daily CoWork OS development brief.",
+      "Do not edit files, commit, push, publish, post externally, or change settings.",
+      "This routine is for situational awareness and prioritization only.",
+      "Inspect the local repo and summarize:",
+      "1. Current repo state - current branch, dirty files, untracked files",
+      "2. Health signals - whether there are obvious build/type/test blockers",
+      "3. Product/development priorities - read .cowork/PRIORITIES.md if present",
+      "4. Suggested work for today - top 3 tasks ordered by leverage",
+    ].join("\n");
+
+    const requires = (TaskExecutor as Any).prototype.detectExecutionRequirement.call(
+      fakeThis,
+      prompt,
+    );
+    expect(requires).toBe(false);
+  });
+
+  it("does not force execution for tasks with 'do not create files' constraint", () => {
+    const fakeThis: Any = Object.create((TaskExecutor as Any).prototype);
+    fakeThis.getEffectiveTaskDomain = () => "auto";
+    fakeThis.getEffectiveExecutionMode = () => "execute";
+
+    const prompt = [
+      "Analyze the codebase architecture. Don't edit any files.",
+      "Report back with a summary of how the modules are connected.",
+    ].join("\n");
+
+    const requires = (TaskExecutor as Any).prototype.detectExecutionRequirement.call(
+      fakeThis,
+      prompt,
+    );
+    expect(requires).toBe(false);
+  });
+
+  it("still requires execution when read-only but explicitly asks to run commands", () => {
+    const fakeThis: Any = Object.create((TaskExecutor as Any).prototype);
+    fakeThis.getEffectiveTaskDomain = () => "auto";
+    fakeThis.getEffectiveExecutionMode = () => "execute";
+
+    const prompt = [
+      "Do not edit files.",
+      "Run npm test and npm run build, then report the results.",
+    ].join("\n");
+
+    const requires = (TaskExecutor as Any).prototype.detectExecutionRequirement.call(
+      fakeThis,
+      prompt,
+    );
+    expect(requires).toBe(true);
   });
 });

--- a/src/electron/agent/__tests__/executor-completion-contract.test.ts
+++ b/src/electron/agent/__tests__/executor-completion-contract.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskExecutor } from "../executor";
+import {
+  buildCompletionGuidancePrompt,
+  detectReadOnlyConstraint,
+} from "../executor-completion-utils";
 
 type HarnessOptions = {
   prompt: string;
@@ -215,8 +219,10 @@ checklist_contract:
 
     const contract = (executor as Any).buildCompletionContract();
 
-    expect(contract.requiredArtifactExtensions).toContain(".md");
-    expect(contract.artifactKind).toBe("file");
+    // The heartbeat prompt mentions PRIORITIES.md as an input/target to update,
+    // but explicit-only extraction no longer infers .md as a required output extension.
+    // Artifact evidence is still satisfied because the task created the file.
+    expect(contract.requiredArtifactExtensions).toEqual([]);
     expect((executor as Any).hasArtifactEvidence(contract)).toBe(true);
   });
 
@@ -854,11 +860,37 @@ Verification complete: this routine produced a review-backed build-health conclu
         "Heartbeat dispatch completed. Checklist covered: CI/CD pipeline health, stalled planner-managed issues, and community discussions. No duplicate work was repeated.",
       planStepDescription: "Stalled planner-managed issues are reviewed for next action.",
     });
+    (executor as Any).toolResultMemory = [
+      { tool: "web_fetch", summary: "Fetched CI pipeline health", timestamp: Date.now() },
+      { tool: "web_search", summary: "Searched unresolved community questions", timestamp: Date.now() },
+    ];
 
     await (executor as Any).execute();
 
     expect(executor.daemon.completeTask).toHaveBeenCalledTimes(1);
     expect(executor.daemon.updateTask).not.toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "failed",
+        error: expect.stringContaining("missing verification evidence"),
+      }),
+    );
+  });
+
+  it("rejects completed review/check steps when no evidence tools were used", async () => {
+    const executor = createExecuteHarness({
+      title: "Heartbeat: Pending work detected",
+      prompt:
+        "Check CI/CD pipeline health, review stalled planner-managed issues, and scan unresolved community questions.",
+      lastOutput:
+        "Heartbeat dispatch completed. Checklist covered: CI/CD pipeline health, stalled planner-managed issues, and community discussions.",
+      planStepDescription: "Stalled planner-managed issues are reviewed for next action.",
+    });
+
+    await (executor as Any).execute();
+
+    expect(executor.daemon.completeTask).not.toHaveBeenCalled();
+    expect(executor.daemon.updateTask).toHaveBeenCalledWith(
       "task-1",
       expect.objectContaining({
         status: "failed",
@@ -883,6 +915,96 @@ Verification complete: this routine produced a review-backed build-health conclu
 
     expect(executor.daemon.completeTask).toHaveBeenCalledTimes(1);
     expect(executor.daemon.updateTask).not.toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "failed",
+        error: expect.stringContaining("missing verification evidence"),
+      }),
+    );
+  });
+
+  it("accepts structured documentation-drift reports when repo evidence tools were used", async () => {
+    const executor = createExecuteHarness({
+      title: "CoWork OS documentation drift check",
+      prompt:
+        "Review current repo evidence for documentation drift in CoWork OS. Do not edit files. Report docs that need updates, exact source of truth in code/config, suggested documentation change, and priority.",
+      lastOutput: `## Documentation Drift Report
+
+1. Docs that need updates: docs/automation.md
+- Source of truth in code/config: src/electron/cron/service.ts now restricts run_command when a scheduled job has shellAccess false.
+- Drift: the automation docs still describe scheduled tasks as if command execution is always available.
+- Suggested doc update: add the shellAccess false behavior and say read/list/search evidence is expected for no-edit review routines.
+- Priority: should fix`,
+      planStepDescription: "Gather current docs and source evidence",
+      source: "cron",
+    });
+    (executor as Any).toolResultMemory = [
+      {
+        tool: "read_file",
+        summary: "Read src/electron/cron/service.ts",
+        timestamp: Date.now(),
+      },
+      { tool: "grep", summary: "Searched docs for shellAccess", timestamp: Date.now() },
+    ];
+
+    await (executor as Any).execute();
+
+    expect(executor.daemon.completeTask).toHaveBeenCalledTimes(1);
+    expect(executor.daemon.updateTask).not.toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "failed",
+        error: expect.stringContaining("missing verification evidence"),
+      }),
+    );
+  });
+
+  it("rejects structured documentation-drift labels without repo evidence tools", async () => {
+    const executor = createExecuteHarness({
+      title: "CoWork OS documentation drift check",
+      prompt:
+        "Review current repo evidence for documentation drift in CoWork OS. Do not edit files. Report docs that need updates, exact source of truth in code/config, suggested documentation change, and priority.",
+      lastOutput: `## Documentation Drift Report
+
+1. Docs that need updates: docs/automation.md
+- Source of truth in code/config: src/electron/cron/service.ts
+- Drift: scheduled task docs are stale.
+- Suggested doc update: update the automation docs.
+- Priority: should fix`,
+      planStepDescription: "Gather current docs and source evidence",
+      source: "cron",
+    });
+
+    await (executor as Any).execute();
+
+    expect(executor.daemon.completeTask).not.toHaveBeenCalled();
+    expect(executor.daemon.updateTask).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        status: "failed",
+        error: expect.stringContaining("missing verification evidence"),
+      }),
+    );
+  });
+
+  it("rejects generic documentation-drift findings without repo evidence tools", async () => {
+    const executor = createExecuteHarness({
+      title: "CoWork OS documentation drift check",
+      prompt:
+        "Review current repo evidence for documentation drift in CoWork OS. Do not edit files. Report docs that need updates, exact source of truth in code/config, suggested documentation change, and priority.",
+      lastOutput: `## Findings
+
+I reviewed the documentation drift state.
+
+Recommendation: update docs/automation.md because scheduled task docs are stale.`,
+      planStepDescription: "Gather current docs and source evidence",
+      source: "cron",
+    });
+
+    await (executor as Any).execute();
+
+    expect(executor.daemon.completeTask).not.toHaveBeenCalled();
+    expect(executor.daemon.updateTask).toHaveBeenCalledWith(
       "task-1",
       expect.objectContaining({
         status: "failed",
@@ -1418,6 +1540,9 @@ Verification complete: this routine produced a review-backed build-health conclu
       createdFiles: [],
       planStepDescription: "Review transcript and recommend",
     });
+    (executor as Any).toolResultMemory = [
+      { tool: "web_fetch", summary: "Fetched transcript evidence", timestamp: Date.now() },
+    ];
 
     await (executor as Any).execute();
 
@@ -1561,5 +1686,124 @@ Verification complete: this routine produced a review-backed build-health conclu
         waiveFailedStepIds: ["1"],
       }),
     );
+  });
+
+  it("suppresses artifact requirements when prompt has read-only constraint", () => {
+    const executor = createExecuteHarness({
+      title: "Daily CoWork OS Project Brief",
+      prompt: [
+        "Create my daily CoWork OS development brief.",
+        "Do not edit files, commit, push, publish, post externally, or change settings.",
+        "This routine is for situational awareness and prioritization only.",
+        "read .cowork/PRIORITIES.md if present",
+        "compare current repo state against the active priorities",
+      ].join("\n"),
+      lastOutput: "Daily brief prepared.",
+    });
+
+    const contract = (executor as Any).buildCompletionContract();
+
+    expect(contract.requiresArtifactEvidence).toBe(false);
+    expect(contract.requiredArtifactExtensions).toEqual([]);
+    expect(contract.artifactKind).toBe("none");
+  });
+
+  it("suppresses artifact requirements with don't edit variant", () => {
+    const executor = createExecuteHarness({
+      title: "Architecture review",
+      prompt: "Analyze the codebase architecture. Don't edit any files. Report back with a summary.",
+      lastOutput: "Architecture summary.",
+    });
+
+    const contract = (executor as Any).buildCompletionContract();
+
+    expect(contract.requiresArtifactEvidence).toBe(false);
+    expect(contract.requiredArtifactExtensions).toEqual([]);
+    expect(contract.artifactKind).toBe("none");
+  });
+
+  it("still requires artifacts when read-only constraint is absent", () => {
+    const executor = createExecuteHarness({
+      title: "Research report",
+      prompt: "Research AI agent trends and compile a comprehensive report.",
+      lastOutput: "Report prepared.",
+    });
+
+    const contract = (executor as Any).buildCompletionContract();
+
+    expect(contract.requiresArtifactEvidence).toBe(true);
+  });
+
+  it("does not false-positive on 'fix the read-only permission issue'", () => {
+    expect(detectReadOnlyConstraint("Fix the read-only permission issue on the database.")).toBe(
+      false,
+    );
+  });
+
+  it("does not false-positive on 'database is in read-only mode, fix it'", () => {
+    expect(
+      detectReadOnlyConstraint(
+        "The database is in read-only mode, fix it so writes work again.",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not false-positive on 'debug the read-only access error'", () => {
+    expect(detectReadOnlyConstraint("Debug the read-only access error users are reporting.")).toBe(
+      false,
+    );
+  });
+
+  it("detects read-only constraint in 'this task is read-only'", () => {
+    expect(detectReadOnlyConstraint("This task is read-only. Just analyze and report.")).toBe(true);
+  });
+});
+
+describe("buildCompletionGuidancePrompt", () => {
+  it("includes read-only warning when hasReadOnlyConstraint is true", () => {
+    const result = buildCompletionGuidancePrompt({
+      hasReadOnlyConstraint: true,
+      explicitOutputExtensions: [],
+      likelyRequiresExecution: false,
+    });
+    expect(result).toContain("read-only constraints");
+    expect(result).toContain("Do NOT create, modify, or delete files");
+  });
+
+  it("includes extension format guidance when extensions are specified", () => {
+    const result = buildCompletionGuidancePrompt({
+      hasReadOnlyConstraint: false,
+      explicitOutputExtensions: [".pdf", ".xlsx"],
+      likelyRequiresExecution: false,
+    });
+    expect(result).toContain(".pdf, .xlsx");
+  });
+
+  it("includes execution guidance when likelyRequiresExecution is true", () => {
+    const result = buildCompletionGuidancePrompt({
+      hasReadOnlyConstraint: false,
+      explicitOutputExtensions: [],
+      likelyRequiresExecution: true,
+    });
+    expect(result).toContain("run_command");
+  });
+
+  it("omits execution guidance when hasReadOnlyConstraint is true", () => {
+    const result = buildCompletionGuidancePrompt({
+      hasReadOnlyConstraint: true,
+      explicitOutputExtensions: [],
+      likelyRequiresExecution: true,
+    });
+    expect(result).not.toContain("run_command");
+  });
+
+  it("always includes core guidance", () => {
+    const result = buildCompletionGuidancePrompt({
+      hasReadOnlyConstraint: false,
+      explicitOutputExtensions: [],
+      likelyRequiresExecution: false,
+    });
+    expect(result).toContain("TASK COMPLETION GUIDANCE");
+    expect(result).toContain("Never fabricate tool output");
   });
 });

--- a/src/electron/agent/__tests__/file-mutation-verifier.test.ts
+++ b/src/electron/agent/__tests__/file-mutation-verifier.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { FileMutationVerifier } from "../file-mutation-verifier";
+
+describe("FileMutationVerifier", () => {
+  it("reports no discrepancy when write_file succeeds", () => {
+    const verifier = new FileMutationVerifier();
+    verifier.recordMutationResult({
+      toolName: "write_file",
+      input: { path: "output/report.md" },
+      succeeded: true,
+    });
+
+    expect(verifier.getFailedMutations()).toHaveLength(0);
+    expect(verifier.buildAdvisoryFooter()).toBeNull();
+  });
+
+  it("reports discrepancy when write_file fails", () => {
+    const verifier = new FileMutationVerifier();
+    verifier.recordMutationResult({
+      toolName: "write_file",
+      input: { path: "output/report.md" },
+      succeeded: false,
+      error: "Permission denied",
+    });
+
+    const failed = verifier.getFailedMutations();
+    expect(failed).toHaveLength(1);
+    expect(failed[0].targetPath).toBe("output/report.md");
+    expect(failed[0].errorPreview).toBe("Permission denied");
+
+    const footer = verifier.buildAdvisoryFooter();
+    expect(footer).toContain("1 file(s) were NOT modified");
+    expect(footer).toContain("output/report.md");
+    expect(footer).toContain("Permission denied");
+  });
+
+  it("clears prior failure when same path succeeds (self-correction)", () => {
+    const verifier = new FileMutationVerifier();
+    verifier.recordMutationResult({
+      toolName: "write_file",
+      input: { path: "output/report.md" },
+      succeeded: false,
+      error: "Syntax error in content",
+    });
+    verifier.recordMutationResult({
+      toolName: "write_file",
+      input: { path: "output/report.md" },
+      succeeded: true,
+    });
+
+    expect(verifier.getFailedMutations()).toHaveLength(0);
+    expect(verifier.buildAdvisoryFooter()).toBeNull();
+  });
+
+  it("tracks multiple failures in the footer", () => {
+    const verifier = new FileMutationVerifier();
+    verifier.recordMutationResult({
+      toolName: "write_file",
+      input: { path: "a.txt" },
+      succeeded: false,
+      error: "Error 1",
+    });
+    verifier.recordMutationResult({
+      toolName: "edit_file",
+      input: { path: "b.ts" },
+      succeeded: false,
+      error: "Error 2",
+    });
+
+    const footer = verifier.buildAdvisoryFooter();
+    expect(footer).toContain("2 file(s) were NOT modified");
+    expect(footer).toContain("a.txt");
+    expect(footer).toContain("b.ts");
+  });
+
+  it("returns null footer when no mutations recorded", () => {
+    const verifier = new FileMutationVerifier();
+    expect(verifier.buildAdvisoryFooter()).toBeNull();
+  });
+
+  it("clears state on reset", () => {
+    const verifier = new FileMutationVerifier();
+    verifier.recordMutationResult({
+      toolName: "write_file",
+      input: { path: "file.txt" },
+      succeeded: false,
+      error: "Failed",
+    });
+    expect(verifier.getFailedMutations()).toHaveLength(1);
+
+    verifier.reset();
+    expect(verifier.getFailedMutations()).toHaveLength(0);
+    expect(verifier.buildAdvisoryFooter()).toBeNull();
+  });
+
+  it("extracts path from various input field names", () => {
+    const verifier = new FileMutationVerifier();
+    const fields = [
+      { path: "a.txt" },
+      { filename: "b.txt" },
+      { destination: "c.txt" },
+      { file_path: "d.txt" },
+      { target: "e.txt" },
+      { outputPath: "f.txt" },
+    ];
+
+    for (const input of fields) {
+      verifier.recordMutationResult({
+        toolName: "write_file",
+        input,
+        succeeded: false,
+        error: "fail",
+      });
+    }
+
+    const failed = verifier.getFailedMutations();
+    expect(failed.map((m) => m.targetPath)).toEqual([
+      "a.txt", "b.txt", "c.txt", "d.txt", "e.txt", "f.txt",
+    ]);
+  });
+});

--- a/src/electron/agent/content/ContentBuilder.ts
+++ b/src/electron/agent/content/ContentBuilder.ts
@@ -28,6 +28,7 @@ export interface BuildExecutionPromptParams {
   visualQAContext?: string;
   personalityPrompt?: string;
   guidelinesPrompt?: string;
+  completionGuidancePrompt?: string;
   turnGuidancePrompt?: string;
   turnGuidanceMaxTokens?: number;
   coreInstructions?: string;
@@ -245,6 +246,12 @@ export class ContentBuilder {
           }),
           makeSection("web_search_contract", params.webSearchModeContract, 260, {
             required: true,
+            layerKind: "always",
+            cacheScope: "session",
+          }),
+          makeSection("completion_guidance", params.completionGuidancePrompt, 500, {
+            required: false,
+            dropPriority: 1,
             layerKind: "always",
             cacheScope: "session",
           }),

--- a/src/electron/agent/executor-completion-utils.ts
+++ b/src/electron/agent/executor-completion-utils.ts
@@ -17,6 +17,7 @@ const VERIFICATION_TOOL_EVIDENCE = new Set([
   "web_search",
   "web_fetch",
   "search_files",
+  "grep",
   "glob",
   "run_command",
   "http_request",
@@ -189,6 +190,155 @@ export function inferRequiredArtifactExtensions(taskTitle: string, taskPrompt: s
   return Array.from(extensions);
 }
 
+const EXPLICIT_OUTPUT_EXTENSION_SET = new Set([
+  "pdf", "docx", "md", "csv", "xlsx", "json", "jsonl",
+  "txt", "pptx", "mp4", "mov", "webm", "html",
+]);
+
+/**
+ * Extracts artifact extensions ONLY from explicit output-intent patterns —
+ * e.g. "save as .pdf", "export to .xlsx", "create a PDF report".
+ * Unlike inferRequiredArtifactExtensions() which scans the full prompt text,
+ * this function does NOT pick up extensions from input-context references
+ * like "read PRIORITIES.md".
+ */
+export function extractExplicitOutputExtensions(
+  taskTitle: string,
+  taskPrompt: string,
+): string[] {
+  const prompt = `${taskTitle}\n${normalizePromptForContracts(taskPrompt)}`.toLowerCase();
+  const extensions = new Set<string>();
+
+  // Pattern 1: "save/export/write/output ... to/as ... .ext"
+  const saveAsPattern =
+    /\b(?:save|export|write|output)\b[^.!?\n]{0,80}\b(?:to|as)\b[^.!?\n]{0,80}\.(\w{2,5})\b/gi;
+  let match = saveAsPattern.exec(prompt);
+  while (match) {
+    const ext = match[1]!;
+    if (EXPLICIT_OUTPUT_EXTENSION_SET.has(ext)) extensions.add(`.${ext}`);
+    match = saveAsPattern.exec(prompt);
+  }
+
+  // Pattern 2: "create/generate a PDF/DOCX/CSV file/document/report"
+  const createFormatPattern =
+    /\b(?:create|generate|produce|draft|build|write)\s+(?:a\s+|an\s+|the\s+)?(?:\w+\s+){0,3}(pdf|docx|xlsx|csv|pptx|txt|markdown|md)\s+(?:file|document|report|spreadsheet|deck)\b/gi;
+  match = createFormatPattern.exec(prompt);
+  while (match) {
+    let ext = match[1]!;
+    if (ext === "markdown") ext = "md";
+    if (EXPLICIT_OUTPUT_EXTENSION_SET.has(ext)) extensions.add(`.${ext}`);
+    match = createFormatPattern.exec(prompt);
+  }
+
+  // Pattern 3: "write ... as a markdown file" / "write the findings as a markdown file"
+  const writeAsFormatPattern =
+    /\b(?:write|save|export)\b[^.!?\n]{0,60}\bas\s+(?:a\s+|an\s+)?(?:\w+\s+){0,2}(markdown|md|pdf|csv|json|txt|docx|xlsx|pptx)\s+(?:file|document|report)\b/gi;
+  match = writeAsFormatPattern.exec(prompt);
+  while (match) {
+    let ext = match[1]!;
+    if (ext === "markdown") ext = "md";
+    if (EXPLICIT_OUTPUT_EXTENSION_SET.has(ext)) extensions.add(`.${ext}`);
+    match = writeAsFormatPattern.exec(prompt);
+  }
+
+  // Pattern 4: Semantic format nouns in output-intent context
+  // "create a spreadsheet" → .xlsx, "generate a PDF" → .pdf, etc.
+  const semanticFormats: Array<[RegExp, string]> = [
+    [/\b(?:create|generate|build|produce)\s+(?:a\s+|an\s+|the\s+)?(?:\w+\s+){0,3}spreadsheet\b/i, ".xlsx"],
+    [/\b(?:create|generate|build|produce)\s+(?:a\s+|an\s+|the\s+)?(?:\w+\s+){0,3}excel\s+(?:file|workbook|spreadsheet|document)\b/i, ".xlsx"],
+    [/\b(?:create|generate|build|produce|export)\s+(?:a\s+|an\s+|the\s+)?(?:\w+\s+){0,3}pdf\b/i, ".pdf"],
+    [/\b(?:create|generate|build|produce|export)\s+(?:a\s+|an\s+|the\s+)?(?:\w+\s+){0,3}docx?\b/i, ".docx"],
+  ];
+  for (const [pattern, ext] of semanticFormats) {
+    if (pattern.test(prompt)) extensions.add(ext);
+  }
+
+  // Presentation detection still uses the dedicated function
+  if (promptRequestsPresentationArtifactOutput(taskTitle, taskPrompt)) {
+    extensions.add(".pptx");
+  }
+  if (promptRequestsVideoArtifactOutput(taskTitle, taskPrompt) && extensions.size === 0) {
+    extensions.add(".mp4");
+  }
+
+  return Array.from(extensions);
+}
+
+/**
+ * Builds dynamic completion guidance for injection into the system prompt.
+ * This is the Hermes-style behavioral steering layer — it tells the model
+ * how to handle task completion rather than enforcing it post-hoc.
+ */
+export function buildCompletionGuidancePrompt(opts: {
+  hasReadOnlyConstraint: boolean;
+  explicitOutputExtensions: string[];
+  likelyRequiresExecution: boolean;
+}): string {
+  const lines: string[] = [
+    "TASK COMPLETION GUIDANCE:",
+    "- When you create or modify files, use the appropriate write tool — do not describe what you would write without actually writing it.",
+    "- If a tool call fails, report the failure honestly and try an alternative approach. Never fabricate tool output.",
+    "- End with a substantive summary of what was accomplished, not just a status message.",
+  ];
+
+  if (opts.hasReadOnlyConstraint) {
+    lines.push(
+      "- IMPORTANT: This task has explicit read-only constraints. Do NOT create, modify, or delete files. Deliver all results as direct text output.",
+    );
+  }
+
+  if (opts.explicitOutputExtensions.length > 0) {
+    const exts = opts.explicitOutputExtensions.join(", ");
+    lines.push(
+      `- This task requests output in ${exts} format. Use the appropriate write tool and confirm the file was created successfully.`,
+    );
+  }
+
+  if (opts.likelyRequiresExecution && !opts.hasReadOnlyConstraint) {
+    lines.push(
+      "- This task likely expects command execution. Use run_command to execute commands rather than describing what commands to run.",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Detects whether the prompt contains an explicit read-only constraint
+ * (e.g. "do not edit files", "this is read-only", "without editing").
+ * When true, artifact and execution requirements are suppressed because
+ * the task should produce text output only, not file artifacts.
+ *
+ * "read-only" alone is NOT matched — it must appear as a constraint declaration
+ * (e.g. "this is read-only", "read-only mode"), not as a subject to fix
+ * (e.g. "fix the read-only permission", "database is in read-only mode, fix it").
+ */
+export function detectReadOnlyConstraint(prompt: string): boolean {
+  const lower = String(prompt || "").toLowerCase();
+
+  // Explicit "do not" / "don't" constraints — unambiguous
+  const hasExplicitConstraint =
+    /\b(?:do\s+not\s+(?:edit|create|modify|write)\s+(?:any\s+)?files?|do\s+not\s+make\s+(?:any\s+)?changes|no\s+file\s+changes|without\s+(?:editing|modifying|creating)|don'?t\s+(?:edit|create|modify|write)\s+(?:any\s+)?files?|situational\s+awareness\s+(?:only|mode))\b/.test(
+      lower,
+    );
+  if (hasExplicitConstraint) return true;
+
+  // "read-only" requires constraint context — must NOT be preceded by fix/debug verbs
+  // "fix the read-only issue" → false, "this task is read-only" → true
+  if (/\bread[- ]only\b/.test(lower)) {
+    const isSubjectToFix =
+      /\b(?:fix|repair|resolve|debug|troubleshoot|diagnose|investigate|restore|change|update|remove|disable|toggle|switch)\b[^.!?\n]{0,40}\bread[- ]only\b/.test(
+        lower,
+      ) ||
+      /\bread[- ]only\b[^.!?\n]{0,40}\b(?:fix|repair|resolve|broken|issue|problem|bug|error|fail)\b/.test(
+        lower,
+      );
+    if (!isSubjectToFix) return true;
+  }
+
+  return false;
+}
+
 export function buildCompletionContract(opts: {
   taskTitle: string;
   taskPrompt: string;
@@ -196,13 +346,18 @@ export function buildCompletionContract(opts: {
   requiresDecisionSignal: boolean;
   isWatchSkipRecommendationTask: boolean;
 }): CompletionContract {
+  const fullPrompt = `${opts.taskTitle}\n${normalizePromptForContracts(opts.taskPrompt)}`;
+  const hasReadOnlyConstraint = detectReadOnlyConstraint(fullPrompt);
+
   const requiresExecutionEvidence = shouldRequireExecutionEvidence(opts.taskTitle, opts.taskPrompt);
   const requiresCanvasArtifact = promptRequestsCanvasArtifactOutput(opts.taskTitle, opts.taskPrompt);
-  const requiredArtifactExtensions = inferRequiredArtifactExtensions(
-    opts.taskTitle,
-    opts.taskPrompt,
-  );
+  // Use explicit-only extraction: only picks up extensions from output-intent
+  // patterns (e.g. "save as .pdf"), not from input references (e.g. "read PRIORITIES.md").
+  const requiredArtifactExtensions = hasReadOnlyConstraint
+    ? []
+    : extractExplicitOutputExtensions(opts.taskTitle, opts.taskPrompt);
   const requiresArtifactEvidence =
+    !hasReadOnlyConstraint &&
     (promptRequestsArtifactOutput(opts.taskTitle, opts.taskPrompt) ||
       requiresCanvasArtifact ||
       requiredArtifactExtensions.length > 0) &&
@@ -214,11 +369,13 @@ export function buildCompletionContract(opts: {
     !opts.isWatchSkipRecommendationTask &&
     (hasExplicitCanvasCue || requiredArtifactExtensions.length === 0);
   const artifactKind: CompletionContract["artifactKind"] =
-    shouldTreatAsCanvasArtifact
-      ? "canvas"
-      : requiresArtifactEvidence
-        ? "file"
-        : "none";
+    hasReadOnlyConstraint
+      ? "none"
+      : shouldTreatAsCanvasArtifact
+        ? "canvas"
+        : requiresArtifactEvidence
+          ? "file"
+          : "none";
 
   // Only require canvas_push evidence when the prompt explicitly mentions "canvas".
   // Tasks detected as canvas via promptIsMultiFileWebAppCreation (e.g. "Create a website")
@@ -339,6 +496,50 @@ export function responseHasReasonedConclusionSignal(text: string): boolean {
     );
 
   return hasConclusionCue && hasReasoningCue;
+}
+
+export function responseHasReviewReportEvidenceSignal(text: string): boolean {
+  const normalized = String(text || "").toLowerCase();
+  if (!normalized.trim()) return false;
+
+  const hasAffectedDocumentation =
+    /\b(?:affected\s+(?:documentation|docs?)|docs?\s+(?:that\s+need|to\s+update)|readme\.md|docs\/|changelog\.md|agents\.md|package\.json)\b/.test(
+      normalized,
+    );
+  const hasSourceOfTruth =
+    /\b(?:source(?:\s+of\s+truth)?|source-of-truth|code\/config|current\s+(?:repo\s+)?(?:behavior|state)|fresh\s+evidence|repo\s+evidence)\b/.test(
+      normalized,
+    );
+  const hasMismatchOrFinding =
+    /\b(?:drift|mismatch|stale|outdated|missing|under-?documented|not\s+documented|finding|gap)\b/.test(
+      normalized,
+    );
+  const hasSuggestedDocChange =
+    /\b(?:suggested\s+(?:documentation|doc)\s+(?:change|update)|documentation\s+change|doc\s+update|update\s+(?:the\s+)?docs?|add\s+(?:to\s+)?docs?)\b/.test(
+      normalized,
+    );
+  const hasPriority =
+    /\b(?:priority|must\s+fix\s+before\s+release|should\s+fix|optional)\b/.test(normalized);
+  const hasReviewFraming =
+    /\b(?:documentation\s+drift|drift\s+(?:check|assessment|report)|review-backed|review\s+report|inspected|reviewed|checked)\b/.test(
+      normalized,
+    );
+
+  const matchedFieldCount = [
+    hasAffectedDocumentation,
+    hasSourceOfTruth,
+    hasMismatchOrFinding,
+    hasSuggestedDocChange,
+    hasPriority,
+    hasReviewFraming,
+  ].filter(Boolean).length;
+
+  return (
+    matchedFieldCount >= 4 &&
+    hasMismatchOrFinding &&
+    hasSuggestedDocChange &&
+    hasPriority
+  );
 }
 
 export function hasVerificationToolEvidence(
@@ -530,15 +731,18 @@ export function hasVerificationEvidence(opts: {
       (isVerificationStepDescription(step.description || "") ||
         COMPLETED_REVIEW_STEP_REGEX.test(step.description || "")),
   );
+  const hasToolEvidence = hasVerificationToolEvidence(opts.toolResultMemory);
 
-  const hasReviewBackedConclusion = responseHasVerificationSignal(opts.bestCandidate);
-  if (hasCompletedReviewStep || hasReviewBackedConclusion) {
+  if (responseHasExecutionReportEvidenceSignal(opts.bestCandidate)) {
     return true;
   }
 
   return (
-    hasVerificationToolEvidence(opts.toolResultMemory) &&
-    responseHasReasonedConclusionSignal(opts.bestCandidate)
+    hasToolEvidence &&
+    (hasCompletedReviewStep ||
+      responseHasVerificationSignal(opts.bestCandidate) ||
+      responseHasReasonedConclusionSignal(opts.bestCandidate) ||
+      responseHasReviewReportEvidenceSignal(opts.bestCandidate))
   );
 }
 

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -232,6 +232,7 @@ import {
   calculateBackoffDelay,
   sleep,
 } from "./executor-helpers";
+import { FileMutationVerifier } from "./file-mutation-verifier";
 import { ExecutorEventEmitter } from "./executor-event-emitter";
 import { createTimelineEmitter } from "./timeline-emitter";
 import { LifecycleMutex } from "./executor-lifecycle-mutex";
@@ -304,10 +305,14 @@ import {
   responseDirectlyAddressesPrompt as responseDirectlyAddressesPromptUtil,
   responseHasDecisionSignal as responseHasDecisionSignalUtil,
   responseHasReasonedConclusionSignal as responseHasReasonedConclusionSignalUtil,
+  responseHasReviewReportEvidenceSignal as responseHasReviewReportEvidenceSignalUtil,
   responseHasVerificationSignal as responseHasVerificationSignalUtil,
   responseLooksOperationalOnly as responseLooksOperationalOnlyUtil,
   shouldPreserveExistingDeliverableForRecovery as shouldPreserveExistingDeliverableForRecoveryUtil,
   shouldRequireExecutionEvidence as shouldRequireExecutionEvidenceUtil,
+  detectReadOnlyConstraint as detectReadOnlyConstraintUtil,
+  extractExplicitOutputExtensions as extractExplicitOutputExtensionsUtil,
+  buildCompletionGuidancePrompt as buildCompletionGuidancePromptUtil,
 } from "./executor-completion-utils";
 import {
   CANONICAL_ARTIFACT_EXTENSION_REGEX,
@@ -767,6 +772,7 @@ export class TaskExecutor {
   private toolFailureTracker: ToolFailureTracker;
   private toolCallDeduplicator: ToolCallDeduplicator;
   private fileOperationTracker: FileOperationTracker;
+  private fileMutationVerifier: FileMutationVerifier;
   private lastWebFetchFailure: {
     timestamp: number;
     tool: "web_fetch" | "http_request";
@@ -6536,6 +6542,7 @@ ${transcript}
 
     // Initialize file operation tracker to detect redundant reads and duplicate creations
     this.fileOperationTracker = new FileOperationTracker();
+    this.fileMutationVerifier = new FileMutationVerifier();
     this.initializeSessionRuntime();
 
     logger.info(
@@ -6655,16 +6662,22 @@ ${transcript}
   private getVisualQAContextPrompt(): string {
     if (!this.task) return "";
     const combined = `${this.task.title}\n${this.getContractPrompt()}`;
-    if (!this.detectVisualQARequirement(combined)) return "";
-    return [
-      "VISUAL QA REQUIRED FOR THIS TASK:",
-      "This task builds a web app AND has a testing/quality/shipping intent.",
-      "Your plan MUST include a 'Visual QA with Playwright' step after building.",
-      "Before QA: if you just scaffolded the project, run 'npm install' (or yarn/pnpm) via run_command first — NEVER skip this.",
-      "Use qa_run (with server_command if needed) to automatically test the app.",
-      "qa_run will start the server, launch a browser, take screenshots, and report bugs.",
-      "Fix any critical/major issues found, then re-run qa_run to confirm. Call qa_cleanup when done.",
-    ].join("\n");
+    const visualQARequired = this.detectVisualQARequirement(combined);
+    const sections = [
+      this.buildWebPagePreviewGuidancePrompt(combined),
+      visualQARequired
+        ? [
+            "VISUAL QA REQUIRED FOR THIS TASK:",
+            "This task builds a web app AND has a testing/quality/shipping intent.",
+            "Your plan MUST include a 'Visual QA with Playwright' step after building.",
+            "Before QA: if you just scaffolded the project, run 'npm install' (or yarn/pnpm) via run_command first - NEVER skip this.",
+            "Use qa_run (with server_command if needed) to automatically test the app.",
+            "qa_run will start the server, launch a browser, take screenshots, and report bugs.",
+            "Fix any critical/major issues found, then re-run qa_run to confirm. Call qa_cleanup when done.",
+          ].join("\n")
+        : "",
+    ].filter(Boolean);
+    return sections.join("\n\n");
   }
 
   private getInfraContextPrompt(): string {
@@ -9168,6 +9181,15 @@ ${transcript}
       "generate_video",
       "get_video_generation_job",
     ]);
+    // Record mutation result for the file mutation verifier (Hermes-style over-claiming detection).
+    if ((mutatingTools.has(toolName) || this.isFileMutationTool(toolName)) && this.fileMutationVerifier) {
+      this.fileMutationVerifier.recordMutationResult({
+        toolName,
+        input,
+        succeeded: toolSucceeded,
+        error: toolSucceeded ? undefined : String(result?.error || result?.message || "").slice(0, 200),
+      });
+    }
     if (toolSucceeded && (mutatingTools.has(toolName) || this.isFileMutationTool(toolName))) {
       const changedPath =
         result?.path ||
@@ -9697,7 +9719,36 @@ ${transcript}
     if (!this.isExecuteLikeToolMode()) {
       return false;
     }
+    if (this.promptHasReadOnlyConstraint(prompt)) {
+      return false;
+    }
     return this.followUpRequiresCommandExecution(prompt);
+  }
+
+  /**
+   * Detects any explicit read-only constraint in the prompt.
+   * Broader than the old promptIsReadOnlyReviewReport() which required
+   * documentation-review + report-format intent on top of the read-only constraint.
+   * Now any "do not edit files", "read-only", etc. suppresses execution requirements,
+   * unless the prompt explicitly asks to run commands.
+   */
+  private promptHasReadOnlyConstraint(prompt: string): boolean {
+    const lower = String(prompt || "").toLowerCase();
+    if (!lower.trim()) return false;
+    if (!detectReadOnlyConstraintUtil(lower)) return false;
+    // Even with a read-only constraint, if the prompt explicitly asks to run
+    // commands (e.g. "do not edit files but run npm test"), honour the execution request.
+    const hasExplicitRunIntent =
+      /\b(?:run|execute)\s+(?:npm|pnpm|yarn|bun|cargo|go|make|cmake|gradle|mvn|dotnet|pytest|python|swift|xcodebuild|tests?|build|commands?)\b/.test(
+        lower,
+      ) ||
+      /\b(?:run|execute)\s+(?:the\s+|a\s+)?[\w-]+(?:\s+[\w-]+){0,3}\s+commands?\b/.test(lower);
+    return !hasExplicitRunIntent;
+  }
+
+  /** @deprecated Use promptHasReadOnlyConstraint instead */
+  private promptIsReadOnlyReviewReport(prompt: string): boolean {
+    return this.promptHasReadOnlyConstraint(prompt);
   }
 
   /**
@@ -10579,6 +10630,9 @@ ${transcript}
       requiresMutation: inferredMutation,
       requiresArtifactEvidence,
       requiresWriteByArtifactMode: artifactWriteRequired,
+      hasReadOnlyConstraint: this.promptHasReadOnlyConstraint(
+        `${this.task?.title || ""}\n${this.getContractPrompt()}`,
+      ),
     });
     const policyRequiredTools = getPolicyRequiredToolsForMode(
       this.agentPolicyConfig,
@@ -11736,6 +11790,10 @@ ${transcript}
     return responseHasReasonedConclusionSignalUtil(text);
   }
 
+  private responseHasReviewReportEvidenceSignal(text: string): boolean {
+    return responseHasReviewReportEvidenceSignalUtil(text);
+  }
+
   private hasVerificationToolEvidence(): boolean {
     return hasVerificationToolEvidenceUtil(this.toolResultMemory);
   }
@@ -11953,12 +12011,34 @@ ${transcript}
       .filter((stepId) => stepId.length > 0);
   }
 
+  /**
+   * Determines how strictly completion contracts should be enforced.
+   * - "relaxed": Skip contract guard entirely. Used for tasks with explicit read-only constraints
+   *   (e.g. "do not edit files") that should produce text output only.
+   * - "standard": Enforce explicit output contracts (not inferred ones).
+   */
+  private getCompletionStrictness(): "standard" | "relaxed" {
+    const prompt = this.getContractPrompt();
+    if (detectReadOnlyConstraintUtil(prompt)) return "relaxed";
+    return "standard";
+  }
+
   private getFinalOutcomeGuardError(): string | null {
     const contract = this.buildCompletionContract();
     const bestCandidate = this.getBestFinalResponseCandidate();
     const createdFiles = (this.fileOperationTracker?.getCreatedFiles?.() || []).map((file) =>
       String(file),
     );
+
+    // For relaxed strictness (read-only tasks), skip artifact and execution
+    // evidence checks but keep verification evidence and direct answer checks.
+    const strictness = this.getCompletionStrictness();
+    if (strictness === "relaxed") {
+      contract.requiresArtifactEvidence = false;
+      contract.requiresExecutionEvidence = false;
+      contract.requiredArtifactExtensions = [];
+    }
+
     const baseGuardError = getFinalOutcomeGuardErrorUtil({
       contract,
       preferBestEffortCompletion: this.shouldPreferBestEffortCompletion(),
@@ -12020,6 +12100,8 @@ ${transcript}
             hasVerificationSignal: this.responseHasVerificationSignal(bestCandidate),
             hasReasonedConclusionSignal:
               this.responseHasReasonedConclusionSignal(bestCandidate),
+            hasReviewReportEvidenceSignal:
+              this.responseHasReviewReportEvidenceSignal(bestCandidate),
             hasToolEvidence: this.hasVerificationToolEvidence(),
           },
           successfulTools,
@@ -12108,9 +12190,10 @@ ${transcript}
     this.task.dependencyOutcome = reliabilityOutcomes.dependencyOutcome;
     this.task.failureDomains = reliabilityOutcomes.failureDomains;
     this.task.stopReasons = reliabilityOutcomes.stopReasons;
-    this.task.resultSummary = summary;
+    const mutationFooter = this.fileMutationVerifier?.buildAdvisoryFooter();
+    this.task.resultSummary = mutationFooter ? `${summary}\n\n${mutationFooter}` : summary;
     const outputSummary = this.buildTaskOutputSummary();
-    this.persistBestKnownOutcome(summary, terminalStatus, failureClass);
+    this.persistBestKnownOutcome(this.task.resultSummary, terminalStatus, failureClass);
     const goalAgentConfig = this.applyGoalTerminalState(summary, terminalStatus);
     const verificationMetadata =
       this.verificationOutcomeV2Enabled && this.completionVerificationMetadata
@@ -13606,9 +13689,41 @@ ${transcript}
     );
   }
 
+  private isWebPagePreviewWorkflowTask(text: string): boolean {
+    const lower = String(text || "").toLowerCase();
+    const hasAction =
+      /\b(design|build|create|make|implement|scaffold|develop|generate|edit|modify|update|fix|debug|troubleshoot|polish|redesign|improve|verify|test)\b/.test(
+        lower,
+      );
+    if (!hasAction) return false;
+
+    const hasWebPageTarget =
+      /\b(html|css|react|vite|next\.?js|nextjs|vue|svelte|webpack|web\s*page|web\s*app|webapp|website|landing\s*page|frontend|spa|localhost|dev\s*server)\b/.test(
+        lower,
+      ) ||
+      /\.(?:html|css|jsx|tsx)\b/.test(lower) ||
+      /\b(?:index|app|main)\.(?:html|jsx|tsx)\b/.test(lower);
+    if (!hasWebPageTarget) return false;
+
+    const codeOnlySignals =
+      /\b(design\s+tokens?|css\s+variables?|button\s+variants?|component\s+variants?|call\s+sites?|class\s+names?|type\s+check|lint only|static checks? only)\b/.test(
+        lower,
+      );
+    const explicitWebPreviewSignals =
+      this.hasExplicitLiveVisualSurfaceIntent(lower) ||
+      /\b(html|react|vite|next\.?js|nextjs|web\s*page|web\s*app|webapp|website|landing\s*page|frontend|localhost|dev\s*server)\b/.test(
+        lower,
+      );
+    return !codeOnlySignals || explicitWebPreviewSignals;
+  }
+
   private isCodeFirstUiTask(text?: string): boolean {
     const combined = String(text || `${this.task.title}\n${this.getContractPrompt()}`);
-    return isDesignSystemRelevantTask(combined) && !this.hasExplicitLiveVisualSurfaceIntent(combined);
+    return (
+      isDesignSystemRelevantTask(combined) &&
+      !this.hasExplicitLiveVisualSurfaceIntent(combined) &&
+      !this.isWebPagePreviewWorkflowTask(combined)
+    );
   }
 
   private isCodeFirstUiBlockedTool(toolName: string): boolean {
@@ -13642,6 +13757,18 @@ ${transcript}
       "- Do not split subjective visual consistency into separate verification steps such as same sizing, same radius, same padding, or same font weight.",
       "- Prefer a compact implementation plan: inspect design system, centralize button variants/styles, update call sites, run static checks/build if available.",
       "- Verification should be code-based: changed files, class/component usage, lint/type/build checks, or exact token/class references.",
+    ].join("\n");
+  }
+
+  private buildWebPagePreviewGuidancePrompt(taskPrompt: string): string {
+    if (!this.isWebPagePreviewWorkflowTask(taskPrompt)) return "";
+    return [
+      "WEB PAGE PREVIEW GUIDANCE:",
+      "- For HTML, React, Vite, Next.js, landing page, website, and frontend page design/edit/debug tasks, plan to render the page and inspect it in the visible in-app browser when practical.",
+      "- For React/Vite/Next.js projects, start the existing dev server with the repo's script or use qa_run with server_command when automated QA is more appropriate; use an available localhost port.",
+      "- For standalone HTML, open the file or local preview URL in the browser instead of inventing a complex server.",
+      "- Use browser_navigate, browser_snapshot, browser_screenshot, and browser_emulate for desktop/mobile checks, screenshots, layout overlap, interaction, console, and network issues.",
+      "- Fix issues found in the rendered page, then re-check before finalizing. Skip browser checks only for pure design-token/component refactors where rendered-page evidence would not change the outcome.",
     ].join("\n");
   }
 
@@ -14128,6 +14255,7 @@ ${transcript}
       workspaceContextPrompt: this.buildExecutionWorkspaceContextPrompt(),
       currentTimePrompt: `Current time: ${getCurrentDateTimeContext()}`,
       modeDomainContractPrompt: buildModeDomainContract(params.executionMode, params.taskDomain),
+      completionGuidancePrompt: this.buildCompletionGuidancePrompt(),
       roleContext: params.roleContext,
       memoryContext: params.memoryContext,
       awarenessSnapshot: params.awarenessSnapshot,
@@ -14144,6 +14272,19 @@ ${transcript}
       totalBudgetTokens: EXECUTION_SYSTEM_PROMPT_TOTAL_BUDGET,
       transcriptContext,
       sectionCache: this.promptSectionCache,
+    });
+  }
+
+  private buildCompletionGuidancePrompt(): string {
+    const prompt = this.getContractPrompt();
+    const hasReadOnly = detectReadOnlyConstraintUtil(prompt);
+    const explicitExts = hasReadOnly
+      ? []
+      : extractExplicitOutputExtensionsUtil(this.task.title || "", prompt);
+    return buildCompletionGuidancePromptUtil({
+      hasReadOnlyConstraint: hasReadOnly,
+      explicitOutputExtensions: explicitExts,
+      likelyRequiresExecution: this.requiresExecutionToolRun,
     });
   }
 
@@ -23594,6 +23735,7 @@ Return ONLY a JSON object:
         }),
         this.buildIntegrationMentionGuidancePrompt(),
         this.buildLocalModelExecutionGuidancePrompt("planning"),
+        this.buildWebPagePreviewGuidancePrompt(planTextPrompt),
         this.buildCodeFirstUiGuidancePrompt(planTextPrompt),
         adaptiveRecoveryGuidance,
       ]
@@ -30076,11 +30218,16 @@ Return ONLY a JSON object:
         !isSummaryStep &&
         !stepAttemptedExecutionTool
       ) {
-        stepFailed = true;
-        if (!lastFailureReason) {
-          lastFailureReason =
-            "Execution-oriented task finished without attempting run_command/run_applescript. Execute commands directly instead of returning guidance only.";
-        }
+        // Demoted to advisory: log instead of failing the step.
+        // Behavioral steering in the system prompt guides the model to use
+        // execution tools; failing the step here caused false positives for
+        // read-only tasks and triggered wasteful plan-revision recovery loops.
+        this.emitEvent("log", {
+          metric: "execution_tool_advisory",
+          message:
+            "Step completed without execution tool — relying on behavioral steering. " +
+            "Previous behavior would have failed the step here.",
+        });
       }
 
       const currentStepBrowserVerificationObserved =
@@ -32089,9 +32236,14 @@ Return ONLY a JSON object:
       }
     }
 
-    await this.sendMessageUnified(message, images, quotedAssistantMessage, {
-      agentConfigOverride: options?.agentConfigOverride,
-    });
+    if (options?.agentConfigOverride) {
+      await this.sendMessageUnified(message, images, quotedAssistantMessage, {
+        agentConfigOverride: options.agentConfigOverride,
+      });
+      return;
+    }
+
+    await this.sendMessageUnified(message, images, quotedAssistantMessage);
   }
 
   private async sendMessageUnified(

--- a/src/electron/agent/file-mutation-verifier.ts
+++ b/src/electron/agent/file-mutation-verifier.ts
@@ -1,0 +1,86 @@
+export interface MutationRecord {
+  toolName: string;
+  targetPath: string | null;
+  succeeded: boolean;
+  errorPreview: string | null;
+  timestamp: number;
+}
+
+/**
+ * Tracks file-mutation tool calls (write_file, edit_file, copy_file, etc.)
+ * and detects discrepancies between what the model claims and what actually happened.
+ *
+ * Inspired by the Hermes agent's file mutation verifier: the model may summarise
+ * a turn claiming every file was edited, but some write_file calls may have failed.
+ * This verifier makes over-claiming structurally visible past the model.
+ */
+export class FileMutationVerifier {
+  private mutations: MutationRecord[] = [];
+
+  recordMutationResult(opts: {
+    toolName: string;
+    input: unknown;
+    succeeded: boolean;
+    error?: string;
+  }): void {
+    const targetPath = this.extractTargetPath(opts.toolName, opts.input);
+    if (opts.succeeded && targetPath) {
+      // Self-correction: remove prior failure for the same path
+      this.mutations = this.mutations.filter(
+        (m) => !(m.targetPath === targetPath && !m.succeeded),
+      );
+    }
+    this.mutations.push({
+      toolName: opts.toolName,
+      targetPath,
+      succeeded: opts.succeeded,
+      errorPreview: opts.error ? opts.error.slice(0, 200) : null,
+      timestamp: Date.now(),
+    });
+  }
+
+  getFailedMutations(): MutationRecord[] {
+    const successPaths = new Set(
+      this.mutations.filter((m) => m.succeeded && m.targetPath).map((m) => m.targetPath),
+    );
+    return this.mutations.filter(
+      (m) => !m.succeeded && (!m.targetPath || !successPaths.has(m.targetPath)),
+    );
+  }
+
+  buildAdvisoryFooter(): string | null {
+    const failed = this.getFailedMutations();
+    if (failed.length === 0) return null;
+
+    const details = failed
+      .slice(0, 5)
+      .map((m) => {
+        const path = m.targetPath || "(unknown path)";
+        const err = m.errorPreview || "tool returned failure";
+        return `  - ${m.toolName}("${path}"): ${err}`;
+      })
+      .join("\n");
+
+    return [
+      `File-mutation verifier: ${failed.length} file(s) were NOT modified this turn`,
+      "despite any wording above that may suggest otherwise.",
+      details,
+    ].join("\n");
+  }
+
+  reset(): void {
+    this.mutations = [];
+  }
+
+  private extractTargetPath(toolName: string, input: unknown): string | null {
+    if (!input || typeof input !== "object") return null;
+    const obj = input as Record<string, unknown>;
+    if (typeof obj.path === "string") return obj.path;
+    if (typeof obj.filename === "string") return obj.filename;
+    if (typeof obj.destination === "string") return obj.destination;
+    if (typeof obj.file_path === "string") return obj.file_path;
+    if (typeof obj.target === "string") return obj.target;
+    if (typeof obj.outputPath === "string") return obj.outputPath;
+    return null;
+  }
+}

--- a/src/electron/agent/step-contract.ts
+++ b/src/electron/agent/step-contract.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 
 export type StepContractMode = "mutation_required" | "artifact_presence_required" | "analysis_only";
-export type StepContractEnforcementLevel = "strict" | "standard";
+export type StepContractEnforcementLevel = "strict" | "standard" | "advisory";
 
 const CANONICAL_ARTIFACT_EXTENSION_LIST = [
   "pdf",
@@ -45,6 +45,7 @@ const CANONICAL_ARTIFACT_EXTENSION_LIST = [
 ] as const;
 
 const CANONICAL_ARTIFACT_EXTENSION_SET = new Set<string>(CANONICAL_ARTIFACT_EXTENSION_LIST);
+export { CANONICAL_ARTIFACT_EXTENSION_SET as CANONICAL_ARTIFACT_EXTENSION_SET_EXPORT };
 const CANONICAL_EXTENSIONS_WITH_DOT = CANONICAL_ARTIFACT_EXTENSION_LIST.map((extension) => `.${extension}`);
 const CANONICAL_EXTENSION_PATTERN = CANONICAL_ARTIFACT_EXTENSION_LIST
   .map((extension) => extension.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
@@ -255,12 +256,26 @@ export function deriveStepContractMode(opts: {
   requiresMutation: boolean;
   requiresArtifactEvidence: boolean;
   requiresWriteByArtifactMode: boolean;
+  hasReadOnlyConstraint?: boolean;
 }): {
   mode: StepContractMode;
   enforcementLevel: StepContractEnforcementLevel;
   contractReason: string;
 } {
   const desc = String(opts.description || "");
+
+  // When the task has an explicit read-only constraint (e.g. "do not edit files"),
+  // downgrade all enforcement to advisory — the step should not fail for missing mutations.
+  // Note: we only check the task-level flag, NOT descriptionHasReadOnlyIntent() —
+  // a step like "research trends" describes read-only activities but the task may still
+  // need file output.
+  if (opts.hasReadOnlyConstraint) {
+    return {
+      mode: "analysis_only",
+      enforcementLevel: "advisory",
+      contractReason: "readonly_constraint_detected",
+    };
+  }
 
   if (opts.requiresMutation || opts.requiresWriteByArtifactMode) {
     return {


### PR DESCRIPTION
## Summary
- add completion guidance for explicit output files, read-only constraints, and likely execution requirements
- relax completion enforcement for explicit read-only tasks while keeping verification/direct-answer checks
- add file mutation verification advisory footers for failed or missing file mutations
- expand executor completion and command-requirement coverage

## Validation
- npx vitest run src/electron/agent/__tests__/executor-completion-contract.test.ts src/electron/agent/__tests__/executor-command-requirement.test.ts src/electron/agent/__tests__/file-mutation-verifier.test.ts
- npm run build:electron