### PR TITLE
Harden build-health routine evidence checks

### DIFF
--- a/src/electron/agent/__tests__/executor-completion-contract.test.ts
+++ b/src/electron/agent/__tests__/executor-completion-contract.test.ts
@@ -3,6 +3,7 @@ import { TaskExecutor } from "../executor";
 import {
   buildCompletionGuidancePrompt,
   detectReadOnlyConstraint,
+  responseHasExecutionReportEvidenceSignal,
 } from "../executor-completion-utils";
 
 type HarnessOptions = {
@@ -849,6 +850,58 @@ Verification complete: this routine produced a review-backed build-health conclu
         error: expect.stringContaining("missing verification evidence"),
       }),
     );
+  });
+
+  it("rejects build-health mutation-blocker summaries that contain labels but no command/API evidence", () => {
+    const text = `Almarion, the package.json step did not make changes. The attempted write_file operation was correctly blocked because it would have replaced the existing root manifest with minimal starter content.
+
+Verification Evidence
+commands completed:
+No shell commands were run.
+Attempted mutation: write_file on package.json.
+exit codes:
+Not applicable; no shell command executed.
+required check status:
+Required write_file attempt: completed as an attempted mutation, but safely rejected.
+package.json update: failed due to destructive overwrite protection.
+final build-health verdict:
+Blocked. Build health cannot be improved or re-verified from this step until the package.json change is made non-destructive.
+Verification complete: this routine produced a review-backed build-health conclusion.`;
+
+    expect(responseHasExecutionReportEvidenceSignal(text)).toBe(false);
+  });
+
+  it("requires command or API tool evidence for build-health command execution steps", () => {
+    const executor = createExecuteHarness({
+      title: "CoWork OS Build Health Watcher",
+      prompt: `Run a fresh build-health check.
+
+Required checks:
+- npm run lint
+- npm run type-check
+
+End with a final section titled "Verification Evidence".`,
+      lastOutput: "",
+      planStepDescription: "Required build/check commands executed.",
+      source: "cron",
+    });
+    (executor as Any).toolResultMemory = [
+      { tool: "read_file", summary: "Read package.json", timestamp: Date.now() },
+      { tool: "glob", summary: "Found config files", timestamp: Date.now() },
+      { tool: "task_history", summary: "Read previous routine history", timestamp: Date.now() },
+    ];
+
+    expect((executor as Any).isBuildHealthCommandEvidenceStep({
+      id: "1",
+      description: "Required build/check commands executed.",
+      status: "pending",
+    })).toBe(true);
+    expect((executor as Any).hasBuildHealthCommandOrApiEvidence()).toBe(false);
+
+    (executor as Any).toolResultMemory = [
+      { tool: "http_request", summary: "GitHub check-runs HTTP 200", timestamp: Date.now() },
+    ];
+    expect((executor as Any).hasBuildHealthCommandOrApiEvidence()).toBe(true);
   });
 
   it("accepts completed review/check steps even when the final response is operational", async () => {

--- a/src/electron/agent/__tests__/executor-workspace-preflight-ack.test.ts
+++ b/src/electron/agent/__tests__/executor-workspace-preflight-ack.test.ts
@@ -302,6 +302,46 @@ describe("TaskExecutor workspace preflight acknowledgement", () => {
     expect(reason).toBeNull();
   });
 
+  it("treats build-health package.json plan steps as read-only tooling inspection", () => {
+    const fakeThis: Any = Object.create((TaskExecutor as Any).prototype);
+    fakeThis.workspace = { path: process.cwd() };
+    fakeThis.task = {
+      id: "t-build-health",
+      title: "CoWork OS Build Health Watcher",
+      prompt: `Run a fresh build-health check.
+
+Required checks:
+- npm run lint
+- npm run type-check
+
+End with a final section titled "Verification Evidence".`,
+      rawPrompt: `Run a fresh build-health check.
+
+Required checks:
+- npm run lint
+- npm run type-check
+
+End with a final section titled "Verification Evidence".`,
+      source: "cron",
+    };
+    fakeThis.agentPolicyConfig = null;
+    fakeThis.toolRegistry = { getTools: () => [] };
+    const step = {
+      id: "s-build-health-package",
+      description: "`package.json`",
+      kind: "primary",
+      status: "pending",
+    };
+    fakeThis.plan = { steps: [step] };
+
+    const contract = (TaskExecutor as Any).prototype.resolveStepExecutionContract.call(fakeThis, step);
+
+    expect(contract.mode).toBe("analysis_only");
+    expect(contract.requiresMutation).toBe(false);
+    expect(contract.requiresArtifactEvidence).toBe(false);
+    expect(Array.from(contract.requiredTools)).not.toContain("write_file");
+  });
+
   it("does not preflight-fail verification-only relative paths that are not yet materialized", () => {
     const fakeThis: Any = Object.create((TaskExecutor as Any).prototype);
     fakeThis.workspace = { path: process.cwd() };

--- a/src/electron/agent/executor-completion-utils.ts
+++ b/src/electron/agent/executor-completion-utils.ts
@@ -458,16 +458,13 @@ export function responseHasExecutionReportEvidenceSignal(text: string): boolean 
   if (!normalized.trim()) return false;
 
   const hasCommandOrApiEvidence =
-    /\b(?:cargo|go|make|cmake|xcodebuild|swift|pytest|python -m pytest|gradle|mvn|dotnet)\b[\w\s:.-]{0,80}/.test(
+    /(?:^|[\n`*-]\s*)(?:cargo|go|make|cmake|xcodebuild|swift|pytest|python -m pytest|gradle|mvn|dotnet)\s+[\w:./-]+/m.test(
       normalized,
     ) ||
     /\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?[\w:-]+\b/.test(normalized) ||
     /\bexit(?:\s+code)?\s*`?\d+`?\b/.test(normalized) ||
     /\bhttp\s*`?\d{3}`?\b/.test(normalized) ||
-    /\b(?:get|post|put|patch|delete)\s+https?:\/\//.test(normalized) ||
-    /\bapi requests?\b/.test(normalized) ||
-    /\bcommands? completed\b/.test(normalized) ||
-    /\bexact command results\b/.test(normalized);
+    /\b(?:get|post|put|patch|delete)\s+https?:\/\//.test(normalized);
   const hasPassFailEvidence =
     /\b(?:passed|failed|skipped|success|failure)\b/.test(normalized) ||
     /\bpass\/fail\b/.test(normalized) ||

--- a/src/electron/agent/executor.ts
+++ b/src/electron/agent/executor.ts
@@ -10573,6 +10573,24 @@ ${transcript}
     const descriptionRaw = String(step.description || "");
     const description = descriptionRaw.toLowerCase();
     const requiredTools = this.extractRequiredToolsFromStepDescription(description);
+    const buildHealthReadOnlyStep = this.isBuildHealthReadOnlyStep(step);
+    if (buildHealthReadOnlyStep) {
+      for (const toolName of [
+        "write_file",
+        "edit_file",
+        "create_document",
+        "generate_document",
+        "compile_latex",
+        "create_spreadsheet",
+        "generate_spreadsheet",
+        "create_presentation",
+        "generate_presentation",
+        "canvas_create",
+        "canvas_push",
+      ]) {
+        requiredTools.delete(toolName);
+      }
+    }
     if (this.isTerminalImageGenerationTask()) {
       requiredTools.add(canonicalizeToolNameUtil("generate_image"));
     }
@@ -10597,7 +10615,9 @@ ${transcript}
         requiredTools.delete("edit_file");
       }
     }
-    const requiresArtifactEvidence = this.stepRequiresArtifactEvidence(step);
+    const requiresArtifactEvidence = buildHealthReadOnlyStep
+      ? false
+      : this.stepRequiresArtifactEvidence(step);
     const artifactContractMode = requiresArtifactEvidence
       ? this.resolveStepArtifactContractMode(step)
       : null;
@@ -10630,9 +10650,9 @@ ${transcript}
       requiresMutation: inferredMutation,
       requiresArtifactEvidence,
       requiresWriteByArtifactMode: artifactWriteRequired,
-      hasReadOnlyConstraint: this.promptHasReadOnlyConstraint(
-        `${this.task?.title || ""}\n${this.getContractPrompt()}`,
-      ),
+      hasReadOnlyConstraint:
+        buildHealthReadOnlyStep ||
+        this.promptHasReadOnlyConstraint(`${this.task?.title || ""}\n${this.getContractPrompt()}`),
     });
     const policyRequiredTools = getPolicyRequiredToolsForMode(
       this.agentPolicyConfig,
@@ -11751,6 +11771,68 @@ ${transcript}
       requiresDirectAnswer: this.promptRequiresDirectAnswer(),
       requiresDecisionSignal: this.promptRequestsDecision(),
       isWatchSkipRecommendationTask: this.promptIsWatchSkipRecommendationTask(),
+    });
+  }
+
+  private isBuildHealthVerificationTask(): boolean {
+    const prompt = `${this.task?.title || ""}\n${this.getContractPrompt()}`.toLowerCase();
+    if (!prompt.trim()) return false;
+    const hasBuildHealthCue =
+      /\bbuild[-\s]?health\b/.test(prompt) ||
+      /\bbuild\s+surfaces?\b/.test(prompt) ||
+      /\bmain\s+build\s+surfaces?\b/.test(prompt);
+    if (!hasBuildHealthCue) return false;
+
+    return (
+      /\b(watcher|routine|check|checks?|verification evidence|review-backed|exit codes?|passed or failed|final build-health verdict|build-health conclusion)\b/.test(
+        prompt,
+      ) || /\bnpm\s+run\s+(?:build|lint|type-check|test)/.test(prompt)
+    );
+  }
+
+  private isBuildHealthReadOnlyStep(step: PlanStep): boolean {
+    if (!this.isBuildHealthVerificationTask()) return false;
+    if (this.buildCompletionContract().requiresArtifactEvidence) return false;
+
+    const desc = String(step.description || "").trim().toLowerCase();
+    if (!desc) return false;
+
+    const stripped = desc.replace(/^`+|`+$/g, "");
+    if (
+      /^(?:\.\/)?(?:package(?:-lock)?\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|npm-shrinkwrap\.json|tsconfig[^/]*\.json|vite\.config\.[cm]?[jt]s|vitest\.config\.[cm]?[jt]s|eslint\.config\.[cm]?js|\.oxlintrc\.json|electron-builder[^/]*\.(?:json|ya?ml|[cm]?[jt]s))$/.test(
+        stripped,
+      )
+    ) {
+      return true;
+    }
+
+    return /\b(required build\/check commands executed|build-health checks?|build health checks?|exit codes? captured|pass\/fail status|passed or failed|blockers? clearly identified|final build-health verdict|verification evidence|inspect workspace structure|identify package\/build tooling)\b/.test(
+      desc,
+    );
+  }
+
+  private isBuildHealthCommandEvidenceStep(step: PlanStep): boolean {
+    if (!this.isBuildHealthVerificationTask()) return false;
+    const desc = String(step.description || "").toLowerCase();
+    if (!desc.trim()) return false;
+    return /\b(required build\/check commands executed|build-health checks?|build health checks?|run build-health checks?|run build health checks?|commands? executed|commands? completed|exit codes? captured|pass\/fail status|passed or failed)\b/.test(
+      desc,
+    );
+  }
+
+  private hasBuildHealthCommandOrApiEvidence(): boolean {
+    const evidenceTools = new Set(["run_command", "http_request", "web_fetch"]);
+    if (this.successfulToolUsageCounts instanceof Map) {
+      for (const [toolName, count] of this.successfulToolUsageCounts.entries()) {
+        const canonical = canonicalizeToolNameUtil(String(toolName || "").trim().toLowerCase());
+        if ((count || 0) > 0 && evidenceTools.has(canonical)) return true;
+      }
+    }
+
+    const memory = Array.isArray(this.toolResultMemory) ? this.toolResultMemory : [];
+    return memory.some((entry) => {
+      const canonical = canonicalizeToolNameUtil(String(entry?.tool || "").trim().toLowerCase());
+      return evidenceTools.has(canonical);
     });
   }
 
@@ -30088,6 +30170,18 @@ Return ONLY a JSON object:
         stepFailed = true;
         if (!lastFailureReason) {
           lastFailureReason = "run_command failed and no subsequent tool succeeded.";
+        }
+      }
+
+      if (
+        !stepFailed &&
+        this.isBuildHealthCommandEvidenceStep(step) &&
+        !this.hasBuildHealthCommandOrApiEvidence()
+      ) {
+        stepFailed = true;
+        if (!lastFailureReason) {
+          lastFailureReason =
+            "Build-health verification step expected concrete command/API evidence, but no successful run_command, http_request, or web_fetch result was recorded.";
         }
       }
 


### PR DESCRIPTION
## Summary
- Treat build-health routine `package.json` steps as read-only inspection instead of mutation-required work.
- Require concrete command or API evidence for build-health execution steps.
- Tighten execution-report evidence parsing so labels alone do not satisfy verification.
- Add regressions for the build-health routine drift and package.json inspection path.

## Testing
- Added unit coverage for completion/evidence parsing and build-health step classification.
- Ran focused Vitest coverage for the updated executor contract tests and command-requirement tests.
- Ran the Electron TypeScript build successfully.