### PR TITLE
fix(renderer): improve timeline event projection

### DIFF
--- a/src/renderer/components/timeline/ActionBlock.tsx
+++ b/src/renderer/components/timeline/ActionBlock.tsx
@@ -14,6 +14,7 @@ import {
   SquareTerminal,
 } from "lucide-react";
 import { getEffectiveTaskEventType } from "../../utils/task-event-compat";
+import { isBrowserToolName } from "../../utils/timeline-tool-labels";
 
 export type ActionBlockIconKind =
   | "explore"
@@ -159,7 +160,11 @@ export function buildActionBlockSummary(
   const webLookups =
     (toolCounts.get("web_fetch") || 0) +
     (toolCounts.get("web_search") || 0) +
-    (toolCounts.get("http_request") || 0);
+    (toolCounts.get("http_request") || 0) +
+    Array.from(toolCounts.entries()).reduce(
+      (sum, [tool, count]) => sum + (isBrowserToolName(tool) ? count : 0),
+      0,
+    );
   let verificationSteps = 0;
   let generativeSteps = 0;
   for (const event of events) {

--- a/src/renderer/components/timeline/ParallelGroupFeed.tsx
+++ b/src/renderer/components/timeline/ParallelGroupFeed.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { AlertTriangle, Check, Circle, Loader2 } from "lucide-react";
 import type { TimelineEventStatus } from "../../../shared/types";
+import { isBrowserToolName } from "../../utils/timeline-tool-labels";
 import { StepFeed } from "./StepFeed";
 import type { TimelineIndicatorSpec } from "./timeline-indicators";
 import type { ParallelGroupProjection } from "./parallel-group-projection";
@@ -65,6 +66,10 @@ function hasActiveImageGenerationLane(group: ParallelGroupProjection): boolean {
   return group.lanes.some(isActiveImageGenerationLane);
 }
 
+function isBrowserToolGroup(group: ParallelGroupProjection): boolean {
+  return group.lanes.length > 0 && group.lanes.every((lane) => isBrowserToolName(lane.toolName));
+}
+
 function ImageGenerationFramePreview() {
   return (
     <div
@@ -81,6 +86,10 @@ function ImageGenerationFramePreview() {
 
 function buildParallelGroupTitle(group: ParallelGroupProjection, isActive: boolean): string {
   const count = group.lanes.length;
+  if (isBrowserToolGroup(group)) {
+    return isActive ? "Using the browser" : "Used the browser";
+  }
+
   const singleLaneTitle =
     count === 1 && typeof group.lanes[0]?.title === "string" ? group.lanes[0].title.trim() : "";
   if (singleLaneTitle) {
@@ -135,10 +144,11 @@ export function ParallelGroupFeed({
   }
 
   const singleLane = group.lanes.length === 1 ? group.lanes[0] : null;
+  const isBrowserGroup = isBrowserToolGroup(group);
   const isActive =
     isActiveStatus(group.status) || group.lanes.some((lane) => isActiveStatus(lane.status));
   const showImageGenerationFrame = hasActiveImageGenerationLane(group);
-  const hasExpandableDetails = group.lanes.length > 1;
+  const hasExpandableDetails = group.lanes.length > 1 || isBrowserGroup;
   const [expanded, setExpanded] = useState(hasExpandableDetails && (isActive || defaultExpanded));
 
   useEffect(() => {
@@ -154,7 +164,7 @@ export function ParallelGroupFeed({
   const indicator = useMemo(() => buildIndicatorForStatus(group.status), [group.status]);
   const groupTitle = useMemo(() => buildParallelGroupTitle(group, isActive), [group, isActive]);
 
-  if (singleLane) {
+  if (singleLane && !isBrowserGroup) {
     return (
       <div className="timeline-event parallel-group-feed-single">
         <div className="parallel-group-feed-lane parallel-group-feed-single-lane">

--- a/src/renderer/components/timeline/__tests__/action-block-summary.test.ts
+++ b/src/renderer/components/timeline/__tests__/action-block-summary.test.ts
@@ -84,6 +84,16 @@ describe("buildActionBlockSummary", () => {
     expect(summary.summary).toBe("1 step");
   });
 
+  it("counts browser tools as web activity", () => {
+    const summary = buildActionBlockSummary([
+      toolEvent("browser-1", "browser_navigate", 1000),
+      toolEvent("browser-2", "browser_screenshot", 1100),
+    ]);
+
+    expect(summary.iconKind).toBe("web");
+    expect(summary.summary).toBe("2 web lookups");
+  });
+
   it("renders generation blocks with a sparkles glyph instead of the generic work circle", () => {
     const html = renderToStaticMarkup(
       createElement(

--- a/src/renderer/components/timeline/__tests__/parallel-group-feed.test.ts
+++ b/src/renderer/components/timeline/__tests__/parallel-group-feed.test.ts
@@ -250,4 +250,73 @@ describe("ParallelGroupFeed", () => {
     expect(markup).not.toContain('class="parallel-group-feed-details"');
     expect(markup).not.toContain("Exit Status Is 0");
   });
+
+  it("renders browser tool batches as a browser step with lane details", () => {
+    const markup = render(
+      React.createElement(ParallelGroupFeed, {
+        group: makeGroup({
+          label: "Research Sources",
+          status: "completed",
+          lanes: [
+            {
+              laneKey: "use-1",
+              toolUseId: "use-1",
+              toolName: "browser_navigate",
+              toolCallIndex: 1,
+              title: "Opened browser: localhost:5173",
+              status: "completed",
+              startedAt: 1001,
+            },
+            {
+              laneKey: "use-2",
+              toolUseId: "use-2",
+              toolName: "browser_screenshot",
+              toolCallIndex: 2,
+              title: "Captured screenshot",
+              status: "completed",
+              startedAt: 1002,
+            },
+          ],
+        }),
+        timeLabel: "12:03",
+        formatTime: () => "12:03",
+        defaultExpanded: true,
+      }),
+    );
+
+    expect(markup).toContain("Used the browser");
+    expect(markup).toContain("Opened browser: localhost:5173");
+    expect(markup).toContain("Captured screenshot");
+    expect(markup).not.toContain("Research Sources");
+  });
+
+  it("renders a single browser lane as an expandable browser step", () => {
+    const markup = render(
+      React.createElement(ParallelGroupFeed, {
+        group: makeGroup({
+          label: "Tool batch (1)",
+          status: "completed",
+          lanes: [
+            {
+              laneKey: "use-1",
+              toolUseId: "use-1",
+              toolName: "browser_snapshot",
+              toolCallIndex: 1,
+              title: "Inspected page",
+              status: "completed",
+              startedAt: 1001,
+            },
+          ],
+        }),
+        timeLabel: "12:03",
+        formatTime: () => "12:03",
+        defaultExpanded: true,
+      }),
+    );
+
+    expect(markup).toContain("Used the browser");
+    expect(markup).toContain("Inspected page");
+    expect(markup).toContain("event-expand-icon");
+    expect(markup).not.toContain("parallel-group-feed-single");
+  });
 });

--- a/src/renderer/components/timeline/__tests__/parallel-group-projection.test.ts
+++ b/src/renderer/components/timeline/__tests__/parallel-group-projection.test.ts
@@ -225,6 +225,38 @@ describe("parallel-group-projection", () => {
     expect(group?.lanes[0]?.title).toBe("Read files: SessionRuntime.ts, ToolScheduler.ts");
   });
 
+  it("shows skill names for grouped SKILL.md reads", () => {
+    const groupId = "tools:step:build:1";
+    const events: TaskEvent[] = [
+      makeEvent("timeline_group_started", "evt-1", {
+        groupId,
+        groupLabel: "Tool batch (1)",
+      }),
+      makeEvent("tool_call", "evt-2", {
+        groupId,
+        tool: "read_file",
+        toolUseId: "use-1",
+        toolCallIndex: 1,
+        input: { path: "/Users/test/.codex/skills/test/SKILL.md" },
+      }),
+      makeEvent("tool_result", "evt-3", {
+        groupId,
+        tool: "read_file",
+        toolUseId: "use-1",
+        toolCallIndex: 1,
+        result: {
+          success: true,
+          path: "/Users/test/.codex/skills/test/SKILL.md",
+          content: "# Test",
+        },
+      }),
+    ];
+
+    const projection = buildParallelGroupProjection(events);
+    const group = projection.groupsByAnchorEventId.get("evt-1");
+    expect(group?.lanes[0]?.title).toBe("Read Test skill");
+  });
+
   it("uses embedded timeline tool payloads for lane titles", () => {
     const groupId = "tools:step:build:1";
     const events: TaskEvent[] = [

--- a/src/renderer/components/timeline/__tests__/timeline-indicators.test.ts
+++ b/src/renderer/components/timeline/__tests__/timeline-indicators.test.ts
@@ -5,6 +5,7 @@ import {
   Circle,
   FileOutput,
   Loader2,
+  Package,
   RotateCcw,
   Search,
   Shield,
@@ -110,6 +111,26 @@ describe("timeline indicators", () => {
     const indicator = resolveTimelineIndicator(makeEvent("retry_started", { attempt: 2 }));
     expect(indicator.icon).toBe(RotateCcw);
     expect(indicator.tone).toBe("active");
+  });
+
+  it("maps skill reads to Package icon", () => {
+    const reading = resolveTimelineIndicator(
+      makeEvent("tool_call", {
+        tool: "read_file",
+        input: { path: "/Users/test/.codex/skills/test/SKILL.md" },
+      }),
+    );
+    expect(reading.icon).toBe(Package);
+    expect(reading.tone).toBe("active");
+
+    const read = resolveTimelineIndicator(
+      makeEvent("tool_result", {
+        tool: "skill",
+        result: { skill_name: "Test" },
+      }),
+    );
+    expect(read.icon).toBe(Package);
+    expect(read.tone).toBe("success");
   });
 
   it("falls back to Circle neutral icon for unknown event types", () => {

--- a/src/renderer/components/timeline/timeline-indicators.ts
+++ b/src/renderer/components/timeline/timeline-indicators.ts
@@ -17,6 +17,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { getEffectiveTaskEventType } from "../../utils/task-event-compat";
+import { isSkillToolName } from "../../utils/timeline-tool-labels";
 
 export type TimelineIndicatorTone = "neutral" | "active" | "success" | "warning" | "error";
 
@@ -42,6 +43,33 @@ function resolveGroupLabel(payload: unknown): string {
   const obj = asObject(payload);
   const raw = typeof obj.groupLabel === "string" ? obj.groupLabel.trim() : "";
   return raw;
+}
+
+function isSkillReadToolEvent(event: TaskEvent): boolean {
+  const effectiveType = getEffectiveTaskEventType(event);
+  if (effectiveType !== "tool_call" && effectiveType !== "tool_result") return false;
+
+  const payload = asObject(event.payload);
+  const tool = typeof payload.tool === "string" ? payload.tool.trim() : "";
+  if (isSkillToolName(tool)) return true;
+
+  if (tool !== "read_file" && tool !== "read_files") return false;
+  const input = asObject(payload.input);
+  const result = asObject(payload.result);
+  const path =
+    (typeof input.path === "string" && input.path.trim()) ||
+    (typeof result.path === "string" && result.path.trim()) ||
+    "";
+  if (/\/?SKILL\.md$/i.test(path)) return true;
+
+  if (Array.isArray(result.files)) {
+    return result.files.some((entry) => {
+      const obj = asObject(entry);
+      return typeof obj.path === "string" && /\/?SKILL\.md$/i.test(obj.path.trim());
+    });
+  }
+
+  return false;
 }
 
 export function resolveTimelineGroupId(event: TaskEvent): string | null {
@@ -134,6 +162,15 @@ export function resolveTimelineIndicator(
 
   if (effectiveType === "retry_started") {
     return { icon: RotateCcw, tone: "active", label: "Retry started" };
+  }
+
+  if (isSkillReadToolEvent(event)) {
+    const completed = effectiveType === "tool_result" || isTaskCompleted;
+    return {
+      icon: Package,
+      tone: completed ? "success" : "active",
+      label: completed ? "Skill read" : "Reading skill",
+    };
   }
 
   if (

--- a/src/renderer/utils/__tests__/task-event-derived.test.ts
+++ b/src/renderer/utils/__tests__/task-event-derived.test.ts
@@ -11,6 +11,7 @@ function makeEvent(
   timestamp: number,
   type: string,
   payload: Record<string, unknown> = {},
+  overrides: Record<string, unknown> = {},
 ): Any {
   return {
     id,
@@ -18,6 +19,7 @@ function makeEvent(
     timestamp,
     type,
     payload,
+    ...overrides,
   };
 }
 
@@ -143,6 +145,37 @@ describe("deriveSharedTaskEventUiState action blocks", () => {
       "error-1",
       "error-3",
     ]);
+  });
+
+  it("deduplicates matching visible failed-step and timeline error events", () => {
+    const reason =
+      "Step contract failure [contract_unmet_write_required][artifact_write_checkpoint_failed]: iteration 5 reached without successful file/canvas mutation.";
+    const shared = deriveSharedTaskEventUiState({
+      rawEvents: [
+        makeEvent(
+          "step-failed",
+          1_000,
+          "timeline_step_finished",
+          {
+            legacyType: "step_failed",
+            message: reason,
+            reason,
+            step: { id: "step-1", description: "Applying fixes", error: reason },
+          },
+          { status: "failed", stepId: "step-1" },
+        ),
+        makeEvent("hidden-progress", 1_001, "timeline_step_updated", {
+          legacyType: "progress_update",
+          message: "Internal progress",
+        }),
+        makeEvent("matching-error", 1_002, "timeline_error", { message: reason }),
+      ],
+      task: { id: "task-1", status: "failed" } as Any,
+      workspace: null,
+      verboseSteps: false,
+    });
+
+    expect(shared.filteredEvents.map((event) => event.id)).toEqual(["step-failed"]);
   });
 
   it("limits command output sessions when more sessions are running than the UI budget", () => {

--- a/src/renderer/utils/__tests__/task-event-visibility.test.ts
+++ b/src/renderer/utils/__tests__/task-event-visibility.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { TaskEvent } from "../../../shared/types";
 import {
   ALWAYS_VISIBLE_TECHNICAL_EVENT_TYPES,
+  filterAdjacentDuplicateTimelineFailures,
   filterVerboseTimelineNoise,
   IMPORTANT_EVENT_TYPES,
   isImportantTaskEvent,
@@ -51,6 +52,26 @@ describe("task event visibility helpers", () => {
         makeEvent("timeline_step_updated", { legacyType: "tool_result", tool: "run_command" }),
       ),
     ).toBe(false);
+  });
+
+  it("hides implementation-only browser action audit events from the step feed", () => {
+    const browserAction = makeEvent(
+      "log",
+      { action: "snapshot", url: "http://localhost:5173" },
+      { type: "browser_action" as TaskEvent["type"] },
+    );
+
+    expect(isImportantTaskEvent(browserAction)).toBe(false);
+    expect(shouldShowTaskEventInStepFeed(browserAction, { verboseSteps: true })).toBe(false);
+  });
+
+  it("keeps canonical browser tool calls visible in the verbose step feed", () => {
+    const browserToolCall = makeEvent("tool_call", {
+      tool: "browser_snapshot",
+      input: { session_id: "default" },
+    });
+
+    expect(shouldShowTaskEventInStepFeed(browserToolCall, { verboseSteps: true })).toBe(true);
   });
 
   it("keeps timeline assistant messages visible in summary mode", () => {
@@ -455,6 +476,72 @@ describe("task event visibility helpers", () => {
       ),
     ]);
     expect(filtered.map((e) => e.id)).toEqual(["a", "c", "e"]);
+  });
+
+  it("deduplicates adjacent timeline_error events that repeat a failed step reason", () => {
+    const reason =
+      "Step contract failure [contract_unmet_write_required][artifact_write_checkpoint_failed]: iteration 5 reached without successful file/canvas mutation.";
+    const filtered = filterAdjacentDuplicateTimelineFailures([
+      makeEvent(
+        "timeline_step_finished",
+        {
+          legacyType: "step_failed",
+          message: reason,
+          reason,
+          step: { id: "step-1", description: "Applying fixes", error: reason },
+        },
+        { id: "step-failed", timestamp: 1000, status: "failed", stepId: "step-1" },
+      ),
+      makeEvent(
+        "timeline_error",
+        { message: reason.replace(/\.$/, "") },
+        { id: "matching-error", timestamp: 1001 },
+      ),
+    ]);
+
+    expect(filtered.map((event) => event.id)).toEqual(["step-failed"]);
+  });
+
+  it("keeps the failed step when an adjacent duplicate timeline_error arrives first", () => {
+    const reason =
+      "Step contract failure [contract_unmet_write_required][artifact_write_checkpoint_failed]: iteration 5 reached without successful file/canvas mutation.";
+    const filtered = filterAdjacentDuplicateTimelineFailures([
+      makeEvent("timeline_error", { message: reason }, { id: "matching-error", timestamp: 1000 }),
+      makeEvent(
+        "timeline_step_finished",
+        {
+          legacyType: "step_failed",
+          message: reason,
+          reason,
+          step: { id: "step-1", description: "Applying fixes", error: reason },
+        },
+        { id: "step-failed", timestamp: 1001, status: "failed", stepId: "step-1" },
+      ),
+    ]);
+
+    expect(filtered.map((event) => event.id)).toEqual(["step-failed"]);
+  });
+
+  it("keeps adjacent timeline_error events with different failure text", () => {
+    const filtered = filterAdjacentDuplicateTimelineFailures([
+      makeEvent(
+        "timeline_step_finished",
+        {
+          legacyType: "step_failed",
+          message: "Step contract failure: missing artifact write",
+          reason: "Step contract failure: missing artifact write",
+          step: { id: "step-1", description: "Applying fixes" },
+        },
+        { id: "step-failed", timestamp: 1000, status: "failed", stepId: "step-1" },
+      ),
+      makeEvent(
+        "timeline_error",
+        { message: "Completion blocked: unresolved failed step(s): step-1" },
+        { id: "completion-error", timestamp: 1001 },
+      ),
+    ]);
+
+    expect(filtered.map((event) => event.id)).toEqual(["step-failed", "completion-error"]);
   });
 
   it("keeps stage-boundary group starts in verbose mode along with custom groups", () => {

--- a/src/renderer/utils/__tests__/timeline-tool-labels.test.ts
+++ b/src/renderer/utils/__tests__/timeline-tool-labels.test.ts
@@ -12,6 +12,9 @@ describe("timeline-tool-labels", () => {
     expect(friendlyToolRunningLabel("web_fetch")).toBe("Fetching a web page");
     expect(friendlyToolRunningLabel("http_request")).toBe("Fetching a web page");
     expect(friendlyToolRunningLabel("grep")).toBe("Searching in files");
+    expect(friendlyToolRunningLabel("browser_screenshot")).toBe("Browser take screenshot");
+    expect(friendlyToolRunningLabel("browser_snapshot")).toBe("Browser snapshot");
+    expect(friendlyToolRunningLabel("skill")).toBe("Reading a skill");
   });
 
   it("formats tool_call titles with context", () => {
@@ -47,6 +50,24 @@ describe("timeline-tool-labels", () => {
         patterns: ["src/renderer/**/*.tsx", "!src/**/*.test.ts"],
       }),
     ).toBe("Read files: src/renderer/**/*.tsx, !src/**/*.test.ts");
+    expect(
+      friendlyToolCallTitle("browser_navigate", {
+        url: "http://localhost:5173/dashboard",
+      }),
+    ).toBe("Browser navigate: localhost/dashboard");
+    expect(friendlyToolCallTitle("browser_screenshot", { full_page: true })).toBe(
+      "Browser take screenshot",
+    );
+    expect(
+      friendlyToolCallTitle("read_file", {
+        path: "/Users/test/.codex/skills/test/SKILL.md",
+      }),
+    ).toBe("Reading Test skill");
+    expect(
+      friendlyToolCallTitle("skill", {
+        skillName: "Test",
+      }),
+    ).toBe("Reading Test skill");
   });
 
   it("formats tool_result titles with detail", () => {
@@ -90,10 +111,45 @@ describe("timeline-tool-labels", () => {
     expect(friendlyToolResultTitle("grep", { success: true, matches: [{}, {}] }, true)).toContain(
       "match",
     );
+    expect(
+      friendlyToolResultTitle(
+        "browser_navigate",
+        { url: "http://localhost:5173/dashboard", title: "Dashboard" },
+        true,
+      ),
+    ).toBe("Browser navigate: Dashboard");
+    expect(
+      friendlyToolResultTitle(
+        "browser_snapshot",
+        { url: "http://localhost:5173/dashboard", title: "Dashboard" },
+        true,
+      ),
+    ).toBe("Browser snapshot — Dashboard");
+    expect(
+      friendlyToolResultTitle(
+        "read_file",
+        { path: "/Users/test/.codex/skills/test/SKILL.md", content: "# Test" },
+        true,
+      ),
+    ).toBe("Read Test skill");
+    expect(
+      friendlyToolResultTitle(
+        "read_files",
+        { files: [{ path: "/Users/test/.codex/skills/test/SKILL.md", content: "# Test" }] },
+        true,
+      ),
+    ).toBe("Read Test skill");
+    expect(
+      friendlyToolResultTitle("skill", { skill_name: "Test" }, true),
+    ).toBe("Read Test skill");
   });
 
   it("uses short lane completion labels", () => {
     expect(friendlyToolLaneCompletedLabel("web_fetch", false)).toBe("Fetched page");
     expect(friendlyToolLaneCompletedLabel("web_search", true)).toBe("Search failed");
+    expect(friendlyToolLaneCompletedLabel("browser_snapshot", false)).toBe("Browser snapshot");
+    expect(friendlyToolLaneCompletedLabel("browser_click", true)).toBe("Browser action failed");
+    expect(friendlyToolLaneCompletedLabel("browser_network", false)).toBe("Browser network");
+    expect(friendlyToolLaneCompletedLabel("skill", false)).toBe("Read skill");
   });
 });

--- a/src/renderer/utils/task-event-derived.ts
+++ b/src/renderer/utils/task-event-derived.ts
@@ -17,6 +17,7 @@ import {
 } from "./task-outputs";
 import { hasAssistantMediaDirective } from "./assistant-media-directives";
 import {
+  filterAdjacentDuplicateTimelineFailures,
   filterVerboseTimelineNoise,
   isLlmRequestCancelledEvent,
   shouldShowTaskEventInSummaryMode,
@@ -790,7 +791,7 @@ export function deriveSharedTaskEventUiState(
   const normalizedEvents = normalizeEventsForTimelineUi(rawEvents);
   const candidateEvents = params.verboseSteps
     ? filterVerboseTimelineNoise(normalizedEvents)
-    : normalizedEvents;
+    : filterAdjacentDuplicateTimelineFailures(normalizedEvents);
 
   const liveEvents: TaskEvent[] = [];
   const inspectOnlyEvents: TaskEvent[] = [];
@@ -825,10 +826,11 @@ export function deriveSharedTaskEventUiState(
     }
   }
 
+  const dedupedLiveEvents = filterAdjacentDuplicateTimelineFailures(liveEvents);
   const parallelGroupProjection = buildParallelGroupProjection(normalizedEvents);
   const suppressedParallelEventIds = parallelGroupProjection.suppressedEventIds;
-  const toolCallPairing = deriveToolCallPairing(liveEvents, suppressedParallelEventIds);
-  const baseTimelineItems = deriveBaseTimelineItems(liveEvents);
+  const toolCallPairing = deriveToolCallPairing(dedupedLiveEvents, suppressedParallelEventIds);
+  const baseTimelineItems = deriveBaseTimelineItems(dedupedLiveEvents);
   const commandOutputSessions = deriveCommandOutputSessions(normalizedEvents);
   const planSteps = derivePlanSteps(normalizedEvents);
   const checklistState = deriveChecklistState(normalizedEvents);
@@ -837,14 +839,14 @@ export function deriveSharedTaskEventUiState(
   const toolUsage = deriveToolUsage(normalizedEvents);
   const referencedFiles = deriveReferencedFiles(normalizedEvents);
   const usedToolNames = deriveUsedToolNames(normalizedEvents);
-  const latestVisibleTaskEvent = getLatestVisibleTaskEvent(baseTimelineItems, liveEvents);
+  const latestVisibleTaskEvent = getLatestVisibleTaskEvent(baseTimelineItems, dedupedLiveEvents);
 
   return {
     projectionMode,
     rawEventCount: params.rawEvents.length,
     normalizedEvents,
-    filteredEvents: liveEvents,
-    liveEvents,
+    filteredEvents: dedupedLiveEvents,
+    liveEvents: dedupedLiveEvents,
     inspectOnlyEvents,
     debugOnlyEvents,
     parallelGroupProjection,

--- a/src/renderer/utils/task-event-visibility.ts
+++ b/src/renderer/utils/task-event-visibility.ts
@@ -199,8 +199,13 @@ function isToolBatchLaneEvent(event: TaskEvent): boolean {
   );
 }
 
+function isImplementationOnlyBrowserActionEvent(event: TaskEvent): boolean {
+  return String(event.type) === "browser_action";
+}
+
 // In non-verbose mode, hide most tool traffic but keep user-facing schedule confirmations visible.
 export function isImportantTaskEvent(event: TaskEvent): boolean {
+  if (isImplementationOnlyBrowserActionEvent(event)) return false;
   const effectiveType = getEffectiveTaskEventType(event);
   if (IMPORTANT_EVENT_TYPES.includes(effectiveType as EventType)) return true;
   if (effectiveType !== "tool_result") return false;
@@ -216,6 +221,69 @@ function getEventMessage(event: TaskEvent): string {
 }
 
 const VERBOSE_DUPLICATE_WINDOW_MS = 15_000;
+
+function normalizeFailureTextForDedupe(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").replace(/[.。]+$/g, "").trim();
+}
+
+function getComparableFailureText(event: TaskEvent): string {
+  if (event.type === "timeline_error") {
+    return normalizeFailureTextForDedupe(getTimelineErrorText(event));
+  }
+
+  const effectiveType = getEffectiveTaskEventType(event);
+  if (effectiveType !== "step_failed") return "";
+
+  const payload = asObject(event.payload);
+  const step = asObject(payload.step);
+  const raw =
+    getPayloadText(payload, "reason") ||
+    getPayloadText(step, "error") ||
+    getPayloadText(payload, "error") ||
+    getPayloadText(payload, "message") ||
+    getPayloadText(step, "description");
+  return normalizeFailureTextForDedupe(raw);
+}
+
+function isTimelineErrorStepFailureDuplicate(current: TaskEvent, previous: TaskEvent): boolean {
+  const currentIsTimelineError = current.type === "timeline_error";
+  const previousIsTimelineError = previous.type === "timeline_error";
+  if (currentIsTimelineError === previousIsTimelineError) return false;
+  if (current.taskId !== previous.taskId) return false;
+
+  const currentEffectiveType = getEffectiveTaskEventType(current);
+  const previousEffectiveType = getEffectiveTaskEventType(previous);
+  const hasFailedStep =
+    currentEffectiveType === "step_failed" || previousEffectiveType === "step_failed";
+  if (!hasFailedStep) return false;
+
+  if (Math.abs((current.timestamp ?? 0) - (previous.timestamp ?? 0)) > VERBOSE_DUPLICATE_WINDOW_MS) {
+    return false;
+  }
+
+  const currentFailureText = getComparableFailureText(current);
+  const previousFailureText = getComparableFailureText(previous);
+  return Boolean(currentFailureText && currentFailureText === previousFailureText);
+}
+
+export function filterAdjacentDuplicateTimelineFailures(events: TaskEvent[]): TaskEvent[] {
+  const out: TaskEvent[] = [];
+  for (const event of events) {
+    const previousVisibleEvent = out[out.length - 1];
+    if (
+      previousVisibleEvent &&
+      isTimelineErrorStepFailureDuplicate(event, previousVisibleEvent)
+    ) {
+      if (event.type === "timeline_error") {
+        continue;
+      }
+      out[out.length - 1] = event;
+      continue;
+    }
+    out.push(event);
+  }
+  return out;
+}
 
 function getToolCorrelationId(payload: Record<string, unknown>): string {
   const toolUseId =
@@ -439,7 +507,7 @@ export function filterVerboseTimelineNoise(events: TaskEvent[]): TaskEvent[] {
       taskIdsAfterBlockingFailure.add(event.taskId);
     }
   }
-  return out;
+  return filterAdjacentDuplicateTimelineFailures(out);
 }
 
 export function shouldShowTaskEventInSummaryMode(
@@ -464,6 +532,7 @@ export function shouldShowTaskEventInStepFeed(
   event: TaskEvent,
   options?: { verboseSteps?: boolean },
 ): boolean {
+  if (isImplementationOnlyBrowserActionEvent(event)) return false;
   if (isToolBatchTimelineGroupEvent(event)) return false;
   if (isToolBatchLaneEvent(event)) return false;
 

--- a/src/renderer/utils/timeline-tool-labels.ts
+++ b/src/renderer/utils/timeline-tool-labels.ts
@@ -26,6 +26,72 @@ function fileBase(path: string): string {
   return path.split("/").pop() || path;
 }
 
+function parentDirBase(path: string): string {
+  const parts = path.split("/").filter((part) => part.length > 0);
+  if (parts.length < 2) return "";
+  return parts[parts.length - 2] || "";
+}
+
+function humanizeIdentifier(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/\.(?:md|markdown)$/i, "")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ");
+  if (!normalized) return "";
+  return normalized.replace(/\b[a-z]/g, (char) => char.toUpperCase());
+}
+
+function formatSkillLabel(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "skill";
+  return /\bskill$/i.test(trimmed) ? trimmed : `${trimmed} skill`;
+}
+
+export function isSkillToolName(toolName: string | undefined): boolean {
+  const normalized = (toolName || "").trim().toLowerCase();
+  return normalized === "skill" || normalized === "use_skill" || normalized === "run_skill";
+}
+
+function skillNameFromPayload(values: Record<string, unknown>): string {
+  const rawName =
+    asTrimmedString(values.skillName) ||
+    asTrimmedString(values.skill_name) ||
+    asTrimmedString(values.name) ||
+    asTrimmedString(values.title) ||
+    asTrimmedString(values.skill) ||
+    asTrimmedString(values.skillId) ||
+    asTrimmedString(values.skill_id) ||
+    asTrimmedString(values.id);
+  return rawName ? humanizeIdentifier(rawName) : "";
+}
+
+function skillNameFromSkillPath(path: string): string {
+  const base = fileBase(path);
+  if (!/^SKILL\.md$/i.test(base)) return "";
+  return humanizeIdentifier(parentDirBase(path));
+}
+
+function skillNameFromToolInput(input: Record<string, unknown>): string {
+  return skillNameFromPayload(input) || skillNameFromSkillPath(asTrimmedString(input.path));
+}
+
+function skillNamesFromReadFilesResult(result: Record<string, unknown>): string[] {
+  const files = Array.isArray(result.files) ? result.files : [];
+  const names = files
+    .map((entry) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) return "";
+      return skillNameFromSkillPath(asTrimmedString((entry as Record<string, unknown>).path));
+    })
+    .filter((entry) => entry.length > 0);
+  return Array.from(new Set(names));
+}
+
+function skillReadLabel(name: string, tense: "running" | "completed"): string {
+  const skillLabel = formatSkillLabel(name);
+  return tense === "running" ? `Reading ${skillLabel}` : `Read ${skillLabel}`;
+}
+
 function summarizeList(values: string[], maxItems = 2): string {
   const items = values.slice(0, maxItems);
   if (items.length === 0) return "";
@@ -33,10 +99,95 @@ function summarizeList(values: string[], maxItems = 2): string {
   return values.length > maxItems ? `${joined}, +${values.length - maxItems} more` : joined;
 }
 
+export function isBrowserToolName(toolName: string | undefined): boolean {
+  return typeof toolName === "string" && toolName.trim().startsWith("browser_");
+}
+
+function browserToolDisplayName(toolName: string): string {
+  switch (toolName) {
+    case "browser_navigate":
+      return "Browser navigate";
+    case "browser_screenshot":
+      return "Browser take screenshot";
+    case "browser_snapshot":
+      return "Browser snapshot";
+    case "browser_get_content":
+      return "Browser get content";
+    case "browser_get_text":
+      return "Browser get text";
+    case "browser_evaluate":
+      return "Browser evaluate";
+    case "browser_click":
+      return "Browser click";
+    case "browser_hover":
+      return "Browser hover";
+    case "browser_drag":
+      return "Browser drag";
+    case "browser_fill":
+      return "Browser fill";
+    case "browser_type":
+      return "Browser type";
+    case "browser_press":
+      return "Browser press";
+    case "browser_select":
+      return "Browser select";
+    case "browser_upload_file":
+      return "Browser upload file";
+    case "browser_handle_dialog":
+      return "Browser handle dialog";
+    case "browser_scroll":
+      return "Browser scroll";
+    case "browser_wait":
+      return "Browser wait";
+    case "browser_tabs":
+      return "Browser tabs";
+    case "browser_switch_tab":
+      return "Browser switch tab";
+    case "browser_close_tab":
+      return "Browser close tab";
+    case "browser_back":
+      return "Browser back";
+    case "browser_forward":
+      return "Browser forward";
+    case "browser_reload":
+      return "Browser reload";
+    case "browser_console":
+      return "Browser console";
+    case "browser_network":
+      return "Browser network";
+    case "browser_downloads":
+      return "Browser downloads";
+    case "browser_storage":
+      return "Browser storage";
+    case "browser_emulate":
+      return "Browser emulate";
+    case "browser_trace_start":
+      return "Browser trace start";
+    case "browser_trace_stop":
+      return "Browser trace stop";
+    case "browser_save_pdf":
+      return "Browser save PDF";
+    case "browser_close":
+      return "Browser close";
+    default:
+      return "Browser";
+  }
+}
+
+function friendlyBrowserRunningLabel(toolName: string): string {
+  return browserToolDisplayName(toolName);
+}
+
+function friendlyBrowserCompletedLabel(toolName: string): string {
+  return browserToolDisplayName(toolName);
+}
+
 /** Short label for parallel lane "running" state */
 export function friendlyToolRunningLabel(toolName: string | undefined): string {
   const t = (toolName || "").trim();
   if (!t) return "Running tool";
+  if (isBrowserToolName(t)) return friendlyBrowserRunningLabel(t);
+  if (isSkillToolName(t)) return "Reading a skill";
   switch (t) {
     case "web_fetch":
     case "http_request":
@@ -98,17 +249,47 @@ export function friendlyToolCallTitle(tool: string | undefined, input: ToolInput
     const via = provider ? ` via ${provider.charAt(0).toUpperCase() + provider.slice(1)}` : "";
     return q ? `Web search${via}: ${truncateLabel(q, 52)}` : `Web search${via}`;
   }
+  if (isBrowserToolName(tc)) {
+    if (tc === "browser_navigate") {
+      const url = typeof ins.url === "string" ? ins.url.trim() : "";
+      return url ? `Browser navigate: ${truncateLabel(hostOrPathFromUrl(url), 52)}` : "Browser navigate";
+    }
+    if (tc === "browser_get_text") {
+      const selector = asTrimmedString(ins.selector) || asTrimmedString(ins.ref);
+      return selector ? `Browser get text: ${truncateLabel(selector, 42)}` : "Browser get text";
+    }
+    if (tc === "browser_click") {
+      const target = asTrimmedString(ins.ref) || asTrimmedString(ins.selector);
+      return target ? `Browser click: ${truncateLabel(target, 44)}` : "Browser click";
+    }
+    if (tc === "browser_fill" || tc === "browser_type") {
+      const target = asTrimmedString(ins.ref) || asTrimmedString(ins.selector);
+      return target ? `Browser type: ${truncateLabel(target, 42)}` : "Browser type";
+    }
+    return friendlyBrowserRunningLabel(tc);
+  }
+  if (isSkillToolName(tc)) {
+    return skillReadLabel(skillNameFromToolInput(ins), "running");
+  }
   if (tc === "read_file") {
     const path = asTrimmedString(ins.path);
+    const skillName = skillNameFromSkillPath(path);
+    if (skillName) return skillReadLabel(skillName, "running");
     const base = path ? fileBase(path) : "";
     return base ? `Read ${base}` : "Read file";
   }
   if (tc === "read_files") {
+    const path = asTrimmedString(ins.path);
+    const skillName = skillNameFromSkillPath(path);
+    if (skillName) return skillReadLabel(skillName, "running");
     const patterns = asTrimmedStringArray(ins.patterns);
     if (patterns.length > 0) {
+      const skillNames = patterns.map(skillNameFromSkillPath).filter((entry) => entry.length > 0);
+      if (skillNames.length === 1 && patterns.length === 1) {
+        return skillReadLabel(skillNames[0], "running");
+      }
       return `Read files: ${truncateLabel(summarizeList(patterns), 52)}`;
     }
-    const path = asTrimmedString(ins.path);
     return path ? `Read files in ${truncateLabel(path, 48)}` : "Read files";
   }
   if (tc === "grep") {
@@ -168,12 +349,32 @@ export function friendlyToolResultTitle(
     const via = provider ? ` via ${provider.charAt(0).toUpperCase() + provider.slice(1)}` : "";
     return q ? `Searched${via}: ${truncateLabel(q, 52)}` : `Search complete${via}`;
   }
+  if (isBrowserToolName(tc)) {
+    const url = typeof res.url === "string" ? res.url.trim() : "";
+    const title = typeof res.title === "string" ? res.title.trim() : "";
+    const page = title || (url ? hostOrPathFromUrl(url) : "");
+    if (tc === "browser_navigate") {
+      return page ? `Browser navigate: ${truncateLabel(page, 52)}` : "Browser navigate";
+    }
+    const label = friendlyBrowserCompletedLabel(tc);
+    return page ? `${label} — ${truncateLabel(page, 48)}` : label;
+  }
+  if (isSkillToolName(tc)) {
+    return skillReadLabel(skillNameFromPayload(res), "completed");
+  }
   if (tc === "read_file") {
     const path = asTrimmedString(res.path);
+    const skillName = skillNameFromSkillPath(path);
+    if (skillName) return skillReadLabel(skillName, "completed");
     const base = path ? fileBase(path) : "";
     return base ? `Read ${base}` : "Read file";
   }
   if (tc === "read_files") {
+    const skillNames = skillNamesFromReadFilesResult(res);
+    if (skillNames.length === 1) return skillReadLabel(skillNames[0], "completed");
+    if (skillNames.length > 1) {
+      return `Read ${skillNames.length} skills`;
+    }
     const files = Array.isArray(res.files)
       ? res.files
           .map((entry) => {
@@ -213,16 +414,23 @@ export function friendlyToolLaneCompletedLabel(toolName: string | undefined, fai
   const t = (toolName || "").trim();
   if (!t) return failed ? "Step failed" : "Done";
   if (failed) {
+    if (isBrowserToolName(t)) return "Browser action failed";
     switch (t) {
       case "web_fetch":
       case "http_request":
         return "Fetch failed";
       case "web_search":
         return "Search failed";
+      case "skill":
+      case "use_skill":
+      case "run_skill":
+        return "Skill read failed";
       default:
         return `${friendlyToolRunningLabel(t)} failed`;
     }
   }
+  if (isSkillToolName(t)) return "Read skill";
+  if (isBrowserToolName(t)) return friendlyBrowserCompletedLabel(t);
   switch (t) {
     case "web_fetch":
     case "http_request":
@@ -238,6 +446,8 @@ export function friendlyToolLaneCompletedLabel(toolName: string | undefined, fai
 }
 
 function friendlyPastVerb(tool: string): string {
+  if (isBrowserToolName(tool)) return friendlyBrowserCompletedLabel(tool);
+  if (isSkillToolName(tool)) return "Read skill";
   switch (tool) {
     case "web_fetch":
     case "http_request":


### PR DESCRIPTION
## Summary
- improve timeline tool labels and derived event metadata
- refine task-event visibility behavior and parallel group projections
- add coverage for action summaries, parallel groups, timeline indicators, visibility, and labels

## Validation
- npx vitest run src/renderer/components/timeline/__tests__/action-block-summary.test.ts src/renderer/components/timeline/__tests__/parallel-group-feed.test.ts src/renderer/components/timeline/__tests__/parallel-group-projection.test.ts src/renderer/components/timeline/__tests__/timeline-indicators.test.ts src/renderer/utils/__tests__/task-event-derived.test.ts src/renderer/utils/__tests__/task-event-visibility.test.ts src/renderer/utils/__tests__/timeline-tool-labels.test.ts
- npm run build:react

Note: Vite emitted the existing large chunk warning during build.