### PR TITLE
[codex] Polish renderer shell settings behavior

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -135,20 +135,8 @@ import { classifyLiveTaskEvent } from "./utils/live-task-event-policy";
 const Settings = lazy(() =>
   import("./components/Settings").then((module) => ({ default: module.Settings })),
 );
-const mainContentModuleStartedAt = typeof performance !== "undefined" ? performance.now() : 0;
 const mainContentModulePromise = import("./components/MainContent");
-void mainContentModulePromise
-  .then(() => {
-    const now = typeof performance !== "undefined" ? performance.now() : 0;
-    void window.electronAPI?.logRendererPerf?.({
-      timestamp: new Date().toISOString(),
-      message: `[Startup] main_content_module_loaded at ${now.toFixed(1)}ms {"loadMs":${Math.max(
-        0,
-        now - mainContentModuleStartedAt,
-      ).toFixed(1)}}`,
-    });
-  })
-  .catch(() => {});
+void mainContentModulePromise.catch(() => {});
 const MainContent = lazy(() =>
   mainContentModulePromise.then((module) => ({ default: module.MainContent })),
 );
@@ -1995,6 +1983,7 @@ export function App() {
   const [unseenOutputTaskIds, setUnseenOutputTaskIds] = useState<string[]>([]);
   const [unseenCompletedTaskIds, setUnseenCompletedTaskIds] = useState<string[]>([]);
   const [isInitialTaskListLoading, setIsInitialTaskListLoading] = useState(true);
+  const [isLoadingMoreTasks, setIsLoadingMoreTasks] = useState(false);
   const [rightPanelHighlight, setRightPanelHighlight] = useState<{
     taskId: string;
     path: string;
@@ -4164,6 +4153,7 @@ export function App() {
       taskOffsetRef.current = 0;
       sidebarTaskCursorRef.current = null;
       isLoadingMoreRef.current = false;
+      setIsLoadingMoreTasks(false);
       const startedAt = performance.now();
       markRendererPerfEvent("sidebar_request_start", rendererPerfLoggingEnabled, {
         limit: INITIAL_TASK_LOAD + TASK_PAGE_LOOKAHEAD,
@@ -4211,6 +4201,7 @@ export function App() {
       return;
     }
     isLoadingMoreRef.current = true;
+    setIsLoadingMoreTasks(true);
     try {
       const offset = taskOffsetRef.current;
       const cursor = sidebarTaskCursorRef.current;
@@ -4248,6 +4239,7 @@ export function App() {
       console.error("Failed to load more tasks:", error);
     } finally {
       isLoadingMoreRef.current = false;
+      setIsLoadingMoreTasks(false);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -5780,6 +5772,7 @@ export function App() {
                 isHealthActive={currentView === "health"}
                 isDevicesActive={currentView === "devices"}
                 isLoadingSessions={isInitialTaskListLoading}
+                isLoadingMoreTasks={isLoadingMoreTasks}
                 completionAttentionTaskIds={unseenCompletedTaskIds}
                 onSelectTask={handleSelectTaskFromShell}
                 onOpenHome={() => setCurrentView("home")}

--- a/src/renderer/components/ControlPlaneSettings.tsx
+++ b/src/renderer/components/ControlPlaneSettings.tsx
@@ -80,21 +80,27 @@ export function ControlPlaneSettings() {
     [sshTunnelEnabled, sshHost, sshUsername, sshPort, sshKeyPath, sshLocalPort, sshRemotePort],
   );
 
-  const loadData = useCallback(async () => {
+  const loadData = useCallback(async (options: { includeStatic?: boolean } = {}) => {
+    const includeStatic = options.includeStatic ?? true;
     try {
       const [settingsData, statusData, tailscale, remoteStatusData, sshStatus] = await Promise.all([
-        window.electronAPI?.getControlPlaneSettings?.() || null,
+        includeStatic ? window.electronAPI?.getControlPlaneSettings?.() || null : null,
         window.electronAPI?.getControlPlaneStatus?.() || null,
-        window.electronAPI?.checkTailscaleAvailability?.() || null,
+        includeStatic ? window.electronAPI?.checkTailscaleAvailability?.() || null : null,
         window.electronAPI?.getRemoteGatewayStatus?.() || null,
         window.electronAPI?.getSSHTunnelStatus?.() || null,
       ]);
 
-      setSettings(settingsData);
       setStatus(statusData);
-      setTailscaleAvailability(tailscale);
       setRemoteStatus(remoteStatusData);
       setSshTunnelStatus(sshStatus);
+
+      if (!includeStatic) {
+        return;
+      }
+
+      setSettings(settingsData);
+      setTailscaleAvailability(tailscale);
 
       // Set connection mode from settings
       if (settingsData?.connectionMode) {
@@ -135,11 +141,12 @@ export function ControlPlaneSettings() {
   }, []);
 
   useEffect(() => {
-    loadData();
+    loadData({ includeStatic: true });
 
-    // Poll status every 5 seconds
+    // Poll only live status. Settings and Tailscale discovery are static enough
+    // to refresh after explicit actions instead of every interval tick.
     const interval = setInterval(() => {
-      loadData();
+      loadData({ includeStatic: false });
     }, 5000);
 
     return () => clearInterval(interval);

--- a/src/renderer/components/MainContent/MainContent.tsx
+++ b/src/renderer/components/MainContent/MainContent.tsx
@@ -83,6 +83,7 @@ import {
 import { isTaskActivelyWorking } from "../../utils/task-working-state";
 import { shouldShowPersistentNeedsUserActionBanner } from "../../utils/task-completion-ux";
 import {
+  filterAdjacentDuplicateTimelineFailures,
   filterVerboseTimelineNoise,
   shouldShowTaskEventInStepFeed,
   shouldShowTaskEventInSummaryMode,
@@ -3953,7 +3954,9 @@ function MainContentComponent({
     return measureRendererPerf("MainContent.filteredEvents", rendererPerfLoggingEnabled, () => {
       const baseEvents = verboseSteps
         ? filterVerboseTimelineNoise(events)
-        : events.filter((event) => shouldShowTaskEventInSummaryMode(event, task?.status));
+        : filterAdjacentDuplicateTimelineFailures(
+            events.filter((event) => shouldShowTaskEventInSummaryMode(event, task?.status)),
+          );
       // Command output is rendered separately via CommandOutput component
       const visibleEvents = baseEvents.filter(
         (event) => event.type !== "command_output" && event.type !== "timeline_command_output",

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -3,8 +3,10 @@ import {
   useEffect,
   useCallback,
   useMemo,
+  useDeferredValue,
   useRef,
   lazy,
+  memo,
   Suspense,
   type ComponentType,
   type ReactNode,
@@ -1048,6 +1050,160 @@ const sidebarSearchEntries: Partial<Record<SettingsTab, SidebarSearchEntry[]>> =
     updates: [{ terms: ["updates", "update", "release notes"] }],
   };
 
+const getSidebarItemLabel = (item: SidebarItem): string => item.label;
+
+const normalizeSettingsSidebarSearchQuery = (value: string): string =>
+  value.trim().toLowerCase();
+
+const matchesSettingsSidebarSearchQuery = (haystack: string, query: string): boolean => {
+  const normalizedQuery = normalizeSettingsSidebarSearchQuery(query);
+  if (!normalizedQuery) return true;
+  const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
+  return tokens.every((token) => haystack.includes(token));
+};
+
+interface SettingsSidebarProps {
+  activeTab: SettingsTab;
+  isMacPlatform: boolean;
+  onBack: () => void;
+  onSelect: (item: SidebarItem, target?: SidebarSearchTarget) => void;
+}
+
+const SettingsSidebar = memo(function SettingsSidebar({
+  activeTab,
+  isMacPlatform,
+  onBack,
+  onSelect,
+}: SettingsSidebarProps) {
+  const [sidebarSearch, setSidebarSearch] = useState("");
+  const deferredSidebarSearch = useDeferredValue(sidebarSearch);
+  const hasSidebarSearch = sidebarSearch.trim().length > 0;
+
+  const filteredSidebarItems = useMemo(() => {
+    return sidebarItems
+      .filter((item) => !item.macOnly || isMacPlatform)
+      .map((item) => {
+        const entries: SidebarSearchEntry[] = [
+          {
+            terms: [getSidebarItemLabel(item), item.group],
+            target: { tab: item.tab },
+          },
+          ...(sidebarSearchEntries[item.tab] ?? []),
+        ];
+        const searchBlob = entries
+          .flatMap((entry) => entry.terms)
+          .join(" ")
+          .toLowerCase();
+        const matchedEntry = entries.find((entry) =>
+          entry.terms.some((term) =>
+            matchesSettingsSidebarSearchQuery(term.toLowerCase(), deferredSidebarSearch),
+          ),
+        );
+        return {
+          item,
+          matchedTarget: matchedEntry?.target,
+          matches: matchesSettingsSidebarSearchQuery(searchBlob, deferredSidebarSearch),
+        };
+      })
+      .filter((entry) => entry.matches);
+  }, [deferredSidebarSearch, isMacPlatform]);
+
+  return (
+    <div className="settings-sidebar">
+      <h1 className="settings-sidebar-title">Settings</h1>
+      <button className="settings-back-btn" onClick={onBack}>
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M19 12H5M12 19l-7-7 7-7" />
+        </svg>
+        Back
+      </button>
+      <div className="settings-sidebar-search">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <path d="M21 21l-4.35-4.35" />
+        </svg>
+        <input
+          type="text"
+          placeholder="Search settings..."
+          value={sidebarSearch}
+          onChange={(e) => setSidebarSearch(e.target.value)}
+        />
+        {hasSidebarSearch && (
+          <button
+            className="settings-sidebar-search-clear"
+            onClick={() => setSidebarSearch("")}
+            aria-label="Clear search"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        )}
+      </div>
+      <div className="settings-nav-items">
+        {
+          filteredSidebarItems
+            .reduce<{ seenGroups: Set<string>; elements: ReactNode[] }>(
+              (acc, { item, matchedTarget }) => {
+                if (!hasSidebarSearch && !acc.seenGroups.has(item.group)) {
+                  acc.elements.push(
+                    <div
+                      key={`group-${item.group}`}
+                      className="settings-nav-group-header"
+                    >
+                      {item.group}
+                    </div>,
+                  );
+                  acc.seenGroups.add(item.group);
+                }
+                acc.elements.push(
+                  <button
+                    key={item.tab}
+                    className={`settings-nav-item ${activeTab === item.tab || (item.tab === "morechannels" && (activeTab === "teams" || activeTab === "x")) ? "active" : ""}`}
+                    data-tab={item.tab}
+                    onClick={() => onSelect(item, matchedTarget)}
+                  >
+                    {item.icon}
+                    {getSidebarItemLabel(item)}
+                  </button>,
+                );
+                return acc;
+              },
+              { seenGroups: new Set<string>(), elements: [] },
+            ).elements
+        }
+        {hasSidebarSearch && filteredSidebarItems.length === 0 && (
+          <div className="settings-nav-no-results">
+            No matching settings
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});
+
 const LLM_PROVIDER_ICONS: Record<string, ReactNode> = {
   anthropic: <Layers {...S} />,
   openai: <CircleDot {...S} />,
@@ -1221,7 +1377,6 @@ export function Settings({
   const [activeAccessSubTab, setActiveAccessSubTab] = useState<
     "controlplane" | "webaccess"
   >(initialTab === "webaccess" ? "webaccess" : "controlplane");
-  const [sidebarSearch, setSidebarSearch] = useState("");
   const settingsRef = useRef<LLMSettingsData>({
     providerType: "anthropic",
     modelKey: "sonnet-4-5",
@@ -1265,44 +1420,6 @@ export function Settings({
       return "linux";
     })();
   const isMacPlatform = platform === "darwin";
-  const getSidebarItemLabel = (item: SidebarItem): string => item.label;
-  const normalizeSearchQuery = (value: string): string =>
-    value.trim().toLowerCase();
-  const matchesSearchQuery = (haystack: string, query: string): boolean => {
-    const normalizedQuery = normalizeSearchQuery(query);
-    if (!normalizedQuery) return true;
-    const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
-    return tokens.every((token) => haystack.includes(token));
-  };
-
-  const filteredSidebarItems = useMemo(() => {
-    return sidebarItems
-      .filter((item) => !item.macOnly || isMacPlatform)
-      .map((item) => {
-        const entries: SidebarSearchEntry[] = [
-          {
-            terms: [getSidebarItemLabel(item), item.group],
-            target: { tab: item.tab },
-          },
-          ...(sidebarSearchEntries[item.tab] ?? []),
-        ];
-        const searchBlob = entries
-          .flatMap((entry) => entry.terms)
-          .join(" ")
-          .toLowerCase();
-        const matchedEntry = entries.find((entry) =>
-          entry.terms.some((term) =>
-            matchesSearchQuery(term.toLowerCase(), sidebarSearch),
-          ),
-        );
-        return {
-          item,
-          matchedTarget: matchedEntry?.target,
-          matches: matchesSearchQuery(searchBlob, sidebarSearch),
-        };
-      })
-      .filter((entry) => entry.matches);
-  }, [isMacPlatform, sidebarSearch]);
 
   const handleSidebarItemSelect = useCallback(
     (item: SidebarItem, target?: SidebarSearchTarget) => {
@@ -7601,100 +7718,12 @@ export function Settings({
   return (
     <div className="settings-page">
       <div className="settings-page-layout">
-        <div className="settings-sidebar">
-          <h1 className="settings-sidebar-title">Settings</h1>
-          <button className="settings-back-btn" onClick={onBack}>
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path d="M19 12H5M12 19l-7-7 7-7" />
-            </svg>
-            Back
-          </button>
-          <div className="settings-sidebar-search">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <circle cx="11" cy="11" r="8" />
-              <path d="M21 21l-4.35-4.35" />
-            </svg>
-            <input
-              type="text"
-              placeholder="Search settings..."
-              value={sidebarSearch}
-              onChange={(e) => setSidebarSearch(e.target.value)}
-            />
-            {sidebarSearch && (
-              <button
-                className="settings-sidebar-search-clear"
-                onClick={() => setSidebarSearch("")}
-                aria-label="Clear search"
-              >
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                >
-                  <line x1="18" y1="6" x2="6" y2="18" />
-                  <line x1="6" y1="6" x2="18" y2="18" />
-                </svg>
-              </button>
-            )}
-          </div>
-          <div className="settings-nav-items">
-            {
-              filteredSidebarItems
-                .reduce<{ seenGroups: Set<string>; elements: ReactNode[] }>(
-                  (acc, { item, matchedTarget }) => {
-                    if (!sidebarSearch && !acc.seenGroups.has(item.group)) {
-                      acc.elements.push(
-                        <div
-                          key={`group-${item.group}`}
-                          className="settings-nav-group-header"
-                        >
-                          {item.group}
-                        </div>,
-                      );
-                      acc.seenGroups.add(item.group);
-                    }
-                    acc.elements.push(
-                      <button
-                        key={item.tab}
-                        className={`settings-nav-item ${activeTab === item.tab || (item.tab === "morechannels" && (activeTab === "teams" || activeTab === "x")) ? "active" : ""}`}
-                        data-tab={item.tab}
-                        onClick={() =>
-                          handleSidebarItemSelect(item, matchedTarget)
-                        }
-                      >
-                        {item.icon}
-                        {getSidebarItemLabel(item)}
-                      </button>,
-                    );
-                    return acc;
-                  },
-                  { seenGroups: new Set<string>(), elements: [] },
-                ).elements
-            }
-            {sidebarSearch && filteredSidebarItems.length === 0 && (
-                <div className="settings-nav-no-results">
-                  No matching settings
-                </div>
-              )}
-          </div>
-        </div>
+        <SettingsSidebar
+          activeTab={activeTab}
+          isMacPlatform={isMacPlatform}
+          onBack={onBack}
+          onSelect={handleSidebarItemSelect}
+        />
 
         <div className="settings-content-card">
           <div className="settings-content">

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -54,6 +54,7 @@ interface SidebarProps {
   isMissionControlActive?: boolean;
   isHealthActive?: boolean;
   isLoadingSessions?: boolean;
+  isLoadingMoreTasks?: boolean;
   completionAttentionTaskIds?: string[];
   onSelectTask: (id: string | null) => void;
   onOpenHome?: () => void;
@@ -485,6 +486,7 @@ export type SidebarVirtualRow =
   | {
       kind: "load-more";
       id: string;
+      loading: boolean;
     };
 
 export function flattenVisibleTaskRows(
@@ -570,6 +572,7 @@ function areSidebarPropsEqual(prev: SidebarProps, next: SidebarProps): boolean {
     prev.isHealthActive === next.isHealthActive &&
     prev.isDevicesActive === next.isDevicesActive &&
     prev.isLoadingSessions === next.isLoadingSessions &&
+    prev.isLoadingMoreTasks === next.isLoadingMoreTasks &&
     prev.hasMoreTasks === next.hasMoreTasks &&
     prev.uiDensity === next.uiDensity &&
     getSidebarTaskListSignature(prev.tasks) === getSidebarTaskListSignature(next.tasks) &&
@@ -607,6 +610,7 @@ function SidebarComponent({
   onOpenMissionControl,
   onOpenDevices,
   isDevicesActive = false,
+  isLoadingMoreTasks = false,
 
   onTasksChanged,
   onLoadMoreTasks,
@@ -970,7 +974,7 @@ function SidebarComponent({
         }),
       );
       if (hasMoreTasks) {
-        rows.push({ kind: "load-more", id: "load-more" });
+        rows.push({ kind: "load-more", id: "load-more", loading: isLoadingMoreTasks });
       }
       return rows;
     },
@@ -978,6 +982,7 @@ function SidebarComponent({
       automatedRowsExpanded,
       automatedTaskRows,
       hasMoreTasks,
+      isLoadingMoreTasks,
       uiDensity,
       virtualizedTaskRows,
       visibleAutomatedTaskTree,
@@ -1785,10 +1790,20 @@ function SidebarComponent({
     }
     if (row.kind === "load-more") {
       return (
-        <div className="task-list-load-more">
-          <span className="terminal-only">loading more...</span>
-          <span className="modern-only">Loading more sessions…</span>
-        </div>
+        <button
+          type="button"
+          className={`task-list-load-more ${row.loading ? "loading" : "idle"}`}
+          onClick={row.loading ? undefined : onLoadMoreTasks}
+          disabled={row.loading || !onLoadMoreTasks}
+          aria-busy={row.loading}
+        >
+          <span className="terminal-only">
+            {row.loading ? "loading more..." : "load more sessions"}
+          </span>
+          <span className="modern-only">
+            {row.loading ? "Loading more sessions..." : "Load more sessions"}
+          </span>
+        </button>
       );
     }
 

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -24076,14 +24076,32 @@ a,
 
 /* Pagination load-more hint shown at the bottom of the task list */
 .task-list-load-more {
+  display: block;
+  width: 100%;
   padding: 8px 12px 10px;
+  border: 0;
+  background: transparent;
   font-size: 11px;
   color: var(--color-text-muted, #6b7280);
   text-align: center;
   font-family: var(--font-ui);
-  opacity: 0.6;
-  pointer-events: none;
   user-select: none;
+}
+
+.task-list-load-more.loading,
+.task-list-load-more:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.task-list-load-more.idle {
+  opacity: 0.75;
+  cursor: pointer;
+}
+
+.task-list-load-more.idle:hover {
+  color: var(--color-text-secondary, #4b5563);
+  opacity: 1;
 }
 
 .cli-sidebar-error {


### PR DESCRIPTION
## Summary
- make task-list pagination expose a loading state and manual load-more button
- reduce repeated static control-plane settings polling
- isolate settings sidebar search into a memoized component and trim startup perf noise
- de-duplicate adjacent timeline failures in summary mode

## Validation
- npm run build:react