### PR TITLE
Implement browser annotations for the browser workbench

### DIFF
--- a/src/electron/agent/daemon.ts
+++ b/src/electron/agent/daemon.ts
@@ -14,6 +14,7 @@ import {
   WorkspacePermissionRuleRepository,
   InputRequestRepository,
   ArtifactRepository,
+  AnnotationRepository,
   MemoryType,
 } from "../database/repositories";
 import { ActivityRepository } from "../activity/ActivityRepository";
@@ -61,6 +62,7 @@ import {
   TeamThoughtEvent,
   isTempWorkspaceId,
   ImageAttachment,
+  Annotation,
   QuotedAssistantMessage,
   TaskFollowUpInput,
   MULTI_LLM_PROVIDER_DISPLAY,
@@ -382,6 +384,7 @@ export class AgentDaemon extends EventEmitter {
   private workspacePermissionRuleRepo: WorkspacePermissionRuleRepository;
   private inputRequestRepo: InputRequestRepository;
   private artifactRepo: ArtifactRepository;
+  private annotationRepo: AnnotationRepository;
   private activityRepo: ActivityRepository;
   private agentRoleRepo: AgentRoleRepository;
   private mentionRepo: MentionRepository;
@@ -459,6 +462,7 @@ export class AgentDaemon extends EventEmitter {
     this.workspacePermissionRuleRepo = new WorkspacePermissionRuleRepository(db);
     this.inputRequestRepo = new InputRequestRepository(db);
     this.artifactRepo = new ArtifactRepository(db);
+    this.annotationRepo = new AnnotationRepository(db);
     this.activityRepo = new ActivityRepository(db);
     this.agentRoleRepo = new AgentRoleRepository(db);
     this.mentionRepo = new MentionRepository(db);
@@ -9122,6 +9126,58 @@ export class AgentDaemon extends EventEmitter {
     this.finishQueueSlot(taskId);
   }
 
+  private buildAnnotationFollowUpContext(taskId: string, message: string): {
+    message: string;
+    annotations: Annotation[];
+  } {
+    const annotations = this.annotationRepo.listOpenByTask(taskId);
+    if (annotations.length === 0) return { message, annotations: [] };
+
+    const lines = [
+      "## Pending User Annotations",
+      "",
+      "Use these annotations as precise user feedback. Address the target(s) explicitly and keep changes scoped to the annotated issues unless the user asks for broader work.",
+      "",
+      ...annotations.flatMap((annotation, index) => {
+        const target = annotation.targetRef as Any;
+        const rect = target?.rect
+          ? `rect x=${target.rect.x} y=${target.rect.y} w=${target.rect.width} h=${target.rect.height}`
+          : "";
+        const viewport = target?.viewport
+          ? `viewport ${target.viewport.width}x${target.viewport.height}${target.viewport.mobile ? " mobile" : ""}`
+          : "";
+        const targetParts = [
+          target?.url ? `url=${target.url}` : "",
+          target?.filePath ? `file=${target.filePath}` : "",
+          target?.selector ? `selector=${target.selector}` : "",
+          target?.xpath ? `xpath=${target.xpath}` : "",
+          target?.tagName ? `tag=${target.tagName}` : "",
+          target?.textQuote ? `text=${JSON.stringify(target.textQuote)}` : "",
+          rect,
+          viewport,
+        ].filter(Boolean);
+        const stylePatch = annotation.stylePatch
+          ? [`Style guidance: ${JSON.stringify(annotation.stylePatch)}`]
+          : [];
+        const screenshot = annotation.screenshotPath
+          ? [`Screenshot: ${annotation.screenshotPath}`]
+          : [];
+        return [
+          `Annotation ${index + 1} (${annotation.id}) [${annotation.surfaceType}, ${annotation.status}]`,
+          `User request: ${annotation.body}`,
+          targetParts.length > 0 ? `Target: ${targetParts.join("; ")}` : "Target: unavailable",
+          ...stylePatch,
+          ...screenshot,
+          "",
+        ];
+      }),
+      "## User Follow-up",
+      message,
+    ];
+
+    return { message: lines.join("\n"), annotations };
+  }
+
   /**
    * Send a follow-up message to a task.
    *
@@ -9184,6 +9240,18 @@ export class AgentDaemon extends EventEmitter {
     const effectiveWorkspace = this.applyTaskWorkspaceOverrides(effectiveTask, workspace);
 
     this.taskRepo.touch(taskId);
+    const annotationContext = this.buildAnnotationFollowUpContext(taskId, message);
+    const effectiveMessage = annotationContext.message;
+    if (annotationContext.annotations.length > 0) {
+      const changedCount = this.annotationRepo.markAddressing(
+        taskId,
+        annotationContext.annotations.map((annotation) => annotation.id),
+      );
+      this.logEvent(taskId, "annotation_addressing_started", {
+        annotationIds: annotationContext.annotations.map((annotation) => annotation.id),
+        changedCount,
+      });
+    }
 
     if (!cached) {
       // Task executor not in memory - need to recreate it
@@ -9215,7 +9283,7 @@ export class AgentDaemon extends EventEmitter {
     if (executor.isRunning) {
       const integrationMentions = effectiveTask.agentConfig?.integrationMentions;
       executor.queueFollowUp(
-        message,
+        effectiveMessage,
         images,
         quotedAssistantMessage,
         integrationMentions,
@@ -9226,6 +9294,7 @@ export class AgentDaemon extends EventEmitter {
       // injected directly into the conversation loop, not through sendMessage.
       this.logEvent(taskId, "user_message", {
         message,
+        ...(effectiveMessage !== message ? { annotationContextInjected: true } : {}),
         ...(integrationMentions && integrationMentions.length > 0 ? { integrationMentions } : {}),
         ...(quotedAssistantMessage ? { quotedAssistantMessage } : {}),
       });
@@ -9233,7 +9302,15 @@ export class AgentDaemon extends EventEmitter {
     }
 
     // Send the message (executor is idle, acquire mutex normally)
-    await executor.sendMessage(message, images, quotedAssistantMessage, {
+    if (effectiveMessage !== message) {
+      executor.suppressNextUserMessageEvent();
+      this.logEvent(taskId, "user_message", {
+        message,
+        annotationContextInjected: true,
+        ...(quotedAssistantMessage ? { quotedAssistantMessage } : {}),
+      });
+    }
+    await executor.sendMessage(effectiveMessage, images, quotedAssistantMessage, {
       agentConfigOverride: effectiveOptions?.agentConfigOverride,
     });
     return { queued: false };

--- a/src/electron/browser/browser-workbench-service.ts
+++ b/src/electron/browser/browser-workbench-service.ts
@@ -607,6 +607,194 @@ export class BrowserWorkbenchService {
     };
   }
 
+  async inspectPoint(input: {
+    taskId: string;
+    sessionId?: unknown;
+    x: number;
+    y: number;
+  }): Promise<AnyRecord | null> {
+    const contents = await this.getWebContents(this.getSession(input.taskId, input.sessionId));
+    if (!contents) return null;
+    const x = Number.isFinite(input.x) ? Math.max(0, Math.round(input.x)) : 0;
+    const y = Number.isFinite(input.y) ? Math.max(0, Math.round(input.y)) : 0;
+    const debug = contents.debugger;
+    if (!debug) return null;
+    try {
+      if (!debug.isAttached()) debug.attach("1.3");
+      await debug.sendCommand("Runtime.enable").catch(() => undefined);
+    } catch {
+      return null;
+    }
+    const expression = `
+      (() => {
+        const pointX = ${JSON.stringify(x)};
+        const pointY = ${JSON.stringify(y)};
+        const el = document.elementFromPoint(pointX, pointY);
+        if (!el) return null;
+        const cssEscape = (value) => {
+          if (window.CSS && typeof window.CSS.escape === "function") return window.CSS.escape(value);
+          return String(value).replace(/[^a-zA-Z0-9_-]/g, "\\\\$&");
+        };
+        const selectorFor = (node) => {
+          if (!(node instanceof Element)) return "";
+          const parts = [];
+          let current = node;
+          while (current && current.nodeType === Node.ELEMENT_NODE && parts.length < 8) {
+            let part = current.localName.toLowerCase();
+            if (current.id) {
+              parts.unshift(part + "#" + cssEscape(current.id));
+              break;
+            }
+            const classNames = Array.from(current.classList || []).slice(0, 3);
+            if (classNames.length > 0) part += "." + classNames.map(cssEscape).join(".");
+            const parent = current.parentElement;
+            if (parent) {
+              const sameTag = Array.from(parent.children).filter((child) => child.localName === current.localName);
+              if (sameTag.length > 1) part += ":nth-of-type(" + (sameTag.indexOf(current) + 1) + ")";
+            }
+            parts.unshift(part);
+            current = parent;
+          }
+          return parts.join(" > ");
+        };
+        const xpathFor = (node) => {
+          if (!(node instanceof Element)) return "";
+          const parts = [];
+          let current = node;
+          while (current && current.nodeType === Node.ELEMENT_NODE) {
+            let index = 1;
+            let sibling = current.previousElementSibling;
+            while (sibling) {
+              if (sibling.localName === current.localName) index += 1;
+              sibling = sibling.previousElementSibling;
+            }
+            parts.unshift(current.localName.toLowerCase() + "[" + index + "]");
+            current = current.parentElement;
+          }
+          return "/" + parts.join("/");
+        };
+        const rect = el.getBoundingClientRect();
+        const style = window.getComputedStyle(el);
+        return {
+          rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+          scroll: { x: window.scrollX || 0, y: window.scrollY || 0 },
+          selector: selectorFor(el),
+          xpath: xpathFor(el),
+          tagName: el.tagName ? el.tagName.toLowerCase() : "",
+          role: el.getAttribute("role") || "",
+          accessibleName: el.getAttribute("aria-label") || el.getAttribute("title") || "",
+          textQuote: (el.innerText || el.textContent || "").trim().replace(/\\s+/g, " ").slice(0, 300),
+          computedStyle: {
+            color: style.color,
+            backgroundColor: style.backgroundColor,
+            fontFamily: style.fontFamily,
+            fontSize: style.fontSize,
+            fontWeight: style.fontWeight,
+            lineHeight: style.lineHeight,
+            margin: style.margin,
+            padding: style.padding,
+            borderRadius: style.borderRadius,
+          },
+        };
+      })()
+    `;
+    const evaluated = await debug.sendCommand("Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+    });
+    return (evaluated?.result?.value || null) as AnyRecord | null;
+  }
+
+  async resolveAnnotationTargets(input: {
+    taskId: string;
+    sessionId?: unknown;
+    targets: AnyRecord[];
+  }): Promise<AnyRecord[]> {
+    const contents = await this.getWebContents(this.getSession(input.taskId, input.sessionId));
+    if (!contents) return [];
+    const targets = Array.isArray(input.targets) ? input.targets.slice(0, 100) : [];
+    if (targets.length === 0) return [];
+    const debug = contents.debugger;
+    if (!debug) return [];
+    try {
+      if (!debug.isAttached()) debug.attach("1.3");
+      await debug.sendCommand("Runtime.enable").catch(() => undefined);
+    } catch {
+      return targets.map((_, index) => ({
+        index,
+        resolved: false,
+        error: "Browser debugger is unavailable",
+      }));
+    }
+    const expression = `
+      (() => {
+        const targets = ${JSON.stringify(targets)};
+        const byXPath = (xpath) => {
+          if (!xpath) return null;
+          try {
+            const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+            return result.singleNodeValue instanceof Element ? result.singleNodeValue : null;
+          } catch {
+            return null;
+          }
+        };
+        const byText = (textQuote) => {
+          const needle = String(textQuote || "").trim().replace(/\\s+/g, " ").slice(0, 160);
+          if (!needle) return null;
+          const all = Array.from(document.body?.querySelectorAll("*") || []).slice(0, 2500);
+          return all.find((node) => {
+            const text = (node.innerText || node.textContent || "").trim().replace(/\\s+/g, " ");
+            return text && text.includes(needle);
+          }) || null;
+        };
+        const describe = (el) => {
+          const rect = el.getBoundingClientRect();
+          const style = window.getComputedStyle(el);
+          return {
+            rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+            scroll: { x: window.scrollX || 0, y: window.scrollY || 0 },
+            tagName: el.tagName ? el.tagName.toLowerCase() : "",
+            role: el.getAttribute("role") || "",
+            accessibleName: el.getAttribute("aria-label") || el.getAttribute("title") || "",
+            textQuote: (el.innerText || el.textContent || "").trim().replace(/\\s+/g, " ").slice(0, 300),
+            computedStyle: {
+              color: style.color,
+              backgroundColor: style.backgroundColor,
+              fontFamily: style.fontFamily,
+              fontSize: style.fontSize,
+              fontWeight: style.fontWeight,
+              lineHeight: style.lineHeight,
+              margin: style.margin,
+              padding: style.padding,
+              borderRadius: style.borderRadius,
+            },
+          };
+        };
+        return targets.map((target, index) => {
+          let el = null;
+          if (target.selector) {
+            try {
+              el = document.querySelector(target.selector);
+            } catch {
+              el = null;
+            }
+          }
+          if (!el) el = byXPath(target.xpath);
+          if (!el) el = byText(target.textQuote);
+          if (!el) return { index, resolved: false };
+          return { index, resolved: true, target: describe(el) };
+        });
+      })()
+    `;
+    const evaluated = await debug.sendCommand("Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+    }).catch(() => null);
+    return Array.isArray(evaluated?.result?.value) ? evaluated.result.value as AnyRecord[] : [];
+  }
+
   private async captureFullPage(contents: Any): Promise<{ png: Buffer; size: { width: number; height: number } }> {
     const debug = contents.debugger;
     if (!debug) throw new Error("Browser debugger is not available for full-page capture");

--- a/src/electron/database/__tests__/AnnotationRepository.test.ts
+++ b/src/electron/database/__tests__/AnnotationRepository.test.ts
@@ -1,0 +1,155 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AnnotationRepository } from "../repositories";
+
+const nativeSqliteAvailable = await import("better-sqlite3")
+  .then((module) => {
+    try {
+      const Probe = module.default;
+      const probe = new Probe(":memory:");
+      probe.close();
+      return true;
+    } catch {
+      return false;
+    }
+  })
+  .catch(() => false);
+
+const describeWithSqlite = nativeSqliteAvailable ? describe : describe.skip;
+
+describeWithSqlite("AnnotationRepository", () => {
+  let db: Database.Database;
+  let repo: AnnotationRepository;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE annotations (
+        id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        workspace_id TEXT,
+        surface_type TEXT NOT NULL,
+        surface_id TEXT,
+        body TEXT NOT NULL,
+        status TEXT NOT NULL,
+        target_ref_json TEXT NOT NULL,
+        style_patch_json TEXT,
+        artifact_id TEXT,
+        screenshot_path TEXT,
+        created_by TEXT NOT NULL DEFAULT 'user',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        resolved_at INTEGER,
+        resolved_by_event_id TEXT
+      );
+    `);
+    repo = new AnnotationRepository(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("creates and lists browser annotations with target metadata", () => {
+    const annotation = repo.create({
+      taskId: "task-1",
+      workspaceId: "workspace-1",
+      surfaceType: "browser",
+      surfaceId: "http://127.0.0.1:5173",
+      body: "Add a one-line summary.",
+      targetRef: {
+        surfaceType: "browser",
+        url: "http://127.0.0.1:5173",
+        title: "Dashboard",
+        rect: { x: 40, y: 120, width: 360, height: 44 },
+        selector: "main h1",
+        textQuote: "Launch health",
+      },
+    });
+
+    expect(annotation.status).toBe("open");
+    expect(annotation.createdBy).toBe("user");
+
+    const list = repo.list({
+      taskId: "task-1",
+      surfaceType: "browser",
+      statuses: ["open"],
+    });
+
+    expect(list).toHaveLength(1);
+    expect(list[0].body).toBe("Add a one-line summary.");
+    expect(list[0].targetRef).toMatchObject({
+      surfaceType: "browser",
+      selector: "main h1",
+      rect: { x: 40, y: 120, width: 360, height: 44 },
+    });
+  });
+
+  it("marks open annotations as addressing and resolves them", () => {
+    const annotation = repo.create({
+      taskId: "task-1",
+      surfaceType: "browser",
+      body: "Tighten the launch copy.",
+      targetRef: {
+        surfaceType: "browser",
+        url: "http://localhost:5173",
+      },
+      stylePatch: {
+        fontSize: "16px",
+      },
+    });
+
+    expect(repo.markAddressing("task-1", [annotation.id])).toBe(1);
+    expect(repo.findById(annotation.id)?.status).toBe("addressing");
+
+    const resolved = repo.update(annotation.id, {
+      status: "resolved",
+      resolvedByEventId: "event-1",
+    });
+
+    expect(resolved?.status).toBe("resolved");
+    expect(resolved?.resolvedAt).toEqual(expect.any(Number));
+    expect(resolved?.resolvedByEventId).toBe("event-1");
+    expect(resolved?.stylePatch).toEqual({ fontSize: "16px" });
+  });
+
+  it("moves in-progress annotations to addressed on completion", () => {
+    const annotation = repo.create({
+      taskId: "task-1",
+      surfaceType: "browser",
+      body: "Update this label.",
+      targetRef: {
+        surfaceType: "browser",
+        url: "http://localhost:5173",
+      },
+    });
+
+    repo.markAddressing("task-1", [annotation.id]);
+
+    expect(repo.markAddressed("task-1")).toBe(1);
+    expect(repo.findById(annotation.id)?.status).toBe("addressed");
+  });
+
+  it("clears optional style metadata without storing a JSON null string", () => {
+    const annotation = repo.create({
+      taskId: "task-1",
+      surfaceType: "browser",
+      body: "Remove the color override.",
+      targetRef: {
+        surfaceType: "browser",
+        url: "http://localhost:5173",
+      },
+      stylePatch: {
+        color: "#08213f",
+      },
+    });
+
+    const updated = repo.update(annotation.id, { stylePatch: null });
+    const raw = db
+      .prepare("SELECT style_patch_json FROM annotations WHERE id = ?")
+      .get(annotation.id) as { style_patch_json: string | null };
+
+    expect(updated?.stylePatch).toBeUndefined();
+    expect(raw.style_patch_json).toBeNull();
+  });
+});

--- a/src/electron/database/repositories.ts
+++ b/src/electron/database/repositories.ts
@@ -10,6 +10,11 @@ import {
   TaskTraceRunSummary,
   EventType,
   Artifact,
+  Annotation,
+  AnnotationCreateInput,
+  AnnotationListQuery,
+  AnnotationStatus,
+  AnnotationUpdateInput,
   Workspace,
   ApprovalRequest,
   PersistedPermissionRule,
@@ -2627,6 +2632,248 @@ export class ArtifactRepository {
       sha256: row.sha256,
       size: row.size,
       createdAt: row.created_at,
+    };
+  }
+}
+
+const ANNOTATION_STATUSES: AnnotationStatus[] = [
+  "open",
+  "addressing",
+  "addressed",
+  "resolved",
+  "dismissed",
+];
+
+function normalizeAnnotationStatus(value: unknown, fallback: AnnotationStatus = "open"): AnnotationStatus {
+  return ANNOTATION_STATUSES.includes(value as AnnotationStatus)
+    ? (value as AnnotationStatus)
+    : fallback;
+}
+
+export class AnnotationRepository {
+  constructor(private db: Database.Database) {}
+
+  create(input: AnnotationCreateInput): Annotation {
+    const now = Date.now();
+    const annotation: Annotation = {
+      id: uuidv4(),
+      taskId: input.taskId,
+      workspaceId: input.workspaceId,
+      surfaceType: input.surfaceType,
+      surfaceId: input.surfaceId,
+      body: input.body.trim(),
+      status: "open",
+      targetRef: input.targetRef,
+      stylePatch: input.stylePatch,
+      artifactId: input.artifactId,
+      screenshotPath: input.screenshotPath,
+      createdBy: input.createdBy || "user",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.db
+      .prepare(`
+        INSERT INTO annotations (
+          id, task_id, workspace_id, surface_type, surface_id, body, status,
+          target_ref_json, style_patch_json, artifact_id, screenshot_path,
+          created_by, created_at, updated_at, resolved_at, resolved_by_event_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        annotation.id,
+        annotation.taskId,
+        annotation.workspaceId || null,
+        annotation.surfaceType,
+        annotation.surfaceId || null,
+        annotation.body,
+        annotation.status,
+        JSON.stringify(annotation.targetRef),
+        annotation.stylePatch ? JSON.stringify(annotation.stylePatch) : null,
+        annotation.artifactId || null,
+        annotation.screenshotPath || null,
+        annotation.createdBy,
+        annotation.createdAt,
+        annotation.updatedAt,
+        null,
+        null,
+      );
+
+    return annotation;
+  }
+
+  update(id: string, patch: AnnotationUpdateInput): Annotation | undefined {
+    const current = this.findById(id);
+    if (!current) return undefined;
+
+    const nextStatus = patch.status ? normalizeAnnotationStatus(patch.status, current.status) : current.status;
+    const now = Date.now();
+    const nextStylePatchJson =
+      patch.stylePatch === null
+        ? null
+        : patch.stylePatch !== undefined
+          ? JSON.stringify(patch.stylePatch)
+          : current.stylePatch
+            ? JSON.stringify(current.stylePatch)
+            : null;
+    const resolvedAt =
+      nextStatus === "resolved" || nextStatus === "dismissed"
+        ? current.resolvedAt || now
+        : patch.status && patch.status !== current.status
+          ? null
+          : current.resolvedAt || null;
+
+    this.db
+      .prepare(`
+        UPDATE annotations
+        SET body = ?,
+            status = ?,
+            target_ref_json = ?,
+            style_patch_json = ?,
+            artifact_id = ?,
+            screenshot_path = ?,
+            updated_at = ?,
+            resolved_at = ?,
+            resolved_by_event_id = ?
+        WHERE id = ?
+      `)
+      .run(
+        patch.body !== undefined ? patch.body.trim() : current.body,
+        nextStatus,
+        JSON.stringify(patch.targetRef || current.targetRef),
+        nextStylePatchJson,
+        patch.artifactId === null ? null : patch.artifactId || current.artifactId || null,
+        patch.screenshotPath === null ? null : patch.screenshotPath || current.screenshotPath || null,
+        now,
+        resolvedAt,
+        patch.resolvedByEventId === null
+          ? null
+          : patch.resolvedByEventId || current.resolvedByEventId || null,
+        id,
+      );
+
+    return this.findById(id);
+  }
+
+  markAddressing(taskId: string, annotationIds?: string[]): number {
+    const ids = (annotationIds || []).map((id) => id.trim()).filter(Boolean);
+    const now = Date.now();
+    if (ids.length > 0) {
+      const placeholders = ids.map(() => "?").join(", ");
+      const result = this.db
+        .prepare(`
+          UPDATE annotations
+          SET status = 'addressing', updated_at = ?
+          WHERE task_id = ?
+            AND status = 'open'
+            AND id IN (${placeholders})
+        `)
+        .run(now, taskId, ...ids);
+      return Number(result.changes || 0);
+    }
+    const result = this.db
+      .prepare(`
+        UPDATE annotations
+        SET status = 'addressing', updated_at = ?
+        WHERE task_id = ?
+          AND status = 'open'
+      `)
+      .run(now, taskId);
+    return Number(result.changes || 0);
+  }
+
+  markAddressed(taskId: string): number {
+    const result = this.db
+      .prepare(`
+        UPDATE annotations
+        SET status = 'addressed', updated_at = ?
+        WHERE task_id = ?
+          AND status = 'addressing'
+      `)
+      .run(Date.now(), taskId);
+    return Number(result.changes || 0);
+  }
+
+  findById(id: string): Annotation | undefined {
+    const row = this.db.prepare("SELECT * FROM annotations WHERE id = ?").get(id) as Any;
+    return row ? this.mapRowToAnnotation(row) : undefined;
+  }
+
+  list(query: AnnotationListQuery = {}): Annotation[] {
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+    if (query.taskId) {
+      clauses.push("task_id = ?");
+      params.push(query.taskId);
+    }
+    if (query.workspaceId) {
+      clauses.push("workspace_id = ?");
+      params.push(query.workspaceId);
+    }
+    if (query.surfaceType) {
+      clauses.push("surface_type = ?");
+      params.push(query.surfaceType);
+    }
+    if (query.surfaceId) {
+      clauses.push("surface_id = ?");
+      params.push(query.surfaceId);
+    }
+    const statuses = (query.statuses || []).filter((status) =>
+      ANNOTATION_STATUSES.includes(status),
+    );
+    if (statuses.length > 0) {
+      clauses.push(`status IN (${statuses.map(() => "?").join(", ")})`);
+      params.push(...statuses);
+    }
+    const limit =
+      typeof query.limit === "number" && Number.isFinite(query.limit)
+        ? Math.min(Math.max(Math.floor(query.limit), 1), 500)
+        : 200;
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const rows = this.db
+      .prepare(`
+        SELECT *
+        FROM annotations
+        ${where}
+        ORDER BY created_at DESC
+        LIMIT ?
+      `)
+      .all(...params, limit) as Any[];
+    return rows.map((row) => this.mapRowToAnnotation(row));
+  }
+
+  listOpenByTask(taskId: string): Annotation[] {
+    return this.list({
+      taskId,
+      statuses: ["open", "addressing"],
+      limit: 100,
+    });
+  }
+
+  private mapRowToAnnotation(row: Any): Annotation {
+    const status = normalizeAnnotationStatus(row.status);
+    return {
+      id: row.id,
+      taskId: row.task_id,
+      workspaceId: row.workspace_id || undefined,
+      surfaceType: row.surface_type as Annotation["surfaceType"],
+      surfaceId: row.surface_id || undefined,
+      body: row.body || "",
+      status,
+      targetRef: safeJsonParse(row.target_ref_json, {
+        surfaceType: row.surface_type || "browser",
+      } as Annotation["targetRef"], "annotation.target_ref_json"),
+      stylePatch: row.style_patch_json
+        ? safeJsonParse(row.style_patch_json, undefined, "annotation.style_patch_json")
+        : undefined,
+      artifactId: row.artifact_id || undefined,
+      screenshotPath: row.screenshot_path || undefined,
+      createdBy: (row.created_by || "user") as Annotation["createdBy"],
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      resolvedAt: row.resolved_at || undefined,
+      resolvedByEventId: row.resolved_by_event_id || undefined,
     };
   }
 }

--- a/src/electron/database/schema.ts
+++ b/src/electron/database/schema.ts
@@ -1186,6 +1186,28 @@ export class DatabaseManager {
         FOREIGN KEY (task_id) REFERENCES tasks(id)
       );
 
+      CREATE TABLE IF NOT EXISTS annotations (
+        id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        workspace_id TEXT,
+        surface_type TEXT NOT NULL,
+        surface_id TEXT,
+        body TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'open',
+        target_ref_json TEXT NOT NULL,
+        style_patch_json TEXT,
+        artifact_id TEXT,
+        screenshot_path TEXT,
+        created_by TEXT NOT NULL DEFAULT 'user',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        resolved_at INTEGER,
+        resolved_by_event_id TEXT,
+        FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+        FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE SET NULL,
+        FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE SET NULL
+      );
+
       CREATE TABLE IF NOT EXISTS approvals (
         id TEXT PRIMARY KEY,
         task_id TEXT NOT NULL,
@@ -1528,6 +1550,14 @@ export class DatabaseManager {
       CREATE INDEX IF NOT EXISTS idx_task_events_task_type_timestamp
         ON task_events(task_id, type, timestamp DESC);
       CREATE INDEX IF NOT EXISTS idx_artifacts_task ON artifacts(task_id);
+      CREATE INDEX IF NOT EXISTS idx_annotations_task_status_created
+        ON annotations(task_id, status, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_annotations_workspace_surface_updated
+        ON annotations(workspace_id, surface_type, updated_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_annotations_surface
+        ON annotations(surface_type, surface_id);
+      CREATE INDEX IF NOT EXISTS idx_annotations_artifact
+        ON annotations(artifact_id);
       CREATE INDEX IF NOT EXISTS idx_approvals_task ON approvals(task_id);
       CREATE INDEX IF NOT EXISTS idx_approvals_status ON approvals(status);
       CREATE INDEX IF NOT EXISTS idx_workspace_permission_rules_workspace

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -84,6 +84,7 @@ import {
   ChannelMessageRepository,
   ChannelRepository,
   ChannelUserRepository,
+  AnnotationRepository,
   TaskEventRepository,
   TaskRepository,
   WorkspaceRepository,
@@ -4269,6 +4270,127 @@ if (!gotTheLock) {
     });
     if (!result) return { success: false, error: "No active browser workbench session" };
     return { success: true, ...result };
+  });
+
+  ipcMain.handle(IPC_CHANNELS.BROWSER_WORKBENCH_INSPECT_POINT, async (_event, data: Any) => {
+    if (
+      !data ||
+      typeof data.taskId !== "string" ||
+      typeof data.x !== "number" ||
+      typeof data.y !== "number"
+    ) {
+      return { success: false, error: "Invalid browser inspect request" };
+    }
+    const target = await getBrowserWorkbenchService().inspectPoint({
+      taskId: data.taskId,
+      sessionId: typeof data.sessionId === "string" ? data.sessionId : "default",
+      x: data.x,
+      y: data.y,
+    });
+    if (!target) return { success: false, error: "No inspectable element at that point" };
+    return { success: true, target };
+  });
+
+  ipcMain.handle(IPC_CHANNELS.BROWSER_WORKBENCH_RESOLVE_ANNOTATION_TARGETS, async (_event, data: Any) => {
+    if (
+      !data ||
+      typeof data.taskId !== "string" ||
+      !Array.isArray(data.targets)
+    ) {
+      return { success: false, error: "Invalid browser annotation target resolve request" };
+    }
+    const targets = await getBrowserWorkbenchService().resolveAnnotationTargets({
+      taskId: data.taskId,
+      sessionId: typeof data.sessionId === "string" ? data.sessionId : "default",
+      targets: data.targets.filter((target: Any) => target && typeof target === "object"),
+    });
+    return { success: true, targets };
+  });
+
+  const getAnnotationRepo = () => new AnnotationRepository(dbManager.getDatabase());
+  const annotationSurfaceTypes = new Set(["browser", "diff", "file", "artifact", "message"]);
+  const logAnnotationEvent = (type: string, annotation: Any, extra: Record<string, unknown> = {}) => {
+    if (!annotation?.taskId) return;
+    agentDaemon.logEvent(annotation.taskId, type, {
+      annotationId: annotation.id,
+      surfaceType: annotation.surfaceType,
+      status: annotation.status,
+      body: annotation.body,
+      targetRef: annotation.targetRef,
+      stylePatch: annotation.stylePatch,
+      screenshotPath: annotation.screenshotPath,
+      ...extra,
+    });
+  };
+
+  ipcMain.handle(IPC_CHANNELS.ANNOTATION_CREATE, (_event, data: Any) => {
+    if (!data || typeof data !== "object") {
+      throw new Error("Invalid annotation payload");
+    }
+    const taskId = typeof data.taskId === "string" ? data.taskId.trim() : "";
+    const body = typeof data.body === "string" ? data.body.trim() : "";
+    const surfaceType = typeof data.surfaceType === "string" ? data.surfaceType.trim() : "";
+    if (!taskId) throw new Error("Annotation taskId is required");
+    if (!body) throw new Error("Annotation body is required");
+    if (!annotationSurfaceTypes.has(surfaceType)) throw new Error("Annotation surfaceType is invalid");
+    if (!data.targetRef || typeof data.targetRef !== "object") {
+      throw new Error("Annotation targetRef is required");
+    }
+
+    const annotation = getAnnotationRepo().create({
+      taskId,
+      workspaceId: typeof data.workspaceId === "string" ? data.workspaceId : undefined,
+      surfaceType: surfaceType as Any,
+      surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : undefined,
+      body,
+      targetRef: data.targetRef,
+      stylePatch: data.stylePatch && typeof data.stylePatch === "object" ? data.stylePatch : undefined,
+      artifactId: typeof data.artifactId === "string" ? data.artifactId : undefined,
+      screenshotPath: typeof data.screenshotPath === "string" ? data.screenshotPath : undefined,
+      createdBy: data.createdBy === "agent" || data.createdBy === "review" ? data.createdBy : "user",
+    });
+    logAnnotationEvent("annotation_created", annotation);
+    return annotation;
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ANNOTATION_LIST, (_event, query: Any) => {
+    const normalized = query && typeof query === "object" ? query : {};
+    return getAnnotationRepo().list({
+      taskId: typeof normalized.taskId === "string" ? normalized.taskId : undefined,
+      workspaceId: typeof normalized.workspaceId === "string" ? normalized.workspaceId : undefined,
+      surfaceType: typeof normalized.surfaceType === "string" ? normalized.surfaceType : undefined,
+      surfaceId: typeof normalized.surfaceId === "string" ? normalized.surfaceId : undefined,
+      statuses: Array.isArray(normalized.statuses) ? normalized.statuses : undefined,
+      limit: typeof normalized.limit === "number" ? normalized.limit : undefined,
+    });
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ANNOTATION_UPDATE, (_event, data: Any) => {
+    const id = typeof data?.id === "string" ? data.id.trim() : "";
+    if (!id) throw new Error("Annotation id is required");
+    const patch = data?.patch && typeof data.patch === "object" ? data.patch : {};
+    const annotation = getAnnotationRepo().update(id, patch);
+    if (annotation) logAnnotationEvent("annotation_updated", annotation);
+    return annotation || null;
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ANNOTATION_RESOLVE, (_event, data: Any) => {
+    const id = typeof data?.id === "string" ? data.id.trim() : "";
+    if (!id) throw new Error("Annotation id is required");
+    const annotation = getAnnotationRepo().update(id, {
+      status: "resolved",
+      resolvedByEventId: typeof data?.resolvedByEventId === "string" ? data.resolvedByEventId : undefined,
+    });
+    if (annotation) logAnnotationEvent("annotation_resolved", annotation);
+    return annotation || null;
+  });
+
+  ipcMain.handle(IPC_CHANNELS.ANNOTATION_DISMISS, (_event, data: Any) => {
+    const id = typeof data?.id === "string" ? data.id.trim() : "";
+    if (!id) throw new Error("Annotation id is required");
+    const annotation = getAnnotationRepo().update(id, { status: "dismissed" });
+    if (annotation) logAnnotationEvent("annotation_dismissed", annotation);
+    return annotation || null;
   });
 
   const resolveDialogDefaultPath = async (candidate?: string | null) => {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -42,6 +42,12 @@ import type {
   AppProfileSummary,
   AudioSummaryConfig,
   AudioSummaryResult,
+  Annotation,
+  AnnotationCreateInput,
+  AnnotationListQuery,
+  AnnotationUpdateInput,
+  BrowserAnnotationTargetRef,
+  BrowserAnnotationTargetResolveResult,
   ProfileExportResult,
   EvalBaselineMetrics,
   EvalCase,
@@ -2121,6 +2127,35 @@ contextBridge.exposeInMainWorld("electronAPI", {
       dataUrl?: string;
       error?: string;
     }>,
+  inspectBrowserWorkbenchPoint: (data: {
+    taskId: string;
+    sessionId?: string;
+    x: number;
+    y: number;
+  }) => ipcRenderer.invoke(IPC_CHANNELS.BROWSER_WORKBENCH_INSPECT_POINT, data) as Promise<{
+    success: boolean;
+    target?: BrowserWorkbenchInspectTarget;
+    error?: string;
+  }>,
+  resolveBrowserWorkbenchAnnotationTargets: (data: {
+    taskId: string;
+    sessionId?: string;
+    targets: BrowserAnnotationTargetRef[];
+  }) => ipcRenderer.invoke(IPC_CHANNELS.BROWSER_WORKBENCH_RESOLVE_ANNOTATION_TARGETS, data) as Promise<{
+    success: boolean;
+    targets?: BrowserAnnotationTargetResolveResult[];
+    error?: string;
+  }>,
+  createAnnotation: (data: AnnotationCreateInput) =>
+    ipcRenderer.invoke(IPC_CHANNELS.ANNOTATION_CREATE, data) as Promise<Annotation>,
+  listAnnotations: (query: AnnotationListQuery) =>
+    ipcRenderer.invoke(IPC_CHANNELS.ANNOTATION_LIST, query) as Promise<Annotation[]>,
+  updateAnnotation: (id: string, patch: AnnotationUpdateInput) =>
+    ipcRenderer.invoke(IPC_CHANNELS.ANNOTATION_UPDATE, { id, patch }) as Promise<Annotation | null>,
+  resolveAnnotation: (id: string, resolvedByEventId?: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.ANNOTATION_RESOLVE, { id, resolvedByEventId }) as Promise<Annotation | null>,
+  dismissAnnotation: (id: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.ANNOTATION_DISMISS, { id }) as Promise<Annotation | null>,
   onBrowserWorkbenchOpenRequest: (callback: (request: BrowserWorkbenchOpenRequest) => void) => {
     const handler = (_: Any, request: BrowserWorkbenchOpenRequest) => callback(request);
     ipcRenderer.on(IPC_CHANNELS.BROWSER_WORKBENCH_OPEN_REQUEST, handler);
@@ -4861,6 +4896,18 @@ export interface BrowserWorkbenchViewportEvent {
   at: number;
 }
 
+export interface BrowserWorkbenchInspectTarget {
+  rect?: { x: number; y: number; width: number; height: number };
+  scroll?: { x: number; y: number };
+  selector?: string;
+  xpath?: string;
+  tagName?: string;
+  role?: string;
+  accessibleName?: string;
+  textQuote?: string;
+  computedStyle?: Record<string, string>;
+}
+
 // Export Mission Control types
 export type {
   HeartbeatStatus,
@@ -4949,6 +4996,30 @@ export interface ElectronAPI {
     dataUrl?: string;
     error?: string;
   }>;
+  inspectBrowserWorkbenchPoint: (data: {
+    taskId: string;
+    sessionId?: string;
+    x: number;
+    y: number;
+  }) => Promise<{
+    success: boolean;
+    target?: BrowserWorkbenchInspectTarget;
+    error?: string;
+  }>;
+  resolveBrowserWorkbenchAnnotationTargets: (data: {
+    taskId: string;
+    sessionId?: string;
+    targets: BrowserAnnotationTargetRef[];
+  }) => Promise<{
+    success: boolean;
+    targets?: BrowserAnnotationTargetResolveResult[];
+    error?: string;
+  }>;
+  createAnnotation: (data: AnnotationCreateInput) => Promise<Annotation>;
+  listAnnotations: (query: AnnotationListQuery) => Promise<Annotation[]>;
+  updateAnnotation: (id: string, patch: AnnotationUpdateInput) => Promise<Annotation | null>;
+  resolveAnnotation: (id: string, resolvedByEventId?: string) => Promise<Annotation | null>;
+  dismissAnnotation: (id: string) => Promise<Annotation | null>;
   onBrowserWorkbenchOpenRequest: (
     callback: (request: BrowserWorkbenchOpenRequest) => void,
   ) => () => void;

--- a/src/renderer/components/BrowserWorkbenchView.tsx
+++ b/src/renderer/components/BrowserWorkbenchView.tsx
@@ -28,6 +28,9 @@ import {
 import type { LucideIcon } from "lucide-react";
 import type {
   ImageAttachment,
+  Annotation,
+  BrowserAnnotationTargetRef,
+  BrowserAnnotationTargetResolveResult,
   LLMModelInfo,
   LLMProviderInfo,
   LLMProviderType,
@@ -140,6 +143,35 @@ function getExternalBrowserUrl(rawUrl: string): string | null {
   } catch {
     return null;
   }
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function getAnnotationUrlKey(rawUrl: string): string {
+  const value = rawUrl.trim();
+  if (!value) return "";
+  try {
+    const parsed = new URL(normalizeUrl(value));
+    parsed.hash = "";
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    return `${parsed.origin}${parsed.pathname}${parsed.search}`;
+  } catch {
+    return value.replace(/#.*$/, "").replace(/\/+$/, "");
+  }
+}
+
+function annotationViewportMatches(
+  target: BrowserAnnotationTargetRef,
+  size: { width: number; height: number } | null,
+): boolean {
+  if (!target.viewport || !size) return false;
+  return (
+    Math.abs(target.viewport.width - size.width) <= 2 &&
+    Math.abs(target.viewport.height - size.height) <= 2
+  );
 }
 
 function getYouTubeVideoId(rawUrl: string): string | null {
@@ -299,6 +331,8 @@ export function BrowserWorkbenchView({
   const annotationImageRef = useRef<HTMLImageElement | null>(null);
   const annotationCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const annotationDrawingRef = useRef(false);
+  const lastAnnotationInspectAtRef = useRef(0);
+  const liveAnnotationInspectRequestIdRef = useRef(0);
   const webviewDomReadyRef = useRef(false);
   const registeredWebContentsIdRef = useRef<number | null>(null);
   const activeUrlRef = useRef(initialUrl || "");
@@ -326,6 +360,13 @@ export function BrowserWorkbenchView({
   const [annotationMessage, setAnnotationMessage] = useState("");
   const [annotationSaving, setAnnotationSaving] = useState(false);
   const [annotationError, setAnnotationError] = useState("");
+  const [liveAnnotationMode, setLiveAnnotationMode] = useState(false);
+  const [liveAnnotationHover, setLiveAnnotationHover] = useState<BrowserAnnotationTargetRef | null>(null);
+  const [liveAnnotationTarget, setLiveAnnotationTarget] = useState<BrowserAnnotationTargetRef | null>(null);
+  const [liveAnnotationText, setLiveAnnotationText] = useState("");
+  const [liveAnnotationSaving, setLiveAnnotationSaving] = useState(false);
+  const [liveAnnotationError, setLiveAnnotationError] = useState("");
+  const [browserAnnotations, setBrowserAnnotations] = useState<Annotation[]>([]);
   const [turnContextExpanded, setTurnContextExpanded] = useState(false);
   const [browserCursor, setBrowserCursor] = useState<BrowserCursorState>(null);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
@@ -354,6 +395,7 @@ export function BrowserWorkbenchView({
     activeUrl && viewportSize && viewportSize.width > 0 && viewportSize.height > 0
       ? viewportSize
       : null;
+  const liveAnnotationOverlayTarget = liveAnnotationTarget || liveAnnotationHover;
   const hasVisibleWebview = Boolean(visibleWebviewSize);
   const activeIsYouTube = Boolean(getYouTubeVideoId(activeUrl || urlText));
   const voiceInput = useVoiceInput({
@@ -853,6 +895,214 @@ export function BrowserWorkbenchView({
     }
   }, [sessionId, taskId, workspacePath]);
 
+  const loadBrowserAnnotations = useCallback(async () => {
+    if (!window.electronAPI.listAnnotations) return;
+    const currentUrl = activeUrlRef.current || activeUrl;
+    const currentUrlKey = getAnnotationUrlKey(currentUrl);
+    const annotations = await window.electronAPI.listAnnotations({
+      taskId,
+      surfaceType: "browser",
+      statuses: ["open", "addressing"],
+      limit: 100,
+    });
+    const matchingAnnotations = annotations.filter((annotation) => {
+        const target = annotation.targetRef as BrowserAnnotationTargetRef;
+        return (
+          target.surfaceType === "browser" &&
+          (!currentUrlKey || getAnnotationUrlKey(target.url) === currentUrlKey)
+        );
+      });
+    if (!window.electronAPI.resolveBrowserWorkbenchAnnotationTargets || matchingAnnotations.length === 0) {
+      setBrowserAnnotations(
+        matchingAnnotations.filter((annotation) =>
+          annotationViewportMatches(annotation.targetRef as BrowserAnnotationTargetRef, visibleWebviewSize),
+        ),
+      );
+      return;
+    }
+    const resolved = await window.electronAPI.resolveBrowserWorkbenchAnnotationTargets({
+      taskId,
+      sessionId,
+      targets: matchingAnnotations.map((annotation) => annotation.targetRef as BrowserAnnotationTargetRef),
+    });
+    const resolvedByIndex = new Map<number, BrowserAnnotationTargetResolveResult>(
+      (resolved.targets || []).map((result) => [result.index, result]),
+    );
+    setBrowserAnnotations(
+      matchingAnnotations.flatMap((annotation, index) => {
+        const target = annotation.targetRef as BrowserAnnotationTargetRef;
+        const resolvedTarget = resolvedByIndex.get(index);
+        if (resolvedTarget?.resolved && resolvedTarget.target?.rect) {
+          return [
+            {
+              ...annotation,
+              targetRef: {
+                ...target,
+                ...resolvedTarget.target,
+                surfaceType: "browser",
+                url: target.url,
+                title: target.title,
+                viewport: visibleWebviewSize
+                  ? {
+                      width: visibleWebviewSize.width,
+                      height: visibleWebviewSize.height,
+                      mobile: controlledViewport?.mobile,
+                      label: controlledViewport?.label,
+                    }
+                  : target.viewport,
+              } satisfies BrowserAnnotationTargetRef,
+            },
+          ];
+        }
+        return annotationViewportMatches(target, visibleWebviewSize) ? [annotation] : [];
+      }),
+    );
+  }, [activeUrl, controlledViewport, sessionId, taskId, visibleWebviewSize]);
+
+  useEffect(() => {
+    void loadBrowserAnnotations();
+  }, [loadBrowserAnnotations]);
+
+  useEffect(() => {
+    if (!activeUrl || browserAnnotations.length === 0) return;
+    const timer = window.setInterval(() => {
+      void loadBrowserAnnotations();
+    }, 1500);
+    return () => window.clearInterval(timer);
+  }, [activeUrl, browserAnnotations.length, loadBrowserAnnotations]);
+
+  const buildBrowserAnnotationTarget = useCallback(
+    (target: Partial<BrowserAnnotationTargetRef>): BrowserAnnotationTargetRef => ({
+      surfaceType: "browser",
+      url: activeUrlRef.current || activeUrl || urlText,
+      title: titleRef.current || title || undefined,
+      viewport: visibleWebviewSize
+        ? {
+            width: visibleWebviewSize.width,
+            height: visibleWebviewSize.height,
+            mobile: controlledViewport?.mobile,
+            label: controlledViewport?.label,
+          }
+        : undefined,
+      ...target,
+    }),
+    [activeUrl, controlledViewport, title, urlText, visibleWebviewSize],
+  );
+
+  const inspectLiveAnnotationPoint = useCallback(async (
+    event: ReactPointerEvent<HTMLDivElement>,
+    force = false,
+  ): Promise<BrowserAnnotationTargetRef | null> => {
+    if (!liveAnnotationMode || liveAnnotationTarget) return null;
+    const now = Date.now();
+    if (!force && now - lastAnnotationInspectAtRef.current < 120) return liveAnnotationHover;
+    lastAnnotationInspectAtRef.current = now;
+    const requestId = liveAnnotationInspectRequestIdRef.current + 1;
+    liveAnnotationInspectRequestIdRef.current = requestId;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = clampNumber(event.clientX - rect.left, 0, rect.width);
+    const y = clampNumber(event.clientY - rect.top, 0, rect.height);
+    try {
+      const result = await window.electronAPI.inspectBrowserWorkbenchPoint?.({
+        taskId,
+        sessionId,
+        x,
+        y,
+      });
+      if (!result?.success || !result.target) return null;
+      const nextTarget = buildBrowserAnnotationTarget(result.target);
+      if (requestId !== liveAnnotationInspectRequestIdRef.current) return null;
+      setLiveAnnotationHover(nextTarget);
+      return nextTarget;
+    } catch (error) {
+      setLiveAnnotationError(error instanceof Error ? error.message : "Inspection failed.");
+      return null;
+    }
+  }, [
+    buildBrowserAnnotationTarget,
+    liveAnnotationHover,
+    liveAnnotationMode,
+    liveAnnotationTarget,
+    sessionId,
+    taskId,
+  ]);
+
+  const selectLiveAnnotationTarget = useCallback(async (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!liveAnnotationMode || liveAnnotationTarget) return;
+    event.preventDefault();
+    const target = liveAnnotationHover || await inspectLiveAnnotationPoint(event, true);
+    if (!target) return;
+    setLiveAnnotationTarget(target);
+    setLiveAnnotationHover(null);
+    setLiveAnnotationText("");
+    setLiveAnnotationError("");
+  }, [inspectLiveAnnotationPoint, liveAnnotationHover, liveAnnotationMode, liveAnnotationTarget]);
+
+  const cancelLiveAnnotationTarget = useCallback(() => {
+    setLiveAnnotationTarget(null);
+    setLiveAnnotationHover(null);
+    setLiveAnnotationText("");
+    setLiveAnnotationError("");
+  }, []);
+
+  const saveLiveBrowserAnnotation = useCallback(async (sendToAgent: boolean) => {
+    const body = liveAnnotationText.trim();
+    if (!liveAnnotationTarget || !body) {
+      setLiveAnnotationError("Add a note for this annotation.");
+      return;
+    }
+    if (!window.electronAPI.createAnnotation) {
+      setLiveAnnotationError("Annotations are not available in this build.");
+      return;
+    }
+    setLiveAnnotationSaving(true);
+    setLiveAnnotationError("");
+    try {
+      let screenshotPath: string | undefined;
+      if (workspacePath && window.electronAPI.captureBrowserWorkbenchScreenshot) {
+        const capture = await window.electronAPI.captureBrowserWorkbenchScreenshot({
+          taskId,
+          sessionId,
+          workspacePath,
+          filename: `browser-annotation-context-${Date.now()}.png`,
+          includeDataUrl: false,
+        });
+        if (capture?.success) {
+          screenshotPath = capture.fullPath || capture.path;
+        }
+      }
+      const created = await window.electronAPI.createAnnotation({
+        taskId,
+        workspaceId,
+        surfaceType: "browser",
+        surfaceId: liveAnnotationTarget.url,
+        body,
+        targetRef: liveAnnotationTarget,
+        screenshotPath,
+      });
+      await loadBrowserAnnotations();
+      cancelLiveAnnotationTarget();
+      setToolbarNotice(sendToAgent ? "Annotation sent" : "Annotation saved");
+      if (sendToAgent && onSendMessage) {
+        await onSendMessage(`Address annotation ${created.id}: ${body}`);
+      }
+    } catch (error) {
+      setLiveAnnotationError(error instanceof Error ? error.message : "Annotation failed.");
+    } finally {
+      setLiveAnnotationSaving(false);
+    }
+  }, [
+    cancelLiveAnnotationTarget,
+    liveAnnotationTarget,
+    liveAnnotationText,
+    loadBrowserAnnotations,
+    onSendMessage,
+    sessionId,
+    taskId,
+    workspaceId,
+    workspacePath,
+  ]);
+
   useEffect(() => {
     if (!toolbarNotice) return;
     const timer = window.setTimeout(() => setToolbarNotice(""), 2200);
@@ -1152,12 +1402,25 @@ export function BrowserWorkbenchView({
           </button>
           <button
             type="button"
+            className={`browser-workbench-nav-btn browser-workbench-action-btn ${liveAnnotationMode ? "is-active" : ""}`}
+            onClick={() => {
+              setLiveAnnotationMode((current) => !current);
+              cancelLiveAnnotationTarget();
+              setToolbarNotice(liveAnnotationMode ? "Annotation mode off" : "Annotating");
+            }}
+            title="Annotate page element"
+            aria-label="Annotate page element"
+          >
+            <PencilLine className="browser-workbench-lucide-icon" size={16} strokeWidth={2.2} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
             className="browser-workbench-nav-btn browser-workbench-action-btn"
             onClick={() => void captureScreenshot("annotation")}
             title="Annotate screenshot"
             aria-label="Annotate screenshot"
           >
-            <PencilLine className="browser-workbench-lucide-icon" size={16} strokeWidth={2.2} aria-hidden="true" />
+            <Plus className="browser-workbench-lucide-icon" size={16} strokeWidth={2.2} aria-hidden="true" />
           </button>
         </div>
       </div>
@@ -1247,26 +1510,162 @@ export function BrowserWorkbenchView({
         ref={surfaceRef}
       >
         {visibleWebviewSize ? (
-          <webview
-            key={webviewKey}
-            ref={webviewRef}
-            src={activeUrl}
-            className="browser-workbench-webview"
+          <div
+            className="browser-workbench-webview-frame"
             style={{
               width: `${visibleWebviewSize.width}px`,
               height: `${visibleWebviewSize.height}px`,
             }}
-            width={visibleWebviewSize.width}
-            height={visibleWebviewSize.height}
-            autosize="true"
-            minwidth={visibleWebviewSize.width}
-            maxwidth={visibleWebviewSize.width}
-            minheight={visibleWebviewSize.height}
-            maxheight={visibleWebviewSize.height}
-            partition={partition}
-            {...webviewPopupProps}
-            webpreferences="contextIsolation=yes, nodeIntegration=no"
-          />
+          >
+            <webview
+              key={webviewKey}
+              ref={webviewRef}
+              src={activeUrl}
+              className="browser-workbench-webview"
+              style={{
+                width: "100%",
+                height: "100%",
+              }}
+              width={visibleWebviewSize.width}
+              height={visibleWebviewSize.height}
+              autosize="true"
+              minwidth={visibleWebviewSize.width}
+              maxwidth={visibleWebviewSize.width}
+              minheight={visibleWebviewSize.height}
+              maxheight={visibleWebviewSize.height}
+              partition={partition}
+              {...webviewPopupProps}
+              webpreferences="contextIsolation=yes, nodeIntegration=no"
+            />
+            {browserAnnotations.map((annotation, index) => {
+              const target = annotation.targetRef as BrowserAnnotationTargetRef;
+              if (target.surfaceType !== "browser" || !target.rect) return null;
+              return (
+                <button
+                  key={annotation.id}
+                  type="button"
+                  className={`browser-live-annotation-pin status-${annotation.status}`}
+                  style={{
+                    left: `${clampNumber(target.rect.x + target.rect.width - 12, 2, visibleWebviewSize.width - 24)}px`,
+                    top: `${clampNumber(target.rect.y - 12, 2, visibleWebviewSize.height - 24)}px`,
+                  }}
+                  title={annotation.body}
+                  aria-label={`Annotation ${index + 1}: ${annotation.body}`}
+                >
+                  {index + 1}
+                </button>
+              );
+            })}
+            {liveAnnotationMode && (
+              <div
+                className="browser-live-annotation-layer"
+                onPointerMove={(event) => {
+                  void inspectLiveAnnotationPoint(event);
+                }}
+                onPointerDown={(event) => {
+                  void selectLiveAnnotationTarget(event);
+                }}
+              >
+                {liveAnnotationOverlayTarget?.rect && (
+                  <div
+                    className={`browser-live-annotation-box ${
+                      liveAnnotationTarget ? "is-selected" : ""
+                    }`}
+                    style={{
+                      left: `${liveAnnotationOverlayTarget.rect.x}px`,
+                      top: `${liveAnnotationOverlayTarget.rect.y}px`,
+                      width: `${liveAnnotationOverlayTarget.rect.width}px`,
+                      height: `${liveAnnotationOverlayTarget.rect.height}px`,
+                    }}
+                    aria-hidden="true"
+                  />
+                )}
+                {liveAnnotationHover && !liveAnnotationTarget && (
+                  <div
+                    className="browser-live-annotation-inspector"
+                    style={{
+                      left: `${clampNumber(
+                        (liveAnnotationHover.rect?.x || 0) + 8,
+                        8,
+                        visibleWebviewSize.width - 170,
+                      )}px`,
+                      top: `${clampNumber(
+                        (liveAnnotationHover.rect?.y || 0) - 38,
+                        8,
+                        visibleWebviewSize.height - 32,
+                      )}px`,
+                    }}
+                  >
+                    <span>{liveAnnotationHover.tagName || "element"}</span>
+                    {liveAnnotationHover.computedStyle?.fontSize && (
+                      <span>{liveAnnotationHover.computedStyle.fontSize}</span>
+                    )}
+                  </div>
+                )}
+                {liveAnnotationTarget?.rect && (
+                  <div
+                    className="browser-live-annotation-composer"
+                    style={{
+                      left: `${clampNumber(
+                        liveAnnotationTarget.rect.x + liveAnnotationTarget.rect.width + 14,
+                        12,
+                        visibleWebviewSize.width - 340,
+                      )}px`,
+                      top: `${clampNumber(
+                        liveAnnotationTarget.rect.y,
+                        12,
+                        visibleWebviewSize.height - 210,
+                      )}px`,
+                    }}
+                    onPointerDown={(event) => event.stopPropagation()}
+                  >
+                    <div className="browser-live-annotation-meta">
+                      <span>{liveAnnotationTarget.tagName || "element"}</span>
+                      {liveAnnotationTarget.selector && <code>{liveAnnotationTarget.selector}</code>}
+                    </div>
+                    <textarea
+                      value={liveAnnotationText}
+                      onChange={(event) => setLiveAnnotationText(event.target.value)}
+                      placeholder="What should CoWork OS change here?"
+                      rows={3}
+                      autoFocus
+                    />
+                    {liveAnnotationError && (
+                      <div className="browser-live-annotation-error">{liveAnnotationError}</div>
+                    )}
+                    <div className="browser-live-annotation-actions">
+                      <button
+                        type="button"
+                        className="browser-annotation-secondary"
+                        onClick={cancelLiveAnnotationTarget}
+                        disabled={liveAnnotationSaving}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        className="browser-annotation-secondary"
+                        onClick={() => void saveLiveBrowserAnnotation(false)}
+                        disabled={liveAnnotationSaving || !liveAnnotationText.trim()}
+                      >
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        className="browser-annotation-primary browser-live-annotation-send"
+                        onClick={() => void saveLiveBrowserAnnotation(true)}
+                        disabled={liveAnnotationSaving || !liveAnnotationText.trim() || !onSendMessage}
+                        title="Send annotation to CoWork OS"
+                        aria-label="Send annotation to CoWork OS"
+                      >
+                        <ArrowUp size={15} strokeWidth={2.4} aria-hidden="true" />
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
         ) : activeUrl ? (
           <div className="browser-workbench-empty">Preparing browser viewport...</div>
         ) : (

--- a/src/renderer/components/__tests__/browser-workbench-navigation.test.ts
+++ b/src/renderer/components/__tests__/browser-workbench-navigation.test.ts
@@ -45,4 +45,17 @@ describe("Browser workbench navigation controls", () => {
     expect(source).toContain('aria-label="Open current page in external browser"');
     expect(source).toContain("getExternalBrowserUrl");
   });
+
+  it("wires live page annotations through inspect, persistence, and follow-up send", () => {
+    const source = readFileSync(componentPath, "utf8");
+
+    expect(source).toContain("inspectBrowserWorkbenchPoint");
+    expect(source).toContain("resolveBrowserWorkbenchAnnotationTargets");
+    expect(source).toContain("createAnnotation");
+    expect(source).toContain("listAnnotations");
+    expect(source).toContain("getAnnotationUrlKey");
+    expect(source).toContain("liveAnnotationInspectRequestIdRef");
+    expect(source).toContain("browser-live-annotation-layer");
+    expect(source).toContain("Address annotation ${created.id}: ${body}");
+  });
 });

--- a/src/renderer/components/__tests__/browser-workbench-styles.test.ts
+++ b/src/renderer/components/__tests__/browser-workbench-styles.test.ts
@@ -55,4 +55,14 @@ describe("Browser workbench styles", () => {
       /\.browser-workbench-tab-close svg\s*\{[^}]*stroke:\s*currentColor;[^}]*opacity:\s*1;/s,
     );
   });
+
+  it("styles live browser annotations as an overlay with pins and composer", () => {
+    const source = readFileSync(stylesPath, "utf8");
+
+    expect(source).toMatch(/\.browser-workbench-webview-frame\s*\{[^}]*position:\s*relative;/s);
+    expect(source).toMatch(/\.browser-live-annotation-layer\s*\{[^}]*cursor:\s*crosshair;/s);
+    expect(source).toMatch(/\.browser-live-annotation-box\s*\{[^}]*border:\s*2px solid #0ea5e9;/s);
+    expect(source).toContain(".browser-live-annotation-pin");
+    expect(source).toContain(".browser-live-annotation-composer");
+  });
 });

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -15979,6 +15979,165 @@ a,
   border: 0;
 }
 
+.browser-workbench-webview-frame {
+  position: relative;
+  flex: 0 0 auto;
+  min-width: 0;
+  min-height: 0;
+  background: #fff;
+}
+
+.browser-live-annotation-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 15;
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.browser-live-annotation-box {
+  position: absolute;
+  min-width: 18px;
+  min-height: 18px;
+  border: 2px solid #0ea5e9;
+  background: rgba(14, 165, 233, 0.18);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.86),
+    0 8px 22px rgba(14, 116, 144, 0.18);
+  pointer-events: none;
+}
+
+.browser-live-annotation-box.is-selected {
+  border-color: #0284c7;
+  background: rgba(14, 165, 233, 0.26);
+}
+
+.browser-live-annotation-pin {
+  position: absolute;
+  z-index: 14;
+  width: 24px;
+  height: 24px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #0284c7;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
+  box-shadow: 0 8px 18px rgba(2, 132, 199, 0.32);
+  cursor: default;
+}
+
+.browser-live-annotation-pin.status-addressing {
+  background: #7c3aed;
+  box-shadow: 0 8px 18px rgba(124, 58, 237, 0.28);
+}
+
+.browser-live-annotation-inspector {
+  position: absolute;
+  z-index: 16;
+  max-width: 170px;
+  min-height: 28px;
+  padding: 5px 7px;
+  border: 1px solid rgba(14, 165, 233, 0.45);
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: rgba(255, 255, 255, 0.96);
+  color: #0f172a;
+  font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);
+  font-size: 11px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.15);
+  pointer-events: none;
+}
+
+.browser-live-annotation-inspector span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.browser-live-annotation-composer {
+  position: absolute;
+  z-index: 17;
+  width: 328px;
+  display: grid;
+  gap: 9px;
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.36);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.98);
+  color: #0f172a;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.18);
+  cursor: default;
+}
+
+.browser-live-annotation-meta {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #475569;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.browser-live-annotation-meta code {
+  min-width: 0;
+  overflow: hidden;
+  color: #64748b;
+  font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);
+  font-size: 10.5px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.browser-live-annotation-composer textarea {
+  width: 100%;
+  min-height: 76px;
+  resize: vertical;
+  padding: 9px 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 9px;
+  background: #fff;
+  color: #0f172a;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.browser-live-annotation-composer textarea:focus {
+  border-color: #38bdf8;
+  outline: 2px solid rgba(14, 165, 233, 0.16);
+}
+
+.browser-live-annotation-error {
+  color: #b91c1c;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.browser-live-annotation-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.browser-live-annotation-send {
+  width: 36px;
+  min-width: 36px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .browser-workbench-surface.has-controlled-viewport {
   background:
     linear-gradient(45deg, rgba(148, 163, 184, 0.14) 25%, transparent 25%),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -814,6 +814,12 @@ export type EventType =
   | "workspace_permissions_updated"
   | "user_message"
   | "user_feedback"
+  | "annotation_created"
+  | "annotation_updated"
+  | "annotation_addressing_started"
+  | "annotation_addressed"
+  | "annotation_resolved"
+  | "annotation_dismissed"
   | "command_output"
   // LLM usage tracking (tokens/cost)
   | "llm_usage"
@@ -3768,6 +3774,162 @@ export interface Artifact {
   sha256: string;
   size: number;
   createdAt: number;
+}
+
+export type AnnotationSurfaceType =
+  | "browser"
+  | "diff"
+  | "file"
+  | "artifact"
+  | "message";
+
+export type AnnotationStatus =
+  | "open"
+  | "addressing"
+  | "addressed"
+  | "resolved"
+  | "dismissed";
+
+export interface AnnotationViewportRef {
+  width: number;
+  height: number;
+  deviceScaleFactor?: number;
+  mobile?: boolean;
+  label?: string;
+}
+
+export interface AnnotationRectRef {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface BrowserAnnotationTargetRef {
+  surfaceType: "browser";
+  url: string;
+  title?: string;
+  viewport?: AnnotationViewportRef;
+  rect?: AnnotationRectRef;
+  scroll?: { x: number; y: number };
+  selector?: string;
+  xpath?: string;
+  tagName?: string;
+  role?: string;
+  accessibleName?: string;
+  textQuote?: string;
+  computedStyle?: Record<string, string>;
+}
+
+export interface BrowserAnnotationTargetResolveResult {
+  index: number;
+  resolved: boolean;
+  target?: Partial<BrowserAnnotationTargetRef>;
+  error?: string;
+}
+
+export interface DiffAnnotationTargetRef {
+  surfaceType: "diff";
+  filePath: string;
+  side?: "old" | "new" | "context";
+  oldLine?: number;
+  newLine?: number;
+  hunkHeader?: string;
+  hunkHash?: string;
+  baseRef?: string;
+  headRef?: string;
+}
+
+export interface FileAnnotationTargetRef {
+  surfaceType: "file" | "artifact";
+  filePath: string;
+  fileType?: string;
+  page?: number;
+  slideIndex?: number;
+  sheetName?: string;
+  cellRange?: string;
+  rect?: AnnotationRectRef;
+  textQuote?: string;
+  blockId?: string;
+}
+
+export interface MessageAnnotationTargetRef {
+  surfaceType: "message";
+  taskEventId: string;
+  textQuote?: string;
+  startOffset?: number;
+  endOffset?: number;
+}
+
+export type AnnotationTargetRef =
+  | BrowserAnnotationTargetRef
+  | DiffAnnotationTargetRef
+  | FileAnnotationTargetRef
+  | MessageAnnotationTargetRef;
+
+export interface AnnotationStylePatch {
+  text?: string;
+  color?: string;
+  backgroundColor?: string;
+  fontFamily?: string;
+  fontSize?: string;
+  fontWeight?: string;
+  lineHeight?: string;
+  spacing?: string;
+  alignment?: string;
+  borderRadius?: string;
+  notes?: string;
+}
+
+export interface Annotation {
+  id: string;
+  taskId: string;
+  workspaceId?: string;
+  surfaceType: AnnotationSurfaceType;
+  surfaceId?: string;
+  body: string;
+  status: AnnotationStatus;
+  targetRef: AnnotationTargetRef;
+  stylePatch?: AnnotationStylePatch;
+  artifactId?: string;
+  screenshotPath?: string;
+  createdBy: "user" | "agent" | "review";
+  createdAt: number;
+  updatedAt: number;
+  resolvedAt?: number;
+  resolvedByEventId?: string;
+}
+
+export interface AnnotationCreateInput {
+  taskId: string;
+  workspaceId?: string;
+  surfaceType: AnnotationSurfaceType;
+  surfaceId?: string;
+  body: string;
+  targetRef: AnnotationTargetRef;
+  stylePatch?: AnnotationStylePatch;
+  artifactId?: string;
+  screenshotPath?: string;
+  createdBy?: Annotation["createdBy"];
+}
+
+export interface AnnotationListQuery {
+  taskId?: string;
+  workspaceId?: string;
+  surfaceType?: AnnotationSurfaceType;
+  surfaceId?: string;
+  statuses?: AnnotationStatus[];
+  limit?: number;
+}
+
+export interface AnnotationUpdateInput {
+  body?: string;
+  status?: AnnotationStatus;
+  targetRef?: AnnotationTargetRef;
+  stylePatch?: AnnotationStylePatch | null;
+  artifactId?: string | null;
+  screenshotPath?: string | null;
+  resolvedByEventId?: string | null;
 }
 
 export interface DocumentVersionEntry {
@@ -7624,9 +7786,16 @@ export const IPC_CHANNELS = {
   BROWSER_WORKBENCH_UNREGISTER: "browserWorkbench:unregister",
   BROWSER_WORKBENCH_STATUS: "browserWorkbench:status",
   BROWSER_WORKBENCH_SCREENSHOT: "browserWorkbench:screenshot",
+  BROWSER_WORKBENCH_INSPECT_POINT: "browserWorkbench:inspectPoint",
+  BROWSER_WORKBENCH_RESOLVE_ANNOTATION_TARGETS: "browserWorkbench:resolveAnnotationTargets",
   BROWSER_WORKBENCH_OPEN_REQUEST: "browserWorkbench:openRequest",
   BROWSER_WORKBENCH_CURSOR: "browserWorkbench:cursor",
   BROWSER_WORKBENCH_VIEWPORT: "browserWorkbench:viewport",
+  ANNOTATION_CREATE: "annotation:create",
+  ANNOTATION_LIST: "annotation:list",
+  ANNOTATION_UPDATE: "annotation:update",
+  ANNOTATION_RESOLVE: "annotation:resolve",
+  ANNOTATION_DISMISS: "annotation:dismiss",
   YOUTUBE_INGEST_VIDEO: "youtube:ingestVideo",
   YOUTUBE_ASK_VIDEO: "youtube:askVideo",
   YOUTUBE_SEARCH_SEGMENTS: "youtube:searchSegments",


### PR DESCRIPTION
## Summary
- Add persistent annotation records, IPC, and browser-target inspection for the workbench
- Support live element annotation in the browser UI with pins, a composer, and send-to-agent flow
- Inject pending annotations into follow-up prompts and track annotation lifecycle events
- Add focused repository and renderer tests plus style coverage

## Testing
- Vitest coverage for the annotation repository and browser workbench source/style guards
- Local type and lint checks passed during implementation