### PR TITLE
[codex] Add usage insights token heatmap

### DIFF
--- a/src/renderer/components/UsageInsightsOverview.tsx
+++ b/src/renderer/components/UsageInsightsOverview.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface RequestDayRow {
   dateKey: string;
@@ -10,15 +10,21 @@ interface RequestDayRow {
 }
 
 interface OverviewProps {
-  sessions: number;
-  messages: number;
   totalTokens: number;
-  mostActiveHour: number | null;
-  favoriteModel: string | null;
+  avgTaskTimeMs: number | null;
   requestsByDay: RequestDayRow[];
+  periodLabel: string;
 }
 
-const DAY_LABELS = ["Mon", "Wed", "Fri"];
+type HeatmapMode = "daily" | "weekly" | "cumulative";
+
+const HEATMAP_MODES: Array<{ value: HeatmapMode; label: string }> = [
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "cumulative", label: "Cumulative" },
+];
+
+const MIN_HEATMAP_MONTHS = 12;
 
 // Roughly the word count of Moby-Dick (~210k words ≈ ~270k tokens).
 const MOBY_DICK_TOKENS = 270_000;
@@ -39,13 +45,15 @@ function formatBigNumber(n: number): string {
   return n.toLocaleString();
 }
 
-function formatHourRange(hour: number): string {
-  const wrap = (h: number) => {
-    const suffix = h < 12 ? "AM" : "PM";
-    const hh = h % 12 === 0 ? 12 : h % 12;
-    return `${hh} ${suffix}`;
-  };
-  return wrap(hour);
+function formatShortDuration(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms) || ms <= 0) return "\u2014";
+  const totalMinutes = Math.max(1, Math.round(ms / 60_000));
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
 }
 
 function parseDateKey(dateKey: string): Date | null {
@@ -66,21 +74,42 @@ interface HeatmapCell {
   count: number;
   intensity: number; // 0..4
   inRange: boolean;
+  rawCount: number;
+}
+
+interface MonthLabel {
+  label: string;
+  start: number;
+  span: number;
+}
+
+function tokenCount(row: RequestDayRow): number {
+  return row.inputTokens + row.outputTokens;
 }
 
 function buildHeatmap(
   requestsByDay: RequestDayRow[],
-): { weeks: HeatmapCell[][]; max: number } {
-  if (requestsByDay.length === 0) return { weeks: [], max: 0 };
+  mode: HeatmapMode,
+): { weeks: HeatmapCell[][]; max: number; months: MonthLabel[] } {
+  if (requestsByDay.length === 0) return { weeks: [], max: 0, months: [] };
   const byDate = new Map<string, number>();
   for (const row of requestsByDay) {
-    byDate.set(row.dateKey, row.llmCalls);
+    byDate.set(row.dateKey, tokenCount(row));
   }
 
   const sorted = [...requestsByDay].sort((a, b) => a.dateKey.localeCompare(b.dateKey));
-  const firstDate = parseDateKey(sorted[0].dateKey);
-  const lastDate = parseDateKey(sorted[sorted.length - 1].dateKey);
-  if (!firstDate || !lastDate) return { weeks: [], max: 0 };
+  const firstDataDate = parseDateKey(sorted[0].dateKey);
+  const lastDataDate = parseDateKey(sorted[sorted.length - 1].dateKey);
+  if (!firstDataDate || !lastDataDate) return { weeks: [], max: 0, months: [] };
+
+  const firstDate = new Date(firstDataDate);
+  const lastDate = new Date(lastDataDate);
+  const minStart = new Date(lastDate);
+  minStart.setMonth(minStart.getMonth() - (MIN_HEATMAP_MONTHS - 1));
+  minStart.setDate(1);
+  if (firstDate > minStart) {
+    firstDate.setTime(minStart.getTime());
+  }
 
   // Back up to the preceding Sunday so the first column is a full week.
   const start = new Date(firstDate);
@@ -88,28 +117,78 @@ function buildHeatmap(
   const end = new Date(lastDate);
   end.setDate(end.getDate() + (6 - end.getDay()));
 
-  const values = Array.from(byDate.values()).filter((v) => v > 0);
-  const max = values.length > 0 ? Math.max(...values) : 0;
-
   const weeks: HeatmapCell[][] = [];
+  const values: number[] = [];
+  let cumulative = 0;
   let cursor = new Date(start);
   while (cursor <= end) {
+    const weekStart = new Date(cursor);
+    let weekTotal = 0;
+    for (let i = 0; i < 7; i++) {
+      const next = new Date(weekStart);
+      next.setDate(weekStart.getDate() + i);
+      weekTotal += byDate.get(toKey(next)) ?? 0;
+    }
+
     const week: HeatmapCell[] = [];
     for (let i = 0; i < 7; i++) {
       const key = toKey(cursor);
-      const count = byDate.get(key) ?? 0;
+      const rawCount = byDate.get(key) ?? 0;
       const inRange = cursor >= firstDate && cursor <= lastDate;
-      let intensity = 0;
-      if (count > 0 && max > 0) {
-        const ratio = count / max;
-        intensity = ratio > 0.75 ? 4 : ratio > 0.5 ? 3 : ratio > 0.25 ? 2 : 1;
+      const isDataRange = cursor >= firstDataDate && cursor <= lastDataDate;
+      if (isDataRange) {
+        cumulative += rawCount;
       }
-      week.push({ dateKey: key, count, intensity, inRange });
+      const count = !inRange
+        ? 0
+        : mode === "weekly"
+          ? rawCount > 0
+            ? weekTotal
+            : 0
+          : mode === "cumulative" && isDataRange
+            ? cumulative
+            : rawCount;
+      if (count > 0) {
+        values.push(count);
+      }
+      week.push({ dateKey: key, count, intensity: 0, inRange, rawCount });
       cursor.setDate(cursor.getDate() + 1);
     }
     weeks.push(week);
   }
-  return { weeks, max };
+
+  const max = values.length > 0 ? Math.max(...values) : 0;
+  for (const week of weeks) {
+    for (const cell of week) {
+      let intensity = 0;
+      if (cell.count > 0 && max > 0) {
+        const ratio = cell.count / max;
+        intensity = ratio > 0.75 ? 4 : ratio > 0.5 ? 3 : ratio > 0.25 ? 2 : 1;
+      }
+      cell.intensity = intensity;
+    }
+  }
+
+  const months = buildMonthLabels(weeks);
+  return { weeks, max, months };
+}
+
+function buildMonthLabels(weeks: HeatmapCell[][]): MonthLabel[] {
+  const labels: MonthLabel[] = [];
+  for (let i = 0; i < weeks.length; i++) {
+    const visibleCell = weeks[i].find((cell) => cell.inRange);
+    if (!visibleCell) continue;
+    const date = parseDateKey(visibleCell.dateKey);
+    if (!date) continue;
+    const label = date.toLocaleDateString(undefined, { month: "short" });
+    const current = labels[labels.length - 1];
+    if (current?.label === label) {
+      current.span += 1;
+    } else {
+      labels.push({ label, start: i + 1, span: 1 });
+    }
+  }
+  return labels;
 }
 
 function computeStreaks(requestsByDay: RequestDayRow[]): {
@@ -177,56 +256,107 @@ function pickBookComparison(totalTokens: number): string | null {
   return `You've used ${rendered} more tokens than ${best.name}.`;
 }
 
-export function UsageInsightsOverview(props: OverviewProps) {
-  const { sessions, messages, totalTokens, mostActiveHour, favoriteModel, requestsByDay } = props;
+function heatmapTitle(cell: HeatmapCell, mode: HeatmapMode): string {
+  const value = formatBigNumber(cell.count);
+  const raw = formatBigNumber(cell.rawCount);
+  if (mode === "weekly") {
+    return `${cell.dateKey}: ${raw} tokens, ${value} for the week`;
+  }
+  if (mode === "cumulative") {
+    return `${cell.dateKey}: ${value} cumulative tokens`;
+  }
+  return `${cell.dateKey}: ${value} tokens`;
+}
 
-  const { activeDays, currentStreak, longestStreak } = useMemo(
+export function UsageInsightsOverview(props: OverviewProps) {
+  const { totalTokens, avgTaskTimeMs, requestsByDay, periodLabel } = props;
+  const [heatmapMode, setHeatmapMode] = useState<HeatmapMode>("cumulative");
+  const heatmapScrollRef = useRef<HTMLDivElement>(null);
+
+  const { currentStreak, longestStreak } = useMemo(
     () => computeStreaks(requestsByDay),
     [requestsByDay],
   );
 
-  const { weeks } = useMemo(() => buildHeatmap(requestsByDay), [requestsByDay]);
+  const { weeks, months } = useMemo(
+    () => buildHeatmap(requestsByDay, heatmapMode),
+    [heatmapMode, requestsByDay],
+  );
+
+  useEffect(() => {
+    const scrollEl = heatmapScrollRef.current;
+    if (!scrollEl) return;
+    scrollEl.scrollLeft = scrollEl.scrollWidth;
+  }, [heatmapMode, weeks.length]);
+
   const comparison = useMemo(() => pickBookComparison(totalTokens), [totalTokens]);
 
-  const peakLabel =
-    mostActiveHour !== null && mostActiveHour >= 0 ? formatHourRange(mostActiveHour) : "\u2014";
+  const peakTokens = useMemo(
+    () => requestsByDay.reduce((peak, row) => Math.max(peak, tokenCount(row)), 0),
+    [requestsByDay],
+  );
 
   return (
     <div className="insights-overview">
       <div className="insights-overview-stats">
-        <StatCard label="Sessions" value={formatBigNumber(sessions)} />
-        <StatCard label="Messages" value={formatBigNumber(messages)} />
         <StatCard label="Total tokens" value={formatBigNumber(totalTokens)} />
-        <StatCard label="Active days" value={formatBigNumber(activeDays)} />
-        <StatCard label="Current streak" value={`${currentStreak}d`} />
-        <StatCard label="Longest streak" value={`${longestStreak}d`} />
-        <StatCard label="Peak hour" value={peakLabel} />
-        <StatCard
-          label="Favorite model"
-          value={favoriteModel ?? "\u2014"}
-          valueClass="insights-overview-stat-value--small"
-        />
+        <StatCard label="Peak tokens" value={formatBigNumber(peakTokens)} />
+        <StatCard label="Avg task" value={formatShortDuration(avgTaskTimeMs)} />
+        <StatCard label="Current streak" value={`${currentStreak} days`} />
+        <StatCard label="Longest streak" value={`${longestStreak} days`} />
       </div>
 
       {weeks.length > 0 && (
-        <div className="insights-overview-heatmap" aria-label="Daily activity heatmap">
-          <div className="insights-overview-heatmap-labels">
-            {DAY_LABELS.map((d) => (
-              <span key={d}>{d}</span>
-            ))}
+        <div className="insights-token-activity" aria-label="Token activity heatmap">
+          <div className="insights-token-activity-header">
+            <div className="insights-token-activity-title">
+              <h3>Token activity</h3>
+              <span className="insights-token-activity-range">{periodLabel}</span>
+            </div>
+            <div className="insights-token-activity-tabs" role="tablist" aria-label="Token activity view">
+              {HEATMAP_MODES.map((mode) => (
+                <button
+                  key={mode.value}
+                  type="button"
+                  role="tab"
+                  aria-selected={heatmapMode === mode.value}
+                  className={`insights-token-activity-tab${heatmapMode === mode.value ? " active" : ""}`}
+                  onClick={() => setHeatmapMode(mode.value)}
+                >
+                  {mode.label}
+                </button>
+              ))}
+            </div>
           </div>
-          <div className="insights-overview-heatmap-grid">
-            {weeks.map((week, wi) => (
-              <div key={wi} className="insights-overview-heatmap-col">
-                {week.map((cell) => (
-                  <div
-                    key={cell.dateKey}
-                    className={`insights-overview-heatmap-cell insights-overview-heatmap-cell-l${cell.intensity}${cell.inRange ? "" : " out-of-range"}`}
-                    title={`${cell.dateKey}: ${cell.count} call${cell.count === 1 ? "" : "s"}`}
-                  />
+          <div className="insights-overview-heatmap" ref={heatmapScrollRef}>
+            <div className="insights-overview-heatmap-grid">
+              {weeks.map((week, wi) => (
+                <div key={wi} className="insights-overview-heatmap-col">
+                  {week.map((cell) => (
+                    <div
+                      key={cell.dateKey}
+                      className={`insights-overview-heatmap-cell insights-overview-heatmap-cell-l${cell.intensity}${cell.inRange ? "" : " out-of-range"}`}
+                      title={heatmapTitle(cell, heatmapMode)}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+            {months.length > 0 && (
+              <div
+                className="insights-overview-heatmap-months"
+                style={{ gridTemplateColumns: `repeat(${weeks.length}, 16px)` }}
+              >
+                {months.map((month) => (
+                  <span
+                    key={`${month.label}-${month.start}`}
+                    style={{ gridColumn: `${month.start} / span ${month.span}` }}
+                  >
+                    {month.label}
+                  </span>
                 ))}
               </div>
-            ))}
+            )}
           </div>
         </div>
       )}

--- a/src/renderer/components/UsageInsightsPanel.tsx
+++ b/src/renderer/components/UsageInsightsPanel.tsx
@@ -224,7 +224,13 @@ interface PluginPackSummary {
   skills: Array<{ id: string; name: string }>;
 }
 
+interface OverviewLoadState {
+  workspaceId: string;
+  data: UsageInsightsData;
+}
+
 const ALL_WORKSPACES = "__all__";
+const OVERVIEW_PERIOD_DAYS = 365;
 
 const chartTooltipProps = {
   contentStyle: {
@@ -250,6 +256,9 @@ function isValidWorkspaceId(id: string | undefined): id is string {
 
 export function UsageInsightsPanel({ workspaceId: initialWorkspaceId }: UsageInsightsPanelProps) {
   const [data, setData] = useState<UsageInsightsData | null>(null);
+  const [overviewData, setOverviewData] = useState<OverviewLoadState | null>(null);
+  const [overviewLoading, setOverviewLoading] = useState(false);
+  const [overviewError, setOverviewError] = useState<string | null>(null);
   const [selectedPreset, setSelectedPreset] =
     useState<UsageInsightsPeriodPreset>(DEFAULT_USAGE_INSIGHTS_PERIOD_PRESET);
   const [customStart, setCustomStart] = useState(() => toISODate(new Date(Date.now() - 30 * 86_400_000)));
@@ -267,6 +276,7 @@ export function UsageInsightsPanel({ workspaceId: initialWorkspaceId }: UsageIns
   const [pluginPacks, setPluginPacks] = useState<PluginPackSummary[]>([]);
   const cacheRef = useRef(new Map<string, UsageInsightsData>());
   const requestSeqRef = useRef(0);
+  const overviewRequestSeqRef = useRef(0);
 
   const periodDays = useMemo(
     () => (selectedPreset === "custom" ? daysBetween(customStart, customEnd) : selectedPreset),
@@ -335,6 +345,40 @@ export function UsageInsightsPanel({ workspaceId: initialWorkspaceId }: UsageIns
     }
   }, [workspaceId, periodDays]);
 
+  const loadOverview = useCallback(async () => {
+    if (!isValidWorkspaceId(workspaceId)) return;
+    const requestId = ++overviewRequestSeqRef.current;
+    const cacheKey = `${workspaceId}|${OVERVIEW_PERIOD_DAYS}`;
+    const cached = cacheRef.current.get(cacheKey);
+    if (cached) {
+      setOverviewData({ workspaceId, data: cached });
+      setOverviewError(null);
+      setOverviewLoading(false);
+      return;
+    }
+    setOverviewLoading(true);
+    setOverviewError(null);
+    setOverviewData((current) => (current?.workspaceId === workspaceId ? current : null));
+    try {
+      const result = await window.electronAPI.getUsageInsights(
+        workspaceId,
+        OVERVIEW_PERIOD_DAYS,
+      );
+      cacheRef.current.set(cacheKey, result);
+      if (overviewRequestSeqRef.current !== requestId) return;
+      setOverviewData({ workspaceId, data: result });
+    } catch (err: unknown) {
+      if (overviewRequestSeqRef.current === requestId) {
+        setOverviewError(err instanceof Error ? err.message : "Failed to load 12-month token activity");
+        setOverviewData((current) => (current?.workspaceId === workspaceId ? current : null));
+      }
+    } finally {
+      if (overviewRequestSeqRef.current === requestId) {
+        setOverviewLoading(false);
+      }
+    }
+  }, [workspaceId]);
+
   useEffect(() => {
     if (!showCustomPicker) return;
     function handleClickOutside(e: MouseEvent) {
@@ -373,6 +417,10 @@ export function UsageInsightsPanel({ workspaceId: initialWorkspaceId }: UsageIns
   useEffect(() => {
     load();
   }, [load]);
+
+  useEffect(() => {
+    void loadOverview();
+  }, [loadOverview]);
 
   useEffect(() => {
     let cancelled = false;
@@ -537,9 +585,32 @@ export function UsageInsightsPanel({ workspaceId: initialWorkspaceId }: UsageIns
     label: formatDayLabel(row.dateKey),
     lineValue: awuLineMetric === "tokens" ? row.tokensPerAwu : row.costPerAwu,
   }));
+  const activeOverviewData = overviewData?.workspaceId === workspaceId ? overviewData.data : null;
+  const overview = activeOverviewData ?? (periodDays >= OVERVIEW_PERIOD_DAYS ? data : null);
+  const overviewPeriodLabel = activeOverviewData ? "Last 12 months" : "Current period";
 
   return (
     <div className="settings-panel insights-panel">
+      {overview && (
+        <UsageInsightsOverview
+          totalTokens={overview.executionMetrics.totalTokens}
+          avgTaskTimeMs={overview.taskMetrics.avgCompletionTimeMs}
+          requestsByDay={overview.requestsByDay ?? []}
+          periodLabel={overviewPeriodLabel}
+        />
+      )}
+      {!overview && overviewLoading && (
+        <div className="insights-overview-status">Loading 12-month token activity...</div>
+      )}
+      {overviewError && !activeOverviewData && (
+        <div className="insights-overview-status">
+          <span>Could not load 12-month token activity.</span>
+          <button type="button" className="insights-overview-status-btn" onClick={() => void loadOverview()}>
+            Retry
+          </button>
+        </div>
+      )}
+
       {/* Header with workspace and period inline */}
       <div className="insights-header">
         <div className="insights-header-left">
@@ -636,21 +707,6 @@ export function UsageInsightsPanel({ workspaceId: initialWorkspaceId }: UsageIns
           </div>
         </div>
       </div>
-
-      {data && (
-        <UsageInsightsOverview
-          sessions={tm?.totalCreated ?? 0}
-          messages={em?.totalLlmCalls ?? 0}
-          totalTokens={em?.totalTokens ?? 0}
-          mostActiveHour={ap ? ap.mostActiveHour : null}
-          favoriteModel={
-            modelRows.length > 0
-              ? [...modelRows].sort((a, b) => b.calls - a.calls)[0]?.model ?? null
-              : null
-          }
-          requestsByDay={data.requestsByDay ?? []}
-        />
-      )}
 
       {/* Hero stats row */}
       {tm && (

--- a/src/renderer/components/settings.css
+++ b/src/renderer/components/settings.css
@@ -645,42 +645,52 @@
 
 /* ── Insights: Overview (stat grid + heatmap) ── */
 .insights-overview {
-  background: linear-gradient(135deg, var(--color-bg-elevated) 0%, var(--color-bg-glass) 100%);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
-  padding: 18px 20px;
-  margin-bottom: 16px;
-  backdrop-filter: blur(var(--glass-blur));
-  -webkit-backdrop-filter: blur(var(--glass-blur));
+  padding: 8px 0 26px;
+  margin-bottom: 22px;
+  background: transparent;
+  border: 0;
 }
 
 .insights-overview-stats {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 10px;
-  margin-bottom: 16px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0;
+  width: min(100%, 980px);
+  margin: 0 auto 56px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--color-bg-elevated) 66%, transparent);
 }
 
 .insights-overview-stat {
-  background: color-mix(in srgb, var(--color-bg-glass) 70%, transparent);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md, 8px);
-  padding: 10px 12px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   min-width: 0;
+  min-height: 86px;
+  padding: 14px 18px;
+  text-align: center;
+}
+
+.insights-overview-stat + .insights-overview-stat {
+  border-left: 1px solid var(--color-border-subtle);
 }
 
 .insights-overview-stat-label {
-  font-size: 11px;
+  order: 2;
+  font-size: 16px;
   color: var(--color-text-muted);
-  letter-spacing: 0.02em;
+  letter-spacing: 0;
+  line-height: 1.15;
 }
 
 .insights-overview-stat-value {
-  font-size: 22px;
-  font-weight: 700;
+  order: 1;
+  font-size: 18px;
+  font-weight: 600;
   color: var(--color-text);
   line-height: 1.1;
   overflow: hidden;
@@ -693,49 +703,88 @@
   font-weight: 600;
 }
 
-.insights-overview-heatmap {
+.insights-token-activity {
+  width: min(100%, 1040px);
+  margin: 0 auto;
+}
+
+.insights-token-activity-header {
   display: flex;
-  gap: 8px;
-  align-items: flex-start;
-  padding: 4px 0 8px;
-  overflow-x: auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 18px;
 }
 
-.insights-overview-heatmap-labels {
-  display: grid;
-  grid-template-rows: repeat(7, 12px);
-  gap: 3px;
-  font-size: 10px;
+.insights-token-activity-header h3 {
+  margin: 0;
+  color: var(--color-text);
+  font-family: var(--font-ui);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.insights-token-activity-title {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.insights-token-activity-range {
   color: var(--color-text-muted);
-  padding-top: 0;
+  font-size: 12px;
+  line-height: 1.2;
 }
 
-.insights-overview-heatmap-labels span:nth-child(1) {
-  grid-row: 2;
+.insights-token-activity-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
 }
-.insights-overview-heatmap-labels span:nth-child(2) {
-  grid-row: 4;
+
+.insights-token-activity-tab {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-ui);
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: color 0.15s ease;
 }
-.insights-overview-heatmap-labels span:nth-child(3) {
-  grid-row: 6;
+
+.insights-token-activity-tab:hover,
+.insights-token-activity-tab.active {
+  color: var(--color-text);
+}
+
+.insights-overview-heatmap {
+  display: block;
+  padding: 0 0 4px;
+  overflow-x: auto;
 }
 
 .insights-overview-heatmap-grid {
   display: flex;
-  gap: 3px;
+  gap: 5px;
+  min-width: max-content;
 }
 
 .insights-overview-heatmap-col {
   display: grid;
-  grid-template-rows: repeat(7, 12px);
-  gap: 3px;
+  grid-template-rows: repeat(7, 16px);
+  gap: 5px;
 }
 
 .insights-overview-heatmap-cell {
-  width: 12px;
-  height: 12px;
-  border-radius: 2px;
-  background: color-mix(in srgb, var(--color-bg-glass) 60%, white 4%);
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, var(--color-text) 4%);
 }
 
 .insights-overview-heatmap-cell.out-of-range {
@@ -755,15 +804,95 @@
   background: var(--color-accent, #60a5fa);
 }
 
+.insights-overview-heatmap-months {
+  display: grid;
+  gap: 5px;
+  min-width: max-content;
+  margin-top: 16px;
+  color: var(--color-text-muted);
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.insights-overview-heatmap-months span {
+  min-width: 0;
+}
+
 .insights-overview-caption {
-  margin-top: 10px;
+  width: min(100%, 1040px);
+  margin: 16px auto 0;
   font-size: 12px;
   color: var(--color-text-muted);
 }
 
+.insights-overview-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: min(100%, 1040px);
+  margin: 0 auto 18px;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.insights-overview-status-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: var(--color-bg-elevated);
+  color: var(--color-text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.insights-overview-status-btn:hover {
+  background: var(--color-bg-glass);
+}
+
 @media (max-width: 900px) {
   .insights-overview-stats {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .insights-overview-stat:nth-child(odd) {
+    border-left: 0;
+  }
+
+  .insights-overview-stat:nth-child(n + 3) {
+    border-top: 1px solid var(--color-border-subtle);
+  }
+}
+
+@media (max-width: 640px) {
+  .insights-overview {
+    padding-top: 0;
+  }
+
+  .insights-overview-stat-label,
+  .insights-token-activity-tab,
+  .insights-overview-heatmap-months {
+    font-size: 14px;
+  }
+
+  .insights-token-activity-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .insights-token-activity-tabs {
+    gap: 18px;
+  }
+
+  .insights-overview-stats {
+    grid-template-columns: 1fr;
+    margin-bottom: 34px;
+  }
+
+  .insights-overview-stat + .insights-overview-stat {
+    border-left: 0;
+    border-top: 1px solid var(--color-border-subtle);
   }
 }
 


### PR DESCRIPTION
## Summary
- redesign the usage insights overview around token activity instead of session/message stats
- load a 12-month overview dataset for the heatmap with loading and retry states
- add daily, weekly, and cumulative token heatmap modes with responsive styling

## Validation
- npm run build:react