### PR TITLE
feat(automation): record run outcomes

### DIFF
--- a/src/electron/agents/HeartbeatService.ts
+++ b/src/electron/agents/HeartbeatService.ts
@@ -17,6 +17,7 @@ import {
   type AwarenessSummary,
   type AutonomyDecision,
   type ChiefOfStaffWorldModel,
+  type CreateAutomationRunOutcomeInput,
   type MemoryFeaturesSettings,
 } from "../../shared/types";
 import { AgentRoleRepository } from "./AgentRoleRepository";
@@ -39,6 +40,10 @@ import { CoreTraceService } from "../core/CoreTraceService";
 import { CoreMemoryCandidateService } from "../core/CoreMemoryCandidateService";
 import { CoreMemoryDistiller } from "../core/CoreMemoryDistiller";
 import { CoreLearningPipelineService } from "../core/CoreLearningPipelineService";
+import {
+  classifyHeartbeatDispatchOutcome,
+  classifyHeartbeatErrorOutcome,
+} from "../automation/automation-outcome-classifier";
 
 type HeartbeatWakeMode = "now" | "next-heartbeat";
 type HeartbeatWakeSource = "hook" | "cron" | "api" | "manual";
@@ -126,10 +131,14 @@ export interface HeartbeatServiceDeps {
     title: string;
     message: string;
     workspaceId?: string;
+    taskId?: string;
     suggestionId?: string;
     recommendedDelivery?: "briefing" | "inbox" | "nudge";
     companionStyle?: "email" | "note";
   }) => Promise<void>;
+  recordAutomationOutcome?: (
+    outcome: CreateAutomationRunOutcomeInput,
+  ) => Promise<unknown>;
   runWorkflowReflection?: (params: {
     workspaceId?: string;
     reason: string;
@@ -918,6 +927,14 @@ export class HeartbeatService extends EventEmitter {
           runType: "dispatch",
           dispatchKind: decision.dispatchKind,
         });
+        await this.recordDispatchOutcome({
+          agent,
+          workspaceId,
+          sourceRunId: dispatchRun.id,
+          trigger: manualOverride ? "manual" : "heartbeat",
+          decision,
+          dispatchResult,
+        });
         this.emitHeartbeatEvent({
           type: "pulse_completed",
           agentRoleId: agent.id,
@@ -963,6 +980,13 @@ export class HeartbeatService extends EventEmitter {
         runId: pulseRun.id,
         runType: "pulse",
       });
+      await this.recordHeartbeatError(
+        agent,
+        pulseRun.id,
+        manualOverride ? "manual" : "heartbeat",
+        message,
+        workspaceId,
+      );
       return result;
       } finally {
       this.running.delete(agent.id);
@@ -994,6 +1018,58 @@ export class HeartbeatService extends EventEmitter {
       lastPulseResult: result.pulseOutcome,
     });
     this.timers.delete(agent.id);
+  }
+
+  private async recordDispatchOutcome(params: {
+    agent: AgentRole;
+    workspaceId: string;
+    sourceRunId: string;
+    trigger: "manual" | "heartbeat";
+    decision: HeartbeatPulseDecision;
+    dispatchResult: HeartbeatResult;
+  }): Promise<void> {
+    try {
+      await this.deps.recordAutomationOutcome?.(
+        classifyHeartbeatDispatchOutcome({
+          agent: params.agent,
+          workspaceId: params.workspaceId,
+          sourceRunId: params.sourceRunId,
+          trigger: params.trigger,
+          reason: params.decision.reason,
+          dispatchKind: params.decision.dispatchKind,
+          result: params.dispatchResult,
+          evidenceRefs: params.decision.evidenceRefs.map((id) => ({
+            type: "heartbeat_evidence",
+            id,
+            label: id,
+          })),
+        }),
+      );
+    } catch (error) {
+      console.warn("[HeartbeatService] Failed to record dispatch outcome:", error);
+    }
+  }
+
+  private async recordHeartbeatError(
+    agent: AgentRole,
+    runId: string,
+    trigger: "manual" | "heartbeat",
+    message: string,
+    workspaceId?: string,
+  ): Promise<void> {
+    try {
+      await this.deps.recordAutomationOutcome?.(
+        classifyHeartbeatErrorOutcome({
+          agent,
+          workspaceId,
+          sourceRunId: runId,
+          trigger,
+          error: message,
+        }),
+      );
+    } catch (error) {
+      console.warn("[HeartbeatService] Failed to record heartbeat error outcome:", error);
+    }
   }
 
   private async maybeRunWorkflowReflection(params: {

--- a/src/electron/agents/__tests__/HeartbeatService.test.ts
+++ b/src/electron/agents/__tests__/HeartbeatService.test.ts
@@ -6,6 +6,7 @@ import type {
   AgentRole,
   AgentMention,
   Activity,
+  CreateAutomationRunOutcomeInput,
   HeartbeatEvent,
   ProactiveSuggestion,
   Task,
@@ -26,6 +27,7 @@ let taskUpdates: Array<{ taskId: string; updates: Partial<Task> }>;
 let createdSuggestions: ProactiveSuggestion[];
 let recordedActivities: Array<Record<string, unknown>>;
 let heartbeatEvents: HeartbeatEvent[];
+let automationOutcomes: CreateAutomationRunOutcomeInput[];
 let tmpDir: string;
 let workspacePaths: Map<string, string>;
 let services: HeartbeatService[];
@@ -161,6 +163,9 @@ function createService(overrides?: Partial<HeartbeatServiceDeps>): HeartbeatServ
       return created;
     },
     addNotification: async () => undefined,
+    recordAutomationOutcome: async (outcome) => {
+      automationOutcomes.push(outcome);
+    },
     ...overrides,
   };
 
@@ -182,6 +187,7 @@ describe("HeartbeatService v3", () => {
     createdSuggestions = [];
     recordedActivities = [];
     heartbeatEvents = [];
+    automationOutcomes = [];
     services = [];
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cowork-heartbeat-v3-"));
     process.env.COWORK_USER_DATA_DIR = path.join(tmpDir, "user-data");
@@ -268,6 +274,13 @@ describe("HeartbeatService v3", () => {
     expect(createdTasks[0]?.heartbeatRunId).toBeTruthy();
     expect(taskUpdates).toHaveLength(1);
     expect(taskUpdates[0]?.updates.heartbeatRunId).toBeTruthy();
+    expect(automationOutcomes).toContainEqual(
+      expect.objectContaining({
+        usefulness: "actionable",
+        title: "Agent agent-1 started background work",
+        taskId: createdTasks[0]?.id,
+      }),
+    );
   });
 
   it("replays one immediate manual pulse after an in-flight pulse finishes", async () => {
@@ -508,6 +521,12 @@ describe("HeartbeatService v3", () => {
 
     const failed = await service.triggerHeartbeat("agent-1");
     expect(failed.status).toBe("error");
+    expect(automationOutcomes).toContainEqual(
+      expect.objectContaining({
+        usefulness: "failed",
+        title: "Agent agent-1 heartbeat failed",
+      }),
+    );
 
     service.submitHeartbeatSignal({
       agentRoleId: "agent-1",

--- a/src/electron/automation/AutomationNotificationPolicy.ts
+++ b/src/electron/automation/AutomationNotificationPolicy.ts
@@ -1,0 +1,33 @@
+import type { AutomationRunOutcome, NotificationType } from "../../shared/types";
+
+export interface AutomationNotificationPayload {
+  type: NotificationType;
+  title: string;
+  message: string;
+  taskId?: string;
+  workspaceId?: string;
+  recommendedDelivery?: "briefing" | "inbox" | "nudge";
+  companionStyle?: "email" | "note";
+}
+
+export function shouldNotifyAutomationOutcome(outcome: AutomationRunOutcome): boolean {
+  if (!outcome.notificationRecommended) return false;
+  return outcome.usefulness === "actionable" || outcome.usefulness === "failed";
+}
+
+export function buildAutomationNotification(
+  outcome: AutomationRunOutcome,
+): AutomationNotificationPayload | null {
+  if (!shouldNotifyAutomationOutcome(outcome)) return null;
+  const type: NotificationType = outcome.usefulness === "failed" ? "warning" : "info";
+  const nextAction = outcome.nextAction ? ` Next: ${outcome.nextAction}` : "";
+  return {
+    type,
+    title: outcome.title,
+    message: `${outcome.summary}${nextAction}`,
+    taskId: outcome.taskId,
+    workspaceId: outcome.workspaceId,
+    recommendedDelivery: "inbox",
+    companionStyle: "note",
+  };
+}

--- a/src/electron/automation/AutomationOutcomeService.ts
+++ b/src/electron/automation/AutomationOutcomeService.ts
@@ -1,0 +1,39 @@
+import type {
+  AutomationRunOutcome,
+  CreateAutomationRunOutcomeInput,
+} from "../../shared/types";
+import type { AutomationRunOutcomeRepository } from "./AutomationRunOutcomeRepository";
+import {
+  buildAutomationNotification,
+  type AutomationNotificationPayload,
+} from "./AutomationNotificationPolicy";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("AutomationOutcomeService");
+
+interface AutomationOutcomeServiceDeps {
+  repo: AutomationRunOutcomeRepository;
+  notify?: (notification: AutomationNotificationPayload) => Promise<void>;
+}
+
+export class AutomationOutcomeService {
+  constructor(private readonly deps: AutomationOutcomeServiceDeps) {}
+
+  async record(input: CreateAutomationRunOutcomeInput): Promise<AutomationRunOutcome> {
+    const outcome = this.deps.repo.create(input);
+    const notification = buildAutomationNotification(outcome);
+    if (!notification || !this.deps.notify) return outcome;
+
+    try {
+      await this.deps.notify(notification);
+      this.deps.repo.markNotificationDelivered(outcome.id);
+      return {
+        ...outcome,
+        notificationDeliveredAt: Date.now(),
+      };
+    } catch (error) {
+      log.warn("Failed to deliver automation outcome notification:", error);
+      return outcome;
+    }
+  }
+}

--- a/src/electron/automation/AutomationRunOutcomeRepository.ts
+++ b/src/electron/automation/AutomationRunOutcomeRepository.ts
@@ -1,0 +1,223 @@
+import { randomUUID } from "node:crypto";
+import type Database from "better-sqlite3";
+import type {
+  AutomationRunOutcome,
+  AutomationRunOutcomeListRequest,
+  AutomationRunOutcomeSummary,
+  CreateAutomationRunOutcomeInput,
+} from "../../shared/types";
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (typeof value !== "string" || !value.trim()) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export class AutomationRunOutcomeRepository {
+  constructor(private readonly db: Database.Database) {
+    this.ensureSchema();
+  }
+
+  create(input: CreateAutomationRunOutcomeInput): AutomationRunOutcome {
+    const outcome: AutomationRunOutcome = {
+      id: input.id || randomUUID(),
+      source: input.source,
+      sourceRunId: input.sourceRunId,
+      taskId: input.taskId,
+      workspaceId: input.workspaceId,
+      companyId: input.companyId,
+      agentRoleId: input.agentRoleId,
+      title: input.title,
+      summary: input.summary,
+      usefulness: input.usefulness,
+      trigger: input.trigger,
+      metrics: input.metrics,
+      evidenceRefs: input.evidenceRefs,
+      nextAction: input.nextAction,
+      notificationRecommended: input.notificationRecommended,
+      notificationReason: input.notificationReason,
+      notificationDeliveredAt: input.notificationDeliveredAt,
+      createdAt: input.createdAt || Date.now(),
+    };
+
+    this.db
+      .prepare(
+        `
+          INSERT INTO automation_run_outcomes (
+            id, source, source_run_id, task_id, workspace_id, company_id, agent_role_id,
+            title, summary, usefulness, trigger, notification_recommended, notification_reason,
+            notification_delivered_at, next_action, metrics_json, evidence_refs_json, created_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .run(
+        outcome.id,
+        outcome.source,
+        outcome.sourceRunId || null,
+        outcome.taskId || null,
+        outcome.workspaceId || null,
+        outcome.companyId || null,
+        outcome.agentRoleId || null,
+        outcome.title,
+        outcome.summary,
+        outcome.usefulness,
+        outcome.trigger,
+        outcome.notificationRecommended ? 1 : 0,
+        outcome.notificationReason || null,
+        outcome.notificationDeliveredAt || null,
+        outcome.nextAction || null,
+        outcome.metrics ? JSON.stringify(outcome.metrics) : null,
+        outcome.evidenceRefs ? JSON.stringify(outcome.evidenceRefs) : null,
+        outcome.createdAt,
+      );
+    return outcome;
+  }
+
+  list(request: AutomationRunOutcomeListRequest = {}): AutomationRunOutcome[] {
+    const clauses = ["1 = 1"];
+    const args: unknown[] = [];
+    if (request.source) {
+      clauses.push("source = ?");
+      args.push(request.source);
+    }
+    if (request.usefulness) {
+      clauses.push("usefulness = ?");
+      args.push(request.usefulness);
+    }
+    if (request.workspaceId) {
+      clauses.push("workspace_id = ?");
+      args.push(request.workspaceId);
+    }
+    if (request.companyId) {
+      clauses.push("company_id = ?");
+      args.push(request.companyId);
+    }
+    const limit = Math.min(Math.max(request.limit || 50, 1), 500);
+    const offset = Math.max(request.offset || 0, 0);
+    args.push(limit, offset);
+    const rows = this.db
+      .prepare(
+        `
+          SELECT *
+          FROM automation_run_outcomes
+          WHERE ${clauses.join(" AND ")}
+          ORDER BY created_at DESC
+          LIMIT ? OFFSET ?
+        `,
+      )
+      .all(...args) as Record<string, unknown>[];
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  summarize(input: { from?: number; to?: number; companyId?: string; workspaceId?: string } = {}): AutomationRunOutcomeSummary {
+    const clauses = ["1 = 1"];
+    const args: unknown[] = [];
+    if (typeof input.from === "number") {
+      clauses.push("created_at >= ?");
+      args.push(input.from);
+    }
+    if (typeof input.to === "number") {
+      clauses.push("created_at <= ?");
+      args.push(input.to);
+    }
+    if (input.companyId) {
+      clauses.push("company_id = ?");
+      args.push(input.companyId);
+    }
+    if (input.workspaceId) {
+      clauses.push("workspace_id = ?");
+      args.push(input.workspaceId);
+    }
+    const rows = this.db
+      .prepare(
+        `
+          SELECT usefulness, COUNT(*) AS count
+          FROM automation_run_outcomes
+          WHERE ${clauses.join(" AND ")}
+          GROUP BY usefulness
+        `,
+      )
+      .all(...args) as Array<{ usefulness: string; count: number }>;
+    const summary: AutomationRunOutcomeSummary = {
+      total: 0,
+      actionable: 0,
+      informational: 0,
+      lowValue: 0,
+      failed: 0,
+    };
+    for (const row of rows) {
+      summary.total += row.count;
+      if (row.usefulness === "actionable") summary.actionable = row.count;
+      if (row.usefulness === "informational") summary.informational = row.count;
+      if (row.usefulness === "low_value") summary.lowValue = row.count;
+      if (row.usefulness === "failed") summary.failed = row.count;
+    }
+    return summary;
+  }
+
+  markNotificationDelivered(id: string, timestamp = Date.now()): void {
+    this.db
+      .prepare("UPDATE automation_run_outcomes SET notification_delivered_at = ? WHERE id = ?")
+      .run(timestamp, id);
+  }
+
+  private ensureSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS automation_run_outcomes (
+        id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        source_run_id TEXT,
+        task_id TEXT,
+        workspace_id TEXT,
+        company_id TEXT,
+        agent_role_id TEXT,
+        title TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        usefulness TEXT NOT NULL,
+        trigger TEXT NOT NULL,
+        notification_recommended INTEGER NOT NULL DEFAULT 0,
+        notification_reason TEXT,
+        notification_delivered_at INTEGER,
+        next_action TEXT,
+        metrics_json TEXT,
+        evidence_refs_json TEXT,
+        created_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_automation_outcomes_created
+        ON automation_run_outcomes(created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_automation_outcomes_company
+        ON automation_run_outcomes(company_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_automation_outcomes_workspace
+        ON automation_run_outcomes(workspace_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_automation_outcomes_usefulness
+        ON automation_run_outcomes(usefulness, created_at DESC);
+    `);
+  }
+
+  private mapRow(row: Record<string, unknown>): AutomationRunOutcome {
+    return {
+      id: String(row.id),
+      source: row.source as AutomationRunOutcome["source"],
+      sourceRunId: typeof row.source_run_id === "string" ? row.source_run_id : undefined,
+      taskId: typeof row.task_id === "string" ? row.task_id : undefined,
+      workspaceId: typeof row.workspace_id === "string" ? row.workspace_id : undefined,
+      companyId: typeof row.company_id === "string" ? row.company_id : undefined,
+      agentRoleId: typeof row.agent_role_id === "string" ? row.agent_role_id : undefined,
+      title: String(row.title),
+      summary: String(row.summary),
+      usefulness: row.usefulness as AutomationRunOutcome["usefulness"],
+      trigger: row.trigger as AutomationRunOutcome["trigger"],
+      metrics: parseJson(row.metrics_json, undefined),
+      evidenceRefs: parseJson(row.evidence_refs_json, undefined),
+      nextAction: typeof row.next_action === "string" ? row.next_action : undefined,
+      notificationRecommended: row.notification_recommended === 1,
+      notificationReason: typeof row.notification_reason === "string" ? row.notification_reason : undefined,
+      notificationDeliveredAt:
+        typeof row.notification_delivered_at === "number" ? row.notification_delivered_at : undefined,
+      createdAt: Number(row.created_at),
+    };
+  }
+}

--- a/src/electron/automation/__tests__/AutomationRunOutcomeRepository.test.ts
+++ b/src/electron/automation/__tests__/AutomationRunOutcomeRepository.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+const nativeSqliteAvailable = await import("better-sqlite3")
+  .then((module) => {
+    try {
+      const Database = module.default;
+      const probe = new Database(":memory:");
+      probe.close();
+      return true;
+    } catch {
+      return false;
+    }
+  })
+  .catch(() => false);
+
+const describeWithSqlite = nativeSqliteAvailable ? describe : describe.skip;
+
+describeWithSqlite("AutomationRunOutcomeRepository", () => {
+  it("stores outcomes and summarizes usefulness counts", async () => {
+    const [{ default: Database }, { AutomationRunOutcomeRepository }] = await Promise.all([
+      import("better-sqlite3"),
+      import("../AutomationRunOutcomeRepository"),
+    ]);
+    const db = new Database(":memory:");
+    const repo = new AutomationRunOutcomeRepository(db);
+
+    const actionable = repo.create({
+      source: "heartbeat",
+      title: "Heartbeat created work",
+      summary: "Created one task.",
+      usefulness: "actionable",
+      trigger: "heartbeat",
+      notificationRecommended: true,
+      metrics: { dispatchedTaskCount: 1 },
+      evidenceRefs: [{ type: "task", id: "task-1", label: "created" }],
+    });
+    repo.create({
+      source: "strategic_planner",
+      title: "Planner checked work",
+      summary: "No changes.",
+      usefulness: "informational",
+      trigger: "schedule",
+      notificationRecommended: false,
+    });
+
+    expect(repo.list({ limit: 5 })).toHaveLength(2);
+    expect(repo.list({ source: "heartbeat" })[0]).toMatchObject({
+      id: actionable.id,
+      metrics: { dispatchedTaskCount: 1 },
+      evidenceRefs: [{ type: "task", id: "task-1", label: "created" }],
+    });
+    expect(repo.summarize()).toEqual({
+      total: 2,
+      actionable: 1,
+      informational: 1,
+      lowValue: 0,
+      failed: 0,
+    });
+
+    db.close();
+  });
+});

--- a/src/electron/automation/__tests__/automation-outcome-classifier.test.ts
+++ b/src/electron/automation/__tests__/automation-outcome-classifier.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyCheckEvidence,
+  classifyStrategicPlannerOutcome,
+} from "../automation-outcome-classifier";
+import {
+  buildAutomationNotification,
+  shouldNotifyAutomationOutcome,
+} from "../AutomationNotificationPolicy";
+import type { AutomationRunOutcome, Company, StrategicPlannerRun } from "../../../shared/types";
+
+describe("automation outcome classification", () => {
+  it("marks declared checks without executed command evidence as low value", () => {
+    const outcome = classifyCheckEvidence({
+      source: "cron",
+      title: "Static checks",
+      summary: "The agent said it could not run checks.",
+      trigger: "schedule",
+      declaredCheck: true,
+      executedCommandCount: 0,
+      toolCallCount: 0,
+      limitationOnly: true,
+    });
+
+    expect(outcome.usefulness).toBe("low_value");
+    expect(outcome.notificationRecommended).toBe(false);
+  });
+
+  it("marks scheduled planner runs with created work as actionable and notify-worthy", () => {
+    const company: Company = {
+      id: "company-1",
+      name: "Acme",
+      slug: "acme",
+      status: "active",
+      isDefault: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const run: StrategicPlannerRun = {
+      id: "run-1",
+      companyId: company.id,
+      status: "completed",
+      trigger: "schedule",
+      summary: "1 issue(s) created, 0 issue(s) updated, 0 task(s) dispatched",
+      createdIssueCount: 1,
+      updatedIssueCount: 0,
+      dispatchedTaskCount: 0,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const outcome = classifyStrategicPlannerOutcome({
+      company,
+      trigger: "schedule",
+      run,
+      createdIssueIds: ["issue-1"],
+      updatedIssueIds: [],
+      dispatchedTaskIds: [],
+      suppressedOutputCount: 0,
+    });
+
+    expect(outcome.usefulness).toBe("actionable");
+    expect(outcome.notificationRecommended).toBe(true);
+  });
+
+  it("suppresses notifications for informational outcomes", () => {
+    const outcome: AutomationRunOutcome = {
+      id: "outcome-1",
+      source: "strategic_planner",
+      title: "Planner found no changes",
+      summary: "No action needed.",
+      usefulness: "informational",
+      trigger: "schedule",
+      notificationRecommended: false,
+      createdAt: 1,
+    };
+
+    expect(shouldNotifyAutomationOutcome(outcome)).toBe(false);
+    expect(buildAutomationNotification(outcome)).toBeNull();
+  });
+});

--- a/src/electron/automation/automation-outcome-classifier.ts
+++ b/src/electron/automation/automation-outcome-classifier.ts
@@ -1,0 +1,196 @@
+import type {
+  AutomationRunEvidenceRef,
+  AutomationRunTrigger,
+  CreateAutomationRunOutcomeInput,
+} from "../../shared/types";
+import type { AgentRole, Company, HeartbeatResult, StrategicPlannerRun } from "../../shared/types";
+
+interface HeartbeatDispatchClassificationInput {
+  agent: AgentRole;
+  workspaceId: string;
+  sourceRunId: string;
+  trigger: AutomationRunTrigger;
+  reason: string;
+  dispatchKind?: string;
+  result: HeartbeatResult;
+  evidenceRefs?: AutomationRunEvidenceRef[];
+}
+
+export function classifyHeartbeatDispatchOutcome(
+  input: HeartbeatDispatchClassificationInput,
+): CreateAutomationRunOutcomeInput {
+  const failed = input.result.status === "error";
+  const actionable = !failed && Boolean(input.result.taskCreated);
+  return {
+    source: "heartbeat",
+    sourceRunId: input.sourceRunId,
+    taskId: input.result.taskCreated,
+    workspaceId: input.workspaceId,
+    agentRoleId: input.agent.id,
+    title: failed
+      ? `${input.agent.displayName} heartbeat dispatch failed`
+      : actionable
+        ? `${input.agent.displayName} started background work`
+        : `${input.agent.displayName} heartbeat dispatch completed`,
+    summary: [
+      input.reason,
+      input.result.taskCreated ? `Created task ${input.result.taskCreated}.` : "",
+      input.result.error,
+    ]
+      .filter(Boolean)
+      .join(" "),
+    usefulness: failed ? "failed" : actionable ? "actionable" : "informational",
+    trigger: input.trigger,
+    metrics: {
+      dispatchedTaskCount: input.result.taskCreated ? 1 : 0,
+      dispatchKind: input.dispatchKind,
+    },
+    evidenceRefs: input.evidenceRefs,
+    nextAction: input.result.taskCreated ? "Review the created background task." : undefined,
+    notificationRecommended: failed || actionable,
+    notificationReason: failed
+      ? "Heartbeat dispatch failed."
+      : actionable
+        ? "Heartbeat created background work."
+        : undefined,
+  };
+}
+
+export function classifyHeartbeatErrorOutcome(input: {
+  agent: AgentRole;
+  workspaceId?: string;
+  sourceRunId: string;
+  trigger: AutomationRunTrigger;
+  error: string;
+}): CreateAutomationRunOutcomeInput {
+  return {
+    source: "heartbeat",
+    sourceRunId: input.sourceRunId,
+    workspaceId: input.workspaceId,
+    agentRoleId: input.agent.id,
+    title: `${input.agent.displayName} heartbeat failed`,
+    summary: input.error,
+    usefulness: "failed",
+    trigger: input.trigger,
+    nextAction: "Inspect the heartbeat run error.",
+    notificationRecommended: true,
+    notificationReason: "Heartbeat failed before it could complete.",
+  };
+}
+
+export function classifyStrategicPlannerOutcome(input: {
+  company: Company;
+  configWorkspaceId?: string;
+  trigger: StrategicPlannerRun["trigger"];
+  run: StrategicPlannerRun;
+  createdIssueIds: string[];
+  updatedIssueIds: string[];
+  dispatchedTaskIds: string[];
+  suppressedOutputCount: number;
+}): CreateAutomationRunOutcomeInput {
+  const actionableCount =
+    input.createdIssueIds.length +
+    input.updatedIssueIds.length +
+    input.dispatchedTaskIds.length;
+  const usefulness =
+    actionableCount > 0 ? "actionable" : input.suppressedOutputCount > 0 ? "low_value" : "informational";
+  return {
+    source: "strategic_planner",
+    sourceRunId: input.run.id,
+    taskId: input.dispatchedTaskIds[0],
+    workspaceId: input.configWorkspaceId || input.company.defaultWorkspaceId,
+    companyId: input.company.id,
+    title:
+      usefulness === "actionable"
+        ? `${input.company.name} planner found background work`
+        : usefulness === "low_value"
+          ? `${input.company.name} planner held low-confidence work`
+          : `${input.company.name} planner found no changes`,
+    summary: input.run.summary || "Planner run completed.",
+    usefulness,
+    trigger: input.trigger,
+    metrics: {
+      changedIssueCount: input.createdIssueIds.length + input.updatedIssueIds.length,
+      createdIssueCount: input.createdIssueIds.length,
+      updatedIssueCount: input.updatedIssueIds.length,
+      dispatchedTaskCount: input.dispatchedTaskIds.length,
+      suppressedOutputCount: input.suppressedOutputCount,
+    },
+    evidenceRefs: [
+      ...input.createdIssueIds.map((id) => ({ type: "issue", id, label: "created" })),
+      ...input.updatedIssueIds.map((id) => ({ type: "issue", id, label: "updated" })),
+      ...input.dispatchedTaskIds.map((id) => ({ type: "task", id, label: "dispatched" })),
+    ],
+    nextAction:
+      actionableCount > 0
+        ? "Review the planner-created work."
+        : input.suppressedOutputCount > 0
+          ? "Review planner confidence thresholds before dispatching."
+          : undefined,
+    notificationRecommended: input.trigger !== "manual" && usefulness === "actionable",
+    notificationReason:
+      input.trigger !== "manual" && usefulness === "actionable"
+        ? "Automated planner run created or dispatched work."
+        : undefined,
+  };
+}
+
+export function classifyStrategicPlannerFailure(input: {
+  company: Company;
+  configWorkspaceId?: string;
+  trigger: StrategicPlannerRun["trigger"];
+  error: string;
+}): CreateAutomationRunOutcomeInput {
+  return {
+    source: "strategic_planner",
+    workspaceId: input.configWorkspaceId || input.company.defaultWorkspaceId,
+    companyId: input.company.id,
+    title: `${input.company.name} planner failed`,
+    summary: input.error,
+    usefulness: "failed",
+    trigger: input.trigger,
+    nextAction: "Inspect the planner run error.",
+    notificationRecommended: input.trigger !== "manual",
+    notificationReason: "Automated planner run failed.",
+  };
+}
+
+export function classifyCheckEvidence(input: {
+  source: CreateAutomationRunOutcomeInput["source"];
+  title: string;
+  summary: string;
+  trigger: AutomationRunTrigger;
+  workspaceId?: string;
+  taskId?: string;
+  sourceRunId?: string;
+  declaredCheck: boolean;
+  executedCommandCount: number;
+  toolCallCount: number;
+  failedCheckCount?: number;
+  limitationOnly?: boolean;
+}): CreateAutomationRunOutcomeInput {
+  const noRealCheckEvidence =
+    input.declaredCheck &&
+    input.executedCommandCount === 0 &&
+    (input.toolCallCount === 0 || input.limitationOnly);
+  const failed = (input.failedCheckCount || 0) > 0;
+  return {
+    source: input.source,
+    sourceRunId: input.sourceRunId,
+    taskId: input.taskId,
+    workspaceId: input.workspaceId,
+    title: input.title,
+    summary: input.summary,
+    usefulness: failed ? "failed" : noRealCheckEvidence ? "low_value" : "informational",
+    trigger: input.trigger,
+    metrics: {
+      checkedSurfaceCount: input.executedCommandCount + input.toolCallCount,
+      failedCheckCount: input.failedCheckCount || 0,
+      executedCommandCount: input.executedCommandCount,
+      toolCallCount: input.toolCallCount,
+      limitationOnly: input.limitationOnly || false,
+    },
+    notificationRecommended: failed,
+    notificationReason: failed ? "A background check failed." : undefined,
+  };
+}

--- a/src/electron/control-plane/StrategicPlannerService.ts
+++ b/src/electron/control-plane/StrategicPlannerService.ts
@@ -12,6 +12,7 @@ import type {
   StrategicPlannerConfigUpdate,
   StrategicPlannerRun,
   StrategicPlannerRunRequest,
+  CreateAutomationRunOutcomeInput,
 } from "../../shared/types";
 import type { AgentDaemon } from "../agent/daemon";
 import { TaskRepository, WorkspaceRepository } from "../database/repositories";
@@ -22,6 +23,10 @@ import {
   resolveOperationalAutonomyPolicy,
 } from "../agents/autonomy-policy";
 import { isTempWorkspaceId } from "../../shared/types";
+import {
+  classifyStrategicPlannerFailure,
+  classifyStrategicPlannerOutcome,
+} from "../automation/automation-outcome-classifier";
 
 const DEFAULT_INTERVAL_MINUTES = 180;
 const DEFAULT_MAX_ISSUES_PER_RUN = 4;
@@ -59,6 +64,9 @@ interface StrategicPlannerServiceDeps {
   db: Database.Database;
   agentDaemon?: AgentDaemon;
   log?: (...args: unknown[]) => void;
+  recordAutomationOutcome?: (
+    outcome: CreateAutomationRunOutcomeInput,
+  ) => Promise<unknown>;
 }
 
 export class StrategicPlannerService {
@@ -304,7 +312,15 @@ export class StrategicPlannerService {
           runId,
         );
       this.recordSuccessfulRunConfigUpdate(request.companyId, Date.now());
-      return this.getRunOrThrow(runId);
+      const completedRun = this.getRunOrThrow(runId);
+      await this.recordAutomatedRunOutcome({
+        company,
+        config,
+        trigger,
+        run: completedRun,
+        outcome,
+      });
+      return completedRun;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.deps.db
@@ -316,10 +332,68 @@ export class StrategicPlannerService {
           `,
         )
         .run(message, Date.now(), Date.now(), runId);
+      await this.recordAutomatedRunFailure(company, config, trigger, message);
       throw error;
     } finally {
       this.activeRuns.delete(request.companyId);
     }
+  }
+
+  private async recordAutomatedRunOutcome(params: {
+    company: Company;
+    config: StrategicPlannerConfig;
+    trigger: string;
+    run: StrategicPlannerRun;
+    outcome: {
+      createdIssueIds: string[];
+      updatedIssueIds: string[];
+      dispatchedTaskIds: string[];
+      suppressedOutputs: Array<{ seedTitle: string; summary: string; outputType: CompanyOutputType }>;
+    };
+  }): Promise<void> {
+    if (!this.deps.recordAutomationOutcome) return;
+    const { company, config, run, outcome } = params;
+    try {
+      await this.deps.recordAutomationOutcome(
+        classifyStrategicPlannerOutcome({
+          company,
+          configWorkspaceId: config.planningWorkspaceId,
+          trigger: this.normalizeTrigger(params.trigger),
+          run,
+          createdIssueIds: outcome.createdIssueIds,
+          updatedIssueIds: outcome.updatedIssueIds,
+          dispatchedTaskIds: outcome.dispatchedTaskIds,
+          suppressedOutputCount: outcome.suppressedOutputs.length,
+        }),
+      );
+    } catch (error) {
+      this.log("Failed to record automated planner outcome", error);
+    }
+  }
+
+  private async recordAutomatedRunFailure(
+    company: Company,
+    config: StrategicPlannerConfig,
+    trigger: string,
+    message: string,
+  ): Promise<void> {
+    if (!this.deps.recordAutomationOutcome) return;
+    try {
+      await this.deps.recordAutomationOutcome(
+        classifyStrategicPlannerFailure({
+          company,
+          configWorkspaceId: config.planningWorkspaceId,
+          trigger: this.normalizeTrigger(trigger),
+          error: message,
+        }),
+      );
+    } catch (error) {
+      this.log("Failed to record automated planner failure outcome", error);
+    }
+  }
+
+  private normalizeTrigger(trigger: string): StrategicPlannerRun["trigger"] {
+    return trigger === "schedule" || trigger === "startup" ? trigger : "manual";
   }
 
   private async tick(): Promise<void> {

--- a/src/electron/control-plane/__tests__/StrategicPlannerService.test.ts
+++ b/src/electron/control-plane/__tests__/StrategicPlannerService.test.ts
@@ -132,6 +132,38 @@ describeWithSqlite("StrategicPlannerService", () => {
     ).toBe(true);
   });
 
+  it("records an actionable outcome when an automated planner run creates work", async () => {
+    const outcomes: Any[] = [];
+    planner = new (await import("../StrategicPlannerService")).StrategicPlannerService({
+      db,
+      recordAutomationOutcome: async (outcome) => {
+        outcomes.push(outcome);
+      },
+    });
+    const company = core.getDefaultCompany();
+    core.createProject({
+      companyId: company.id,
+      name: "Lifecycle Signals",
+    });
+
+    planner.updateConfig(company.id, {
+      enabled: true,
+      maxIssuesPerRun: 2,
+      autoDispatch: false,
+    });
+
+    const run = await planner.runNow({ companyId: company.id, trigger: "schedule" });
+
+    expect(run.status).toBe("completed");
+    expect(outcomes).toContainEqual(
+      expect.objectContaining({
+        usefulness: "actionable",
+        notificationRecommended: true,
+        title: `${company.name} planner found background work`,
+      }),
+    );
+  });
+
   it("uses the company default workspace instead of creating workspace-link issues", async () => {
     const company = core.createCompany({
       name: "Planner Workspace Co",

--- a/src/electron/database/schema.ts
+++ b/src/electron/database/schema.ts
@@ -1399,6 +1399,36 @@ export class DatabaseManager {
       CREATE INDEX IF NOT EXISTS idx_mission_control_evidence_item
         ON mission_control_item_evidence(item_id, timestamp DESC);
 
+      CREATE TABLE IF NOT EXISTS automation_run_outcomes (
+        id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        source_run_id TEXT,
+        task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+        workspace_id TEXT REFERENCES workspaces(id) ON DELETE SET NULL,
+        company_id TEXT REFERENCES companies(id) ON DELETE SET NULL,
+        agent_role_id TEXT REFERENCES agent_roles(id) ON DELETE SET NULL,
+        title TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        usefulness TEXT NOT NULL,
+        trigger TEXT NOT NULL,
+        notification_recommended INTEGER NOT NULL DEFAULT 0,
+        notification_reason TEXT,
+        notification_delivered_at INTEGER,
+        next_action TEXT,
+        metrics_json TEXT,
+        evidence_refs_json TEXT,
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_automation_outcomes_created
+        ON automation_run_outcomes(created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_automation_outcomes_company
+        ON automation_run_outcomes(company_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_automation_outcomes_workspace
+        ON automation_run_outcomes(workspace_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_automation_outcomes_usefulness
+        ON automation_run_outcomes(usefulness, created_at DESC);
+
       CREATE TABLE IF NOT EXISTS company_package_sources (
         id TEXT PRIMARY KEY,
         company_id TEXT REFERENCES companies(id) ON DELETE CASCADE,

--- a/src/electron/ipc/mission-control-handlers.ts
+++ b/src/electron/ipc/mission-control-handlers.ts
@@ -59,6 +59,7 @@ import { CoreHarnessExperimentService } from "../core/CoreHarnessExperimentServi
 import { CoreHarnessExperimentRunner } from "../core/CoreHarnessExperimentRunner";
 import { CoreLearningsService } from "../core/CoreLearningsService";
 import { MissionControlIntelligenceService } from "../mission-control/MissionControlIntelligenceService";
+import { AutomationRunOutcomeRepository } from "../automation/AutomationRunOutcomeRepository";
 import {
   AutomationProfileAttachRequestSchema,
   AutomationProfileCreateRequestSchema,
@@ -249,6 +250,7 @@ export function setupMissionControlHandlers(deps: MissionControlDeps): void {
   const coreMemoryCandidateRepo = new CoreMemoryCandidateRepository(db);
   const coreMemoryDistillRunRepo = new CoreMemoryDistillRunRepository(db);
   const missionControlIntelligence = new MissionControlIntelligenceService(db);
+  const automationOutcomeRepo = new AutomationRunOutcomeRepository(db);
   const agentCompanies = new AgentCompaniesService(db, core, agentRoleRepo);
   const taskRepo = new TaskRepository(db);
   const activityRepo = new ActivityRepository(db);
@@ -926,6 +928,8 @@ export function setupMissionControlHandlers(deps: MissionControlDeps): void {
     const issues = core.listIssues({ companyId: validated, limit: 5000 });
     const runs = core.listRuns({ companyId: validated, limit: 100 });
     const plannerRuns = requirePlannerService().listRuns({ companyId: validated, limit: 8 });
+    const automationOutcomes = automationOutcomeRepo.list({ companyId: validated, limit: 12 });
+    const automationOutcomeSummary = automationOutcomeRepo.summarize({ companyId: validated });
     const operators = agentRoleRepo.findByCompanyId(validated, false);
     const activityWorkspaceId = company.defaultWorkspaceId;
     const activities = activityWorkspaceId
@@ -1125,6 +1129,8 @@ export function setupMissionControlHandlers(deps: MissionControlDeps): void {
       reviewQueue: reviewQueue.slice(0, 20),
       executionMap,
       plannerRuns,
+      automationOutcomes,
+      automationOutcomeSummary,
     };
 
     return summary;

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -54,6 +54,8 @@ import { CrossSignalService } from "./agents/CrossSignalService";
 import { FeedbackService } from "./agents/FeedbackService";
 import { LoreService } from "./agents/LoreService";
 import { AutomationProfileRepository } from "./agents/AutomationProfileRepository";
+import { AutomationRunOutcomeRepository } from "./automation/AutomationRunOutcomeRepository";
+import { AutomationOutcomeService } from "./automation/AutomationOutcomeService";
 import { ProactiveSuggestionsService } from "./agent/ProactiveSuggestionsService";
 import { AgentDaemon } from "./agent/daemon";
 import { CoreMemoryCandidateRepository } from "./core/CoreMemoryCandidateRepository";
@@ -258,6 +260,7 @@ let loreService: LoreService | null = null;
 let xMentionBridgeService: XMentionBridgeService | null = null;
 let strategicPlannerService: StrategicPlannerService | null = null;
 let symphonyService: SymphonyService | null = null;
+let automationOutcomeService: AutomationOutcomeService | null = null;
 let eventTriggerService: EventTriggerService | null = null;
 let routineService: RoutineService | null = null;
 let coreTraceService: CoreTraceService | null = null;
@@ -1536,6 +1539,13 @@ if (!gotTheLock) {
     // Initialize database first - required for SecureSettingsRepository
     const coreInitStartedAt = Date.now();
     dbManager = new DatabaseManager();
+    automationOutcomeService = new AutomationOutcomeService({
+      repo: new AutomationRunOutcomeRepository(dbManager.getDatabase()),
+      notify: async (params) => {
+        const notificationService = getNotificationService();
+        await notificationService?.add(params);
+      },
+    });
     const usageInsightsProjector = UsageInsightsProjector.initialize(
       dbManager.getDatabase(),
     );
@@ -2838,6 +2848,8 @@ if (!gotTheLock) {
         coreMemoryCandidateService: coreMemoryCandidateService || undefined,
         coreMemoryDistiller: coreMemoryDistiller || undefined,
         coreLearningPipelineService: coreLearningPipelineService || undefined,
+        recordAutomationOutcome: async (outcome) =>
+          automationOutcomeService?.record(outcome),
       };
 
       heartbeatService = new HeartbeatService(heartbeatDeps);
@@ -3028,6 +3040,8 @@ if (!gotTheLock) {
         db: dbManager.getDatabase(),
         agentDaemon,
         log: (...args) => logger.info(...args),
+        recordAutomationOutcome: async (outcome) =>
+          automationOutcomeService?.record(outcome),
       });
       setStrategicPlannerService(strategicPlannerService);
       strategicPlannerService.start();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -10474,6 +10474,95 @@ export interface NotificationStoreFile {
   notifications: AppNotification[];
 }
 
+// ============ Automation Outcome Types ============
+
+export type AutomationRunSource =
+  | "heartbeat"
+  | "strategic_planner"
+  | "cron"
+  | "daily_plan"
+  | "subconscious"
+  | "memory_dreaming";
+
+export type AutomationRunUsefulness =
+  | "actionable"
+  | "informational"
+  | "low_value"
+  | "failed";
+
+export type AutomationRunTrigger =
+  | "startup"
+  | "schedule"
+  | "manual"
+  | "heartbeat"
+  | "hook"
+  | "cron"
+  | "api";
+
+export interface AutomationRunEvidenceRef {
+  type: string;
+  id?: string;
+  label: string;
+}
+
+export interface AutomationRunOutcomeMetrics {
+  changedIssueCount?: number;
+  createdIssueCount?: number;
+  updatedIssueCount?: number;
+  dispatchedTaskCount?: number;
+  checkedSurfaceCount?: number;
+  failedCheckCount?: number;
+  suppressedOutputCount?: number;
+  [key: string]: unknown;
+}
+
+export interface AutomationRunOutcome {
+  id: string;
+  source: AutomationRunSource;
+  sourceRunId?: string;
+  taskId?: string;
+  workspaceId?: string;
+  companyId?: string;
+  agentRoleId?: string;
+  title: string;
+  summary: string;
+  usefulness: AutomationRunUsefulness;
+  trigger: AutomationRunTrigger;
+  metrics?: AutomationRunOutcomeMetrics;
+  evidenceRefs?: AutomationRunEvidenceRef[];
+  nextAction?: string;
+  notificationRecommended: boolean;
+  notificationReason?: string;
+  notificationDeliveredAt?: number;
+  createdAt: number;
+}
+
+export type CreateAutomationRunOutcomeInput = Omit<
+  AutomationRunOutcome,
+  "id" | "createdAt" | "notificationDeliveredAt"
+> & {
+  id?: string;
+  createdAt?: number;
+  notificationDeliveredAt?: number;
+};
+
+export interface AutomationRunOutcomeListRequest {
+  source?: AutomationRunSource;
+  usefulness?: AutomationRunUsefulness;
+  workspaceId?: string;
+  companyId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AutomationRunOutcomeSummary {
+  total: number;
+  actionable: number;
+  informational: number;
+  lowValue: number;
+  failed: number;
+}
+
 // ============ Hooks (Webhooks & Gmail Pub/Sub) Types ============
 
 export interface HooksSettingsData {
@@ -13194,6 +13283,8 @@ export interface CompanyCommandCenterSummary {
   reviewQueue: CompanyReviewQueueItem[];
   executionMap: CompanyExecutionMapItem[];
   plannerRuns: StrategicPlannerRun[];
+  automationOutcomes: AutomationRunOutcome[];
+  automationOutcomeSummary: AutomationRunOutcomeSummary;
 }
 
 export type MissionControlCategory =


### PR DESCRIPTION
## Summary
- add automation run outcome types, repository, classifier, and notification policy
- record Heartbeat and Strategic Planner automation outcomes
- expose recent automation outcomes and summary counts in the command-center backend summary
- add automation outcome schema support and main-process service wiring

## Validation
- npx vitest run src/electron/automation/__tests__/AutomationRunOutcomeRepository.test.ts src/electron/automation/__tests__/automation-outcome-classifier.test.ts src/electron/agents/__tests__/HeartbeatService.test.ts src/electron/control-plane/__tests__/StrategicPlannerService.test.ts
- npm run build:electron

Note: SQLite-backed suites were skipped in this environment because native better-sqlite3 was unavailable to Vitest; non-SQLite classifier tests ran and passed.