### PR TITLE
fix(tools): prioritize contextual prompt guidance

### DIFF
--- a/src/electron/agent/tools/__tests__/tool-prompting.test.ts
+++ b/src/electron/agent/tools/__tests__/tool-prompting.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { LLMTool, LLMToolPromptRenderContext } from "../../llm/types";
+import { renderToolDescription } from "../tool-prompting";
+
+const context: LLMToolPromptRenderContext = {
+  executionMode: "execute",
+  taskDomain: "coding",
+  webSearchMode: "allowed",
+  shellEnabled: true,
+};
+
+function tool(overrides: Partial<LLMTool> = {}): LLMTool {
+  return {
+    name: "example_tool",
+    description: "Base description comes from the canonical tool schema.",
+    input_schema: { type: "object", properties: {} },
+    ...overrides,
+  };
+}
+
+describe("renderToolDescription", () => {
+  it("places prompt-specific appended guidance before the base description", () => {
+    const description = renderToolDescription(
+      tool({
+        prompting: {
+          render: () => ({
+            appendDescription: "Use this only after collecting concrete evidence.",
+          }),
+        },
+      }),
+      context,
+    );
+
+    expect(description).toBe(
+      "Use this only after collecting concrete evidence. Base description comes from the canonical tool schema.",
+    );
+  });
+
+  it("still lets prompt metadata replace the description entirely", () => {
+    const description = renderToolDescription(
+      tool({
+        prompting: {
+          render: () => ({
+            description: "Replacement description.",
+            appendDescription: "Appendix should not be used.",
+          }),
+        },
+      }),
+      context,
+    );
+
+    expect(description).toBe("Replacement description.");
+  });
+});

--- a/src/electron/agent/tools/registry.ts
+++ b/src/electron/agent/tools/registry.ts
@@ -3110,7 +3110,8 @@ Web Fetch (PREFERRED for reading web content):
 - http_request: Make raw HTTP requests like curl (GET, POST, PUT, DELETE, etc.)
   Use this for APIs, raw file downloads, or when you need custom headers/body.
 
-Browser Automation (use only when interaction is needed):
+Browser Automation:
+- For HTML/React/Vite/Next.js page design, editing, and troubleshooting, start the local app when needed and inspect it in the visible in-app browser workbench. Use screenshots, snapshots, mobile/desktop emulation, console/network checks, and interaction tests to catch rendered layout and behavior issues before finalizing.
 - browser_navigate: Navigate to a URL in the visible in-app browser workbench by default. Use it for JS-heavy pages, app/site testing, forms, screenshots, or “use/test/check this website as a normal user” tasks.
 - browser_screenshot: Take a screenshot of the page
 - browser_get_content: Get page text, links, and forms (use after navigate, for inspecting interactive elements)

--- a/src/electron/agent/tools/tool-prompting.ts
+++ b/src/electron/agent/tools/tool-prompting.ts
@@ -30,18 +30,6 @@ function joinText(...parts: Array<string | undefined>): string {
     .join(" ");
 }
 
-function joinBaseWithPromptAppend(base: string, append: string): string {
-  const normalizedBase = normalizeText(base);
-  const normalizedAppend = normalizeText(append);
-  if (!normalizedBase) return truncateText(normalizedAppend, TOOL_DESCRIPTION_CHAR_LIMIT);
-  if (!normalizedAppend) return truncateText(normalizedBase, TOOL_DESCRIPTION_CHAR_LIMIT);
-
-  const baseBudget = Math.max(120, Math.floor(TOOL_DESCRIPTION_CHAR_LIMIT * 0.45));
-  const basePart = truncateText(normalizedBase, baseBudget);
-  const appendBudget = Math.max(80, TOOL_DESCRIPTION_CHAR_LIMIT - basePart.length - 1);
-  return joinText(basePart, truncateText(normalizedAppend, appendBudget));
-}
-
 function resolvePromptMetadata(
   tool: LLMTool,
   context: LLMToolPromptRenderContext,
@@ -66,7 +54,7 @@ export function renderToolDescription(
   const merged = resolved.description
     ? normalizeText(resolved.description)
     : resolved.appendDescription
-      ? joinBaseWithPromptAppend(base, resolved.appendDescription)
+      ? joinText(resolved.appendDescription, base)
       : base;
   return truncateText(merged || base, TOOL_DESCRIPTION_CHAR_LIMIT);
 }


### PR DESCRIPTION
## Summary
- place contextual appended tool guidance before canonical tool descriptions
- add frontend-specific browser automation guidance for rendered page inspection
- cover tool description merge behavior with focused tests

## Validation
- npx vitest run src/electron/agent/tools/__tests__/tool-prompting.test.ts src/electron/agent/tools/__tests__/registry-tool-catalog.test.ts
- npm run build:electron