### PR TITLE
[codex] Fix ChatGPT OAuth token exchange

### DIFF
--- a/src/electron/agent/llm/__tests__/openai-oauth.test.ts
+++ b/src/electron/agent/llm/__tests__/openai-oauth.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenAIOAuth, type OpenAIOAuthTokens } from "../openai-oauth";
+
+const refreshOpenAICodexTokenMock = vi.fn();
+
+vi.mock("../pi-ai-loader", () => ({
+  loadPiAiOAuthModule: vi.fn().mockResolvedValue({
+    refreshOpenAICodexToken: (...args: Any[]) => refreshOpenAICodexTokenMock(...args),
+  }),
+}));
+
+function makeTokens(overrides: Partial<OpenAIOAuthTokens> = {}): OpenAIOAuthTokens {
+  return {
+    access_token: "old-access",
+    refresh_token: "old-refresh",
+    expires_at: Date.now() + 10 * 60_000,
+    ...overrides,
+  };
+}
+
+describe("OpenAIOAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the stored ChatGPT access token while it is still valid", async () => {
+    const result = await OpenAIOAuth.getApiKeyFromTokens(makeTokens());
+
+    expect(result).toEqual({ apiKey: "old-access" });
+    expect(refreshOpenAICodexTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes expired ChatGPT OAuth tokens directly and preserves refreshed credentials", async () => {
+    refreshOpenAICodexTokenMock.mockResolvedValue({
+      access: "new-access",
+      refresh: "new-refresh",
+      expires: Date.now() + 120_000,
+      email: "user@example.com",
+    });
+
+    const result = await OpenAIOAuth.getApiKeyFromTokens(
+      makeTokens({ expires_at: Date.now() - 1_000 }),
+    );
+
+    expect(refreshOpenAICodexTokenMock).toHaveBeenCalledWith("old-refresh");
+    expect(result.apiKey).toBe("new-access");
+    expect(result.newTokens).toMatchObject({
+      access_token: "new-access",
+      refresh_token: "new-refresh",
+      email: "user@example.com",
+    });
+  });
+
+  it("keeps direct refresh error details for retry classification and user diagnostics", async () => {
+    refreshOpenAICodexTokenMock.mockRejectedValue(
+      new Error("OpenAI Codex token refresh error: fetch failed"),
+    );
+
+    await expect(
+      OpenAIOAuth.getApiKeyFromTokens(makeTokens({ expires_at: Date.now() - 1_000 })),
+    ).rejects.toThrow("OpenAI Codex token refresh error: fetch failed");
+  });
+});

--- a/src/electron/agent/llm/openai-oauth.ts
+++ b/src/electron/agent/llm/openai-oauth.ts
@@ -57,6 +57,9 @@ const MANUAL_CALLBACK_HELPER_HTML = `data:text/html;charset=utf-8,${encodeURICom
 </html>`)}`;
 
 let proxyBootstrapPromise: Promise<void> | null = null;
+let electronOAuthFetchFallbackInstalled = false;
+
+const OPENAI_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
 
 function ensureNodeFetchProxySupport(): void {
   if (proxyBootstrapPromise || typeof process === "undefined" || !process.versions?.node) {
@@ -74,6 +77,68 @@ function ensureNodeFetchProxySupport(): void {
 }
 
 ensureNodeFetchProxySupport();
+
+function getFetchUrl(input: Parameters<typeof fetch>[0]): string | undefined {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  const url = (input as Any)?.url;
+  return typeof url === "string" ? url : undefined;
+}
+
+function shouldUseElectronOAuthFetch(input: Parameters<typeof fetch>[0]): boolean {
+  const rawUrl = getFetchUrl(input);
+  if (!rawUrl) return false;
+  try {
+    const url = new URL(rawUrl);
+    return url.origin + url.pathname === OPENAI_OAUTH_TOKEN_URL;
+  } catch {
+    return false;
+  }
+}
+
+function getElectronNetFetch(): typeof fetch | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    // oxlint-disable-next-line typescript-eslint(no-require-imports)
+    const electron = require("electron") as Any;
+    const netFetch = electron?.net?.fetch;
+    return typeof netFetch === "function" ? netFetch.bind(electron.net) : null;
+  } catch {
+    return null;
+  }
+}
+
+function installElectronOAuthFetchFallback(): void {
+  if (electronOAuthFetchFallbackInstalled || typeof globalThis.fetch !== "function") {
+    return;
+  }
+
+  const electronFetch = getElectronNetFetch();
+  if (!electronFetch) return;
+
+  const nodeFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ) => {
+    if (shouldUseElectronOAuthFetch(input)) {
+      try {
+        return await electronFetch(input, init);
+      } catch (error: Any) {
+        logger.warn(
+          "Electron net.fetch failed for OpenAI OAuth token request; retrying Node fetch:",
+          error?.message || error,
+        );
+      }
+    }
+    return nodeFetch(input, init);
+  }) as typeof fetch;
+
+  electronOAuthFetchFallbackInstalled = true;
+  logger.info("Installed Electron network fallback for OpenAI OAuth token exchange.");
+}
+
+installElectronOAuthFetchFallback();
 
 function getElectronShell(): Any | null {
   try {
@@ -317,18 +382,14 @@ export class OpenAIOAuth {
   static async getApiKeyFromTokens(
     tokens: OpenAIOAuthTokens,
   ): Promise<{ apiKey: string; newTokens?: OpenAIOAuthTokens }> {
-    const { getOAuthApiKey } = await loadPiAiOAuthModule();
-    const credentials = tokensToCredentials(tokens);
-
-    const result = await getOAuthApiKey("openai-codex", { "openai-codex": credentials });
-
-    if (!result) {
-      throw new Error("Failed to get API key from OAuth credentials");
+    if (!this.isTokenExpired(tokens)) {
+      return { apiKey: tokens.access_token };
     }
 
+    const newTokens = await this.refreshTokens(tokens);
     return {
-      apiKey: result.apiKey,
-      newTokens: credentialsToTokens(result.newCredentials),
+      apiKey: newTokens.access_token,
+      newTokens,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes the ChatGPT subscription sign-in flow when the browser callback succeeds but the Electron main process fails the OAuth token exchange with `fetch failed`.

## Root Cause

The ChatGPT OAuth browser redirect can complete successfully while the follow-up token exchange still runs through Node's `fetch` in the Electron main process. On machines with TLS/proxy trust differences, Node can fail with `fetch failed` after the user sees the OpenAI success page, leaving no OAuth tokens persisted and causing task sends to fail with `OpenAI authentication required`.

The existing refresh path also used pi-ai's generic OAuth API-key helper, which collapsed refresh failures into `Failed to refresh OAuth token for openai-codex`, hiding useful network details.

## Changes

- Route only `https://auth.openai.com/oauth/token` through Electron `net.fetch` when available, so the token exchange uses Chromium's network stack.
- Preserve the Node fetch fallback if Electron `net.fetch` is unavailable or fails.
- Avoid the generic pi-ai OAuth API-key helper for ChatGPT refreshes so direct refresh errors keep their real cause.
- Add focused OpenAI OAuth tests for valid tokens, expired-token refresh, and refresh error propagation.

## Validation

- `npx vitest run src/electron/agent/llm/__tests__/openai-oauth.test.ts src/electron/agent/llm/__tests__/openai-provider.test.ts`
- `npm run build:electron`