### PR TITLE
[codex] Classify browser timeline tool actions

### DIFF
--- a/src/electron/agent/__tests__/executor-plan-parsing.test.ts
+++ b/src/electron/agent/__tests__/executor-plan-parsing.test.ts
@@ -390,6 +390,52 @@ describe("TaskExecutor plan parsing", () => {
     expect(result.blockedResult?.error).toContain("Code-first UI task mode is active");
   });
 
+  it("allows browser tools for web page design and troubleshooting prompts", () => {
+    const executor = createPlanExecutor({
+      usage: { inputTokens: 1, outputTokens: 2 },
+      content: [],
+    });
+    const prompt =
+      "Edit the React landing page, start the app, open it in the browser, and troubleshoot the hero layout.";
+    executor.task.title = "Improve React landing page";
+    executor.task.prompt = prompt;
+    executor.task.rawPrompt = prompt;
+    executor.currentStepId = "1";
+    executor.plan = {
+      description: "Plan",
+      steps: [
+        {
+          id: "1",
+          description: "Edit the React landing page and verify it in the browser.",
+          status: "pending",
+        },
+      ],
+    };
+
+    const result = executor.applyPreToolUsePolicyHook({
+      toolName: "browser_navigate",
+      input: { url: "http://localhost:5173" },
+      stepMode: undefined,
+    });
+
+    expect(result.blockedResult).toBeUndefined();
+  });
+
+  it("adds web page preview guidance for frontend page work", () => {
+    const executor = createPlanExecutor({
+      usage: { inputTokens: 1, outputTokens: 2 },
+      content: [],
+    });
+
+    const guidance = executor.buildWebPagePreviewGuidancePrompt(
+      "Design a React web page and troubleshoot it in the browser.",
+    );
+
+    expect(guidance).toContain("WEB PAGE PREVIEW GUIDANCE");
+    expect(guidance).toContain("visible in-app browser");
+    expect(guidance).toContain("browser_screenshot");
+  });
+
   it("uses the simple image path for app avatar image prompts", async () => {
     const executor = createPlanExecutor({
       usage: { inputTokens: 1, outputTokens: 2 },

--- a/src/electron/agent/timeline/timeline-normalizer.ts
+++ b/src/electron/agent/timeline/timeline-normalizer.ts
@@ -77,8 +77,14 @@ const SHELL_TOOLS = new Set(["run_command", "run_skill"]);
 const BROWSER_TOOLS = new Set([
   "browser_navigate",
   "browser_screenshot",
+  "browser_snapshot",
+  "browser_tabs",
+  "browser_switch_tab",
+  "browser_close_tab",
   "browser_get_content",
   "browser_click",
+  "browser_hover",
+  "browser_drag",
   "browser_fill",
   "browser_type",
   "browser_press",
@@ -87,6 +93,15 @@ const BROWSER_TOOLS = new Set([
   "browser_select",
   "browser_get_text",
   "browser_evaluate",
+  "browser_upload_file",
+  "browser_handle_dialog",
+  "browser_console",
+  "browser_network",
+  "browser_downloads",
+  "browser_storage",
+  "browser_emulate",
+  "browser_trace_start",
+  "browser_trace_stop",
   "browser_back",
   "browser_forward",
   "browser_reload",
@@ -162,6 +177,7 @@ function toCanonicalKind(event: NormalizerInputEvent): CanonicalActionKind {
   if (SEARCH_WEB_TOOLS.has(type)) return "search.web";
   if (SHELL_TOOLS.has(type)) return "shell.run";
   if (BROWSER_TOOLS.has(type)) return "browser.action";
+  if (type === "browser_action") return "browser.action";
 
   // Timeline step events are general step updates
   if (


### PR DESCRIPTION
## Summary
- classify additional browser tools as browser.action timeline events
- preserve legacy browser_action normalization
- add plan-policy coverage for frontend browser preview workflows

## Validation
- npx vitest run src/electron/agent/__tests__/executor-plan-parsing.test.ts