### PR TITLE
Add approval gates for visible browser and computer use

### DIFF
--- a/src/electron/agent/__tests__/tool-policy-engine.test.ts
+++ b/src/electron/agent/__tests__/tool-policy-engine.test.ts
@@ -170,7 +170,7 @@ describe("evaluateToolAvailability computer_use", () => {
       taskText: "Open https://example.com and click the sign in button.",
     });
     expect(r.decision).toBe("defer");
-    expect(r.reason).toBe("computer_use_intent_missing");
+    expect(r.reason).toBe("prefer_browser_background_for_web_surface");
   });
 
   it("allows screen_context_resolve for vague on-screen references", () => {

--- a/src/electron/agent/tool-policy-engine.ts
+++ b/src/electron/agent/tool-policy-engine.ts
@@ -485,6 +485,9 @@ export function evaluateToolAvailability(
           : { decision: "defer", reason: "screen_context_intent_missing", metadata };
       }
       if (isComputerUseToolName(normalizedToolName)) {
+        if (WEB_SURFACE_PATTERN.test(taskText) && !COMPUTER_USE_INTENT_PATTERN.test(taskText)) {
+          return { decision: "defer", reason: "prefer_browser_background_for_web_surface", metadata };
+        }
         return hasNativeDesktopGuiIntent(taskText) || ctx.taskDomain === "operations"
           ? { decision: "allow", metadata }
           : { decision: "defer", reason: "computer_use_intent_missing", metadata };

--- a/src/electron/agent/tools/__tests__/browser-tools.test.ts
+++ b/src/electron/agent/tools/__tests__/browser-tools.test.ts
@@ -1,9 +1,14 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { BrowserTools } from "../browser-tools";
 import { GuardrailManager } from "../../../guardrails/guardrail-manager";
+import { BuiltinToolsSettingsManager } from "../builtin-settings";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("BrowserTools browser_navigate", () => {
   const workspace = {
@@ -22,6 +27,7 @@ describe("BrowserTools browser_navigate", () => {
     const daemon = {
       logEvent: vi.fn(),
       registerArtifact: vi.fn(),
+      requestApproval: vi.fn(),
     } as Any;
 
     return {
@@ -72,7 +78,7 @@ describe("BrowserTools browser_navigate", () => {
     expect(result.status).toBe(200);
   });
 
-  it("uses the visible in-app browser workbench by default when available", async () => {
+  it("uses headless Playwright by default even when the visible workbench service is available", async () => {
     const browserWorkbenchService = {
       getSession: vi.fn().mockReturnValue(null),
       navigate: vi.fn().mockResolvedValue({
@@ -86,7 +92,12 @@ describe("BrowserTools browser_navigate", () => {
     const { tools } = makeTools(browserWorkbenchService);
     const headlessNavigate = vi.fn();
     (tools as Any).browserService = {
-      navigate: headlessNavigate,
+      navigate: headlessNavigate.mockResolvedValue({
+        url: "https://example.com",
+        title: "Example Domain",
+        status: 200,
+        isError: false,
+      }),
       close: vi.fn(),
     };
 
@@ -95,14 +106,8 @@ describe("BrowserTools browser_navigate", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(result.visible).toBe(true);
-    expect(browserWorkbenchService.navigate).toHaveBeenCalledWith({
-      taskId: "task-1",
-      sessionId: undefined,
-      url: "https://example.com",
-      waitUntil: "load",
-    });
-    expect(headlessNavigate).not.toHaveBeenCalled();
+    expect(browserWorkbenchService.navigate).not.toHaveBeenCalled();
+    expect(headlessNavigate).toHaveBeenCalled();
   });
 
   it("keeps using an active visible workbench when profile options are supplied later", async () => {
@@ -145,7 +150,11 @@ describe("BrowserTools browser_navigate", () => {
     expect(headlessNavigate).not.toHaveBeenCalled();
   });
 
-  it("ignores the legacy headless flag for normal visible workbench routing", async () => {
+  it("uses the visible workbench when visible mode is enabled", async () => {
+    vi.spyOn(BuiltinToolsSettingsManager, "getComputerUseAutomationSettings").mockReturnValue({
+      browserAutomationMode: "visible",
+      nativeComputerUseMode: "background_first",
+    });
     const browserWorkbenchService = {
       getSession: vi.fn().mockReturnValue(null),
       navigate: vi.fn().mockResolvedValue({
@@ -164,13 +173,88 @@ describe("BrowserTools browser_navigate", () => {
 
     const result = await tools.executeTool("browser_navigate", {
       url: "https://example.com",
-      headless: true,
     });
 
     expect(result.success).toBe(true);
     expect(result.visible).toBe(true);
+    expect(browserWorkbenchService.navigate).toHaveBeenCalledWith({
+      taskId: "task-1",
+      sessionId: undefined,
+      url: "https://example.com",
+      waitUntil: "load",
+    });
+    expect((tools as Any).browserService.navigate).not.toHaveBeenCalled();
+  });
+
+  it("asks before opening the visible workbench in ask mode", async () => {
+    vi.spyOn(BuiltinToolsSettingsManager, "getComputerUseAutomationSettings").mockReturnValue({
+      browserAutomationMode: "ask",
+      nativeComputerUseMode: "background_first",
+    });
+    const browserWorkbenchService = {
+      getSession: vi.fn().mockReturnValue(null),
+      navigate: vi.fn().mockResolvedValue({
+        success: true,
+        url: "https://example.com",
+        title: "Example Domain",
+        status: null,
+        visible: true,
+      }),
+    };
+    const { tools, daemon } = makeTools(browserWorkbenchService);
+    daemon.requestApproval.mockResolvedValue(true);
+    (tools as Any).browserService = {
+      navigate: vi.fn(),
+      close: vi.fn(),
+    };
+
+    const result = await tools.executeTool("browser_navigate", {
+      url: "https://example.com",
+      visible: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.visible).toBe(true);
+    expect(daemon.requestApproval).toHaveBeenCalledWith(
+      "task-1",
+      "browser",
+      expect.stringContaining("visible browser workbench"),
+      expect.objectContaining({ kind: "browser_visible_workbench", tool: "browser_navigate" }),
+      { allowAutoApprove: false },
+    );
     expect(browserWorkbenchService.navigate).toHaveBeenCalled();
     expect((tools as Any).browserService.navigate).not.toHaveBeenCalled();
+  });
+
+  it("uses headless Playwright when visible workbench ask mode is denied", async () => {
+    vi.spyOn(BuiltinToolsSettingsManager, "getComputerUseAutomationSettings").mockReturnValue({
+      browserAutomationMode: "ask",
+      nativeComputerUseMode: "background_first",
+    });
+    const browserWorkbenchService = {
+      getSession: vi.fn().mockReturnValue(null),
+      navigate: vi.fn(),
+    };
+    const { tools, daemon } = makeTools(browserWorkbenchService);
+    daemon.requestApproval.mockResolvedValue(false);
+    (tools as Any).browserService = {
+      navigate: vi.fn().mockResolvedValue({
+        url: "https://example.com",
+        title: "Example Domain",
+        status: 200,
+        isError: false,
+      }),
+      close: vi.fn(),
+    };
+
+    const result = await tools.executeTool("browser_navigate", {
+      url: "https://example.com",
+      visible: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(browserWorkbenchService.navigate).not.toHaveBeenCalled();
+    expect((tools as Any).browserService.navigate).toHaveBeenCalled();
   });
 
   it("uses headless Playwright when forced", async () => {

--- a/src/electron/agent/tools/__tests__/computer-use-platform.test.ts
+++ b/src/electron/agent/tools/__tests__/computer-use-platform.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ComputerUseTools } from "../computer-use-tools";
 import { setComputerUseProviderFactoryForTesting } from "../../../computer-use/provider";
+import { ComputerUseSessionManager } from "../../../computer-use/session-manager";
 
 const originalPlatform = process.platform;
 
@@ -14,7 +15,59 @@ function setPlatform(platform: NodeJS.Platform): void {
 afterEach(() => {
   setPlatform(originalPlatform);
   setComputerUseProviderFactoryForTesting(null);
+  ComputerUseSessionManager.resetForTesting();
+  ComputerUseTools.resetForTesting();
+  vi.restoreAllMocks();
 });
+
+function makeProvider(overrides: Record<string, Any> = {}): Any {
+  return {
+    ensureReadyWithInteractivePermissions: vi.fn().mockResolvedValue(undefined),
+    getFrontmost: vi.fn().mockResolvedValue({ appName: "Notes", pid: 42, windowId: 100 }),
+    listApps: vi.fn().mockResolvedValue([{ appName: "Notes", pid: 42, isFrontmost: true }]),
+    listWindows: vi.fn().mockResolvedValue([
+      {
+        windowId: 100,
+        title: "Note",
+        framePoints: { x: 0, y: 0, w: 300, h: 200 },
+        scaleFactor: 1,
+        isMinimized: false,
+        isOnscreen: true,
+        isMain: true,
+        isFocused: true,
+      },
+    ]),
+    unminimizeWindow: vi.fn().mockResolvedValue(undefined),
+    activateApp: vi.fn().mockResolvedValue(undefined),
+    raiseWindow: vi.fn().mockResolvedValue(undefined),
+    screenshot: vi.fn().mockResolvedValue({
+      pngBase64: Buffer.from("png").toString("base64"),
+      width: 300,
+      height: 200,
+      scaleFactor: 1,
+    }),
+    axPressAtPoint: vi.fn().mockResolvedValue({ pressed: true }),
+    axFocusAtPoint: vi.fn().mockResolvedValue({ focused: false }),
+    mouseClick: vi.fn().mockResolvedValue(undefined),
+    mouseMove: vi.fn().mockResolvedValue(undefined),
+    mouseDrag: vi.fn().mockResolvedValue(undefined),
+    scrollAtPoint: vi.fn().mockResolvedValue(undefined),
+    focusedElement: vi.fn().mockResolvedValue({ exists: false }),
+    axFocusTextInput: vi.fn().mockResolvedValue({ focused: false }),
+    setValue: vi.fn().mockResolvedValue(undefined),
+    typeText: vi.fn().mockResolvedValue(undefined),
+    pressKeys: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeTools(daemon: Any = { logEvent: vi.fn() }, taskId = `task-${Math.random()}`): ComputerUseTools {
+  return new ComputerUseTools(
+    { id: "w", name: "W", path: "/tmp", createdAt: 0, permissions: {} } as Any,
+    daemon as Any,
+    taskId,
+  );
+}
 
 describe("ComputerUseTools platform exposure", () => {
   it("exposes computer-use tools on macOS", () => {
@@ -45,8 +98,7 @@ describe("ComputerUseTools platform exposure", () => {
 
   it("resolves the helper through the provider interface", async () => {
     setPlatform("win32");
-    const provider = {
-      ensureReadyWithInteractivePermissions: vi.fn().mockResolvedValue(undefined),
+    const provider = makeProvider({
       getFrontmost: vi.fn().mockResolvedValue({ appName: "Notepad", pid: 42, windowId: 100 }),
       listWindows: vi.fn().mockResolvedValue([
         {
@@ -60,23 +112,127 @@ describe("ComputerUseTools platform exposure", () => {
           isFocused: true,
         },
       ]),
-      unminimizeWindow: vi.fn().mockResolvedValue(undefined),
-      activateApp: vi.fn().mockResolvedValue(undefined),
-      raiseWindow: vi.fn().mockResolvedValue(undefined),
-      screenshot: vi.fn().mockResolvedValue({
-        pngBase64: Buffer.from("png").toString("base64"),
-        width: 300,
-        height: 200,
-        scaleFactor: 1,
-      }),
-    };
+    });
     setComputerUseProviderFactoryForTesting(() => provider as Any);
     const daemon = { logEvent: vi.fn() };
-    const tools = new ComputerUseTools({ id: "w", name: "W", path: "/tmp", createdAt: 0, permissions: {} } as Any, daemon as Any, "task-1");
+    const tools = makeTools(daemon, "task-1");
 
     await tools.screenshot();
 
     expect(provider.ensureReadyWithInteractivePermissions).toHaveBeenCalled();
     expect(provider.screenshot).toHaveBeenCalledWith(100);
+  });
+
+  it("does not foreground the target for default background-first screenshots", async () => {
+    setPlatform("darwin");
+    const provider = makeProvider();
+    setComputerUseProviderFactoryForTesting(() => provider);
+    const tools = makeTools();
+
+    await tools.screenshot();
+
+    expect(provider.activateApp).not.toHaveBeenCalled();
+    expect(provider.raiseWindow).not.toHaveBeenCalled();
+    expect(provider.screenshot).toHaveBeenCalledWith(100);
+  });
+
+  it("uses AX press for background-first left clicks without posting mouse events", async () => {
+    setPlatform("darwin");
+    const provider = makeProvider({
+      axPressAtPoint: vi.fn().mockResolvedValue({ pressed: true }),
+    });
+    setComputerUseProviderFactoryForTesting(() => provider);
+    const tools = makeTools();
+    const capture = await tools.screenshot();
+
+    await tools.click(10, 10, "left", capture.captureId);
+
+    expect(provider.axPressAtPoint).toHaveBeenCalled();
+    expect(provider.mouseClick).not.toHaveBeenCalled();
+    expect(provider.activateApp).not.toHaveBeenCalled();
+  });
+
+  it("requires visible-control approval before falling back to a real mouse click", async () => {
+    setPlatform("darwin");
+    const provider = makeProvider({
+      axPressAtPoint: vi.fn().mockResolvedValue({ pressed: false }),
+      axFocusAtPoint: vi.fn().mockResolvedValue({ focused: false }),
+    });
+    setComputerUseProviderFactoryForTesting(() => provider);
+    const daemon = {
+      logEvent: vi.fn(),
+      requestApproval: vi.fn().mockResolvedValue(false),
+    };
+    const tools = makeTools(daemon);
+    const capture = await tools.screenshot();
+
+    await expect(tools.click(10, 10, "left", capture.captureId)).rejects.toThrow(
+      /needs visible control/i,
+    );
+
+    expect(daemon.requestApproval).toHaveBeenCalledWith(
+      expect.any(String),
+      "computer_use",
+      expect.stringContaining("Allow visible Computer Use"),
+      expect.objectContaining({ kind: "computer_use_foreground_control", tool: "click" }),
+      { allowAutoApprove: false },
+    );
+    expect(provider.mouseClick).not.toHaveBeenCalled();
+    expect(provider.activateApp).not.toHaveBeenCalled();
+  });
+
+  it("does not expose model-controlled foreground bypass fields in native tool schemas", () => {
+    setPlatform("darwin");
+    const tools = ComputerUseTools.getToolDefinitions({ headless: false });
+
+    for (const tool of tools) {
+      const properties = (tool.input_schema as Any).properties || {};
+      expect(properties.control_mode).toBeUndefined();
+      expect(properties.allow_visible_control).toBeUndefined();
+    }
+  });
+
+  it("persists visible-control approval for the current task and window", async () => {
+    setPlatform("darwin");
+    const provider = makeProvider({
+      axPressAtPoint: vi.fn().mockResolvedValue({ pressed: false }),
+      axFocusAtPoint: vi.fn().mockResolvedValue({ focused: false }),
+    });
+    setComputerUseProviderFactoryForTesting(() => provider);
+    const daemon = {
+      logEvent: vi.fn(),
+      requestApproval: vi.fn().mockResolvedValue(true),
+    };
+    const tools = makeTools(daemon, "task-visible-grant");
+    const capture = await tools.screenshot();
+
+    await tools.click(10, 10, "left", capture.captureId);
+    await tools.click(20, 10, "left");
+
+    expect(daemon.requestApproval).toHaveBeenCalledTimes(1);
+    expect(provider.mouseClick).toHaveBeenCalledTimes(2);
+    expect(provider.activateApp).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports AX focus as partial progress instead of treating it as a completed click", async () => {
+    setPlatform("darwin");
+    const provider = makeProvider({
+      axPressAtPoint: vi.fn().mockResolvedValue({ pressed: false }),
+      axFocusAtPoint: vi.fn().mockResolvedValue({ focused: true }),
+    });
+    setComputerUseProviderFactoryForTesting(() => provider);
+    const daemon = {
+      logEvent: vi.fn(),
+      requestApproval: vi.fn(),
+    };
+    const tools = makeTools(daemon);
+    const capture = await tools.screenshot();
+
+    const result = await tools.click(10, 10, "left", capture.captureId);
+
+    expect(result.note).toContain("focused the target");
+    expect(provider.mouseClick).not.toHaveBeenCalled();
+    expect(provider.activateApp).not.toHaveBeenCalled();
+    expect(daemon.requestApproval).not.toHaveBeenCalled();
   });
 });

--- a/src/electron/agent/tools/browser-tools.ts
+++ b/src/electron/agent/tools/browser-tools.ts
@@ -19,6 +19,7 @@ import {
 } from "../../browser/browser-workbench-service";
 import { normalizeBrowserUrl } from "../../browser/browser-session-manager";
 import { evaluateNetworkPolicy } from "../../security/network-policy";
+import { BuiltinToolsSettingsManager } from "./builtin-settings";
 
 // oxlint-disable-next-line typescript-eslint/no-explicit-any
 type Any = any;
@@ -57,6 +58,7 @@ export class BrowserTools {
   };
   private browserUseCloudClient: BrowserUseCloudClient | null = null;
   private browserUseCloudSession: BrowserUseCloudSessionState | null = null;
+  private visibleWorkbenchApprovals = new Set<string>();
 
   constructor(
     private workspace: Workspace,
@@ -176,6 +178,8 @@ export class BrowserTools {
   private shouldPreferVisibleWorkbench(input: unknown): boolean {
     const toolInput = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
     if (this.getRequestedBrowserProvider(input) === "browser-use-cloud") return false;
+    const automationMode =
+      BuiltinToolsSettingsManager.getComputerUseAutomationSettings().browserAutomationMode;
     const forceHeadless =
       toolInput.force_headless === true ||
       toolInput.mode === "headless" ||
@@ -184,10 +188,75 @@ export class BrowserTools {
     if (forceHeadless) return false;
     if (typeof toolInput.debugger_url === "string" && toolInput.debugger_url.trim()) return false;
     if (this.hasVisibleWorkbenchSession(input)) return true;
+    if (automationMode === "background") return false;
+    if (automationMode === "ask") return false;
+    if (typeof toolInput.profile === "string" && toolInput.profile.trim()) return false;
+    if (typeof toolInput.browser_channel === "string" && toolInput.browser_channel.trim()) return false;
+    if (this.browserState.profile || this.browserState.debuggerUrl) return false;
+    return automationMode === "visible";
+  }
+
+  private hasExplicitVisibleWorkbenchRequest(input: unknown): boolean {
+    const toolInput = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+    return toolInput.browser_surface === "visible" || toolInput.visible === true;
+  }
+
+  private canStartVisibleWorkbench(input: unknown): boolean {
+    const toolInput = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+    if (this.getRequestedBrowserProvider(input) === "browser-use-cloud") return false;
+    if (
+      toolInput.force_headless === true ||
+      toolInput.mode === "headless" ||
+      toolInput.visible === false ||
+      toolInput.browser_surface === "headless"
+    ) {
+      return false;
+    }
+    if (typeof toolInput.debugger_url === "string" && toolInput.debugger_url.trim()) return false;
     if (typeof toolInput.profile === "string" && toolInput.profile.trim()) return false;
     if (typeof toolInput.browser_channel === "string" && toolInput.browser_channel.trim()) return false;
     if (this.browserState.profile || this.browserState.debuggerUrl) return false;
     return true;
+  }
+
+  private visibleWorkbenchApprovalKey(input: unknown): string {
+    return this.getSessionId(input) || "default";
+  }
+
+  private async requestVisibleWorkbenchApproval(input: unknown, url: string): Promise<boolean> {
+    const key = this.visibleWorkbenchApprovalKey(input);
+    if (this.visibleWorkbenchApprovals.has(key)) return true;
+    const requester = (this.daemon as Any)?.requestApproval;
+    if (typeof requester !== "function") return false;
+    const approved = await requester.call(
+      this.daemon,
+      this.taskId,
+      "browser",
+      "Open a visible browser workbench for this task?",
+      {
+        kind: "browser_visible_workbench",
+        tool: "browser_navigate",
+        url,
+        sessionId: key,
+      },
+      { allowAutoApprove: false },
+    );
+    if (approved) {
+      this.visibleWorkbenchApprovals.add(key);
+    }
+    return approved;
+  }
+
+  private async shouldUseVisibleWorkbenchForNavigation(input: unknown): Promise<boolean> {
+    if (this.shouldPreferVisibleWorkbench(input)) return true;
+    const automationMode =
+      BuiltinToolsSettingsManager.getComputerUseAutomationSettings().browserAutomationMode;
+    if (automationMode !== "ask") return false;
+    if (!this.hasExplicitVisibleWorkbenchRequest(input)) return false;
+    if (!this.canStartVisibleWorkbench(input)) return false;
+    const rawUrl = input && typeof input === "object" ? (input as Record<string, unknown>).url : undefined;
+    const url = typeof rawUrl === "string" ? rawUrl : "";
+    return await this.requestVisibleWorkbenchApproval(input, url);
   }
 
   private getRequestedBrowserProvider(input: unknown): BrowserProvider {
@@ -507,10 +576,10 @@ export class BrowserTools {
       {
         name: "browser_navigate",
         description:
-          "Navigate the browser to a URL. For interactive testing, this opens and controls the visible in-app browser workbench for the active task by default. " +
+          "Navigate the browser to a URL. By default, CoWork uses background/headless browser control unless settings or the tool input request a visible workbench. " +
           "If a visible workbench session already exists, continue using it even when profile/browser_channel options are supplied. " +
-          "The legacy headless flag is compatibility-only and does not override the visible workbench for normal site testing. " +
-          "Optional: set force_headless=true only when the user explicitly asks for background/headless Playwright. " +
+          "Optional: set visible=true or browser_surface='visible' when the user wants to watch or interact with the shared browser. " +
+          "Optional: set force_headless=true or browser_surface='headless' when the user explicitly asks for background/headless Playwright. " +
           "Optional: set profile to use a Playwright browser profile or external signed-in Chrome fallback (not the embedded workbench). " +
           'Optional: set browser_channel to "chrome" (system Google Chrome) or "brave" (system Brave); default is bundled Chromium. ' +
           "NOTE: For RESEARCH tasks (finding news, trends, discussions), use web_search instead - it aggregates results from multiple sources. " +
@@ -1245,7 +1314,7 @@ export class BrowserTools {
       }
 
       case "browser_navigate": {
-        if (this.shouldPreferVisibleWorkbench(input)) {
+        if (await this.shouldUseVisibleWorkbenchForNavigation(input)) {
           const visibleUrl = this.ensureVisibleNavigationAllowed(input?.url);
           const visibleResult = await this.browserWorkbenchService.navigate({
             taskId: this.taskId,

--- a/src/electron/agent/tools/builtin-settings.ts
+++ b/src/electron/agent/tools/builtin-settings.ts
@@ -9,6 +9,11 @@ import * as path from "path";
 import { SecureSettingsRepository } from "../../database/SecureSettingsRepository";
 import { getUserDataDir } from "../../utils/user-data-dir";
 import { createLogger } from "../../utils/logger";
+import {
+  normalizeBrowserAutomationMode,
+  normalizeNativeComputerUseMode,
+  type ComputerUseAutomationSettings,
+} from "../../../shared/computer-use-contract";
 
 const log = createLogger("BuiltinSettings");
 
@@ -60,6 +65,8 @@ export interface BuiltinToolsSettings {
   runCommandApprovalMode: RunCommandApprovalMode;
   // Default runtime for explicit Codex child-task flows
   codexRuntimeMode: CodexRuntimeMode;
+  // Computer/browser automation defaults.
+  computerUseAutomation: ComputerUseAutomationSettings;
   // Version for migrations
   version: string;
 }
@@ -132,6 +139,10 @@ const DEFAULT_SETTINGS: BuiltinToolsSettings = {
   toolAutoApprove: {},
   runCommandApprovalMode: "single_bundle",
   codexRuntimeMode: "native",
+  computerUseAutomation: {
+    browserAutomationMode: "background",
+    nativeComputerUseMode: "background_first",
+  },
   version: "1.0.0",
 };
 
@@ -402,7 +413,7 @@ export class BuiltinToolsSettingsManager {
       },
       toolOverrides: {
         ...defaults.toolOverrides,
-        ...(settings.toolOverrides || {}),
+        ...settings.toolOverrides,
       },
       toolTimeouts: settings.toolTimeouts || {},
       toolAutoApprove: settings.toolAutoApprove || {},
@@ -411,6 +422,14 @@ export class BuiltinToolsSettingsManager {
           ? "per_command"
           : defaults.runCommandApprovalMode,
       codexRuntimeMode: settings.codexRuntimeMode === "acpx" ? "acpx" : "native",
+      computerUseAutomation: {
+        browserAutomationMode: normalizeBrowserAutomationMode(
+          settings.computerUseAutomation?.browserAutomationMode,
+        ),
+        nativeComputerUseMode: normalizeNativeComputerUseMode(
+          settings.computerUseAutomation?.nativeComputerUseMode,
+        ),
+      },
       version: settings.version || defaults.version,
     };
   }
@@ -499,6 +518,18 @@ export class BuiltinToolsSettingsManager {
   static getCodexRuntimeMode(): CodexRuntimeMode {
     const settings = this.loadSettings();
     return settings.codexRuntimeMode === "acpx" ? "acpx" : "native";
+  }
+
+  static getComputerUseAutomationSettings(): ComputerUseAutomationSettings {
+    const settings = this.loadSettings();
+    return {
+      browserAutomationMode: normalizeBrowserAutomationMode(
+        settings.computerUseAutomation?.browserAutomationMode,
+      ),
+      nativeComputerUseMode: normalizeNativeComputerUseMode(
+        settings.computerUseAutomation?.nativeComputerUseMode,
+      ),
+    };
   }
 
   /**

--- a/src/electron/agent/tools/computer-use-tools.ts
+++ b/src/electron/agent/tools/computer-use-tools.ts
@@ -12,6 +12,13 @@ import {
   type ComputerUseHelperWindow,
   isRecoverableScreenshotError,
 } from "../../computer-use/helper-runtime";
+import { BuiltinToolsSettingsManager } from "./builtin-settings";
+import {
+  normalizeNativeComputerUseMode,
+  type NativeComputerUseMode,
+} from "../../../shared/computer-use-contract";
+
+type Any = any; // oxlint-disable-line typescript-eslint/no-explicit-any
 
 const CUA_CAPTURE_REFRESH_WAIT_MS = 150;
 const CUA_SCREENSHOT_RETRY_WAIT_MS = 250;
@@ -98,6 +105,7 @@ interface ScreenshotSelection {
 interface ActionPreparationResult {
   target: ComputerUseTargetState;
   capture: ComputerUseCaptureState;
+  visibleControl: boolean;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -377,6 +385,7 @@ function parseWindowsKeypressSpec(pid: number, keys: string[]): ComputerUseHelpe
  */
 export class ComputerUseTools {
   private static persistedState = new Map<string, PersistedComputerUseState>();
+  private static visibleControlGrants = new Map<string, Set<string>>();
 
   private currentTarget: ComputerUseTargetState | null = null;
   private currentCapture: ComputerUseCaptureState | null = null;
@@ -389,6 +398,11 @@ export class ComputerUseTools {
     const saved = ComputerUseTools.persistedState.get(taskId);
     this.currentTarget = saved?.currentTarget ?? null;
     this.currentCapture = saved?.currentCapture ?? null;
+  }
+
+  static resetForTesting(): void {
+    ComputerUseTools.persistedState.clear();
+    ComputerUseTools.visibleControlGrants.clear();
   }
 
   setWorkspace(workspace: Workspace): void {
@@ -424,6 +438,77 @@ export class ComputerUseTools {
     await this.helper().activateApp(target.pid);
     await this.helper().raiseWindow(target.pid, target.windowId);
     await sleep(CUA_CAPTURE_REFRESH_WAIT_MS);
+  }
+
+  private resolveNativeControlMode(): NativeComputerUseMode {
+    return normalizeNativeComputerUseMode(
+      BuiltinToolsSettingsManager.getComputerUseAutomationSettings().nativeComputerUseMode,
+    );
+  }
+
+  private visibleControlGrantKey(target: ComputerUseTargetState): string {
+    return `${target.pid}:${target.windowId}`;
+  }
+
+  private hasVisibleControlGrant(target: ComputerUseTargetState): boolean {
+    return ComputerUseTools.visibleControlGrants
+      .get(this.taskId)
+      ?.has(this.visibleControlGrantKey(target)) === true;
+  }
+
+  private rememberVisibleControlGrant(target: ComputerUseTargetState): void {
+    let grants = ComputerUseTools.visibleControlGrants.get(this.taskId);
+    if (!grants) {
+      grants = new Set();
+      ComputerUseTools.visibleControlGrants.set(this.taskId, grants);
+    }
+    grants.add(this.visibleControlGrantKey(target));
+  }
+
+  private isVisibleControlAllowed(target: ComputerUseTargetState): boolean {
+    return this.resolveNativeControlMode() === "visible" || this.hasVisibleControlGrant(target);
+  }
+
+  private async requestVisibleControlApproval(
+    toolName: string,
+    target: ComputerUseTargetState,
+    reason: string,
+  ): Promise<boolean> {
+    const requester = (this.daemon as Any)?.requestApproval;
+    if (typeof requester !== "function") return false;
+    return await requester.call(
+      this.daemon,
+      this.taskId,
+      "computer_use",
+      `Allow visible Computer Use to control ${target.appName}?`,
+      {
+        kind: "computer_use_foreground_control",
+        tool: toolName,
+        reason,
+        targetApp: target.appName,
+        bundleId: target.bundleId,
+        windowId: target.windowId,
+        windowTitle: target.windowTitle,
+      },
+      { allowAutoApprove: false },
+    );
+  }
+
+  private async ensureVisibleControlAllowed(
+    toolName: string,
+    target: ComputerUseTargetState,
+    reason: string,
+  ): Promise<void> {
+    if (this.isVisibleControlAllowed(target)) return;
+    const approved = await this.requestVisibleControlApproval(toolName, target, reason);
+    if (!approved) {
+      throw new Error(this.visibleControlRequiredMessage(toolName, target));
+    }
+    this.rememberVisibleControlGrant(target);
+  }
+
+  private visibleControlRequiredMessage(toolName: string, target: ComputerUseTargetState): string {
+    return `${toolName} needs visible control of ${target.appName}. Background Computer Use could not complete this action without real mouse/keyboard events.`;
   }
 
   private makeCaptureState(
@@ -487,6 +572,11 @@ export class ComputerUseTools {
           throw error;
         }
         this.currentTarget = await this.refreshCurrentTarget();
+        await this.ensureVisibleControlAllowed(
+          toolName,
+          this.currentTarget,
+          "background_window_capture_failed",
+        );
         await this.bringTargetToFront(this.currentTarget);
         await sleep(CUA_SCREENSHOT_RETRY_WAIT_MS);
       }
@@ -784,7 +874,10 @@ export class ComputerUseTools {
     return this.currentCapture;
   }
 
-  private async prepareAction(toolName: string, captureId?: string): Promise<ActionPreparationResult> {
+  private async prepareAction(
+    toolName: string,
+    captureId?: string,
+  ): Promise<ActionPreparationResult> {
     await this.ensureReady();
     const target = await this.refreshCurrentTarget();
     const capture = this.requireCurrentCapture(captureId);
@@ -795,8 +888,11 @@ export class ComputerUseTools {
       windowId: target.windowId,
       captureId: capture.id,
     });
-    await this.bringTargetToFront(target);
-    return { target, capture };
+    const visibleControl = this.isVisibleControlAllowed(target);
+    if (visibleControl) {
+      await this.bringTargetToFront(target);
+    }
+    return { target, capture, visibleControl };
   }
 
   async screenshot(selection: ScreenshotSelection = {}): Promise<ComputerUseToolResult> {
@@ -816,7 +912,9 @@ export class ComputerUseTools {
           : await this.resolveFrontmostTarget();
 
     this.persistState();
-    await this.bringTargetToFront(this.currentTarget);
+    if (this.isVisibleControlAllowed(this.currentTarget)) {
+      await this.bringTargetToFront(this.currentTarget);
+    }
     return await this.captureTarget("screenshot");
   }
 
@@ -826,7 +924,7 @@ export class ComputerUseTools {
     button: ComputerUseMouseButton = "left",
     captureId?: string,
   ): Promise<ComputerUseToolResult> {
-    const { target, capture } = await this.prepareAction("click", captureId);
+    const { target, capture, visibleControl } = await this.prepareAction("click", captureId);
     validatePointInCapture(x, y, capture);
     try {
       if (button === "left") {
@@ -847,20 +945,32 @@ export class ComputerUseTools {
             captureWidth: capture.width,
             captureHeight: capture.height,
           });
-          if (!focusResult.focused) {
-            await this.helper().mouseClick({
-              windowId: target.windowId,
-              pid: target.pid,
-              x,
-              y,
-              captureWidth: capture.width,
-              captureHeight: capture.height,
-              button: button as ComputerUseHelperMouseButton,
-              clickCount: 1,
-            });
+          if (focusResult.focused) {
+            return await this.captureTarget(
+              "click",
+              "Background accessibility focused the target, but did not confirm a press. Use another action or approve visible control if a real mouse click is required.",
+            );
           }
+          await this.ensureVisibleControlAllowed("click", target, "background_ax_press_failed");
+          if (!visibleControl) {
+            await this.bringTargetToFront(target);
+          }
+          await this.helper().mouseClick({
+            windowId: target.windowId,
+            pid: target.pid,
+            x,
+            y,
+            captureWidth: capture.width,
+            captureHeight: capture.height,
+            button: button as ComputerUseHelperMouseButton,
+            clickCount: 1,
+          });
         }
       } else {
+        await this.ensureVisibleControlAllowed("click", target, "non_left_mouse_button");
+        if (!visibleControl) {
+          await this.bringTargetToFront(target);
+        }
         await this.helper().mouseClick({
           windowId: target.windowId,
           pid: target.pid,
@@ -882,10 +992,21 @@ export class ComputerUseTools {
     }
   }
 
-  async doubleClick(x: number, y: number, captureId?: string): Promise<ComputerUseToolResult> {
-    const { target, capture } = await this.prepareAction("double_click", captureId);
+  async doubleClick(
+    x: number,
+    y: number,
+    captureId?: string,
+  ): Promise<ComputerUseToolResult> {
+    const { target, capture, visibleControl } = await this.prepareAction(
+      "double_click",
+      captureId,
+    );
     validatePointInCapture(x, y, capture);
     try {
+      if (!visibleControl) {
+        await this.ensureVisibleControlAllowed("double_click", target, "double_click");
+        await this.bringTargetToFront(target);
+      }
       await this.helper().mouseClick({
         windowId: target.windowId,
         pid: target.pid,
@@ -906,10 +1027,21 @@ export class ComputerUseTools {
     }
   }
 
-  async moveMouse(x: number, y: number, captureId?: string): Promise<ComputerUseToolResult> {
-    const { target, capture } = await this.prepareAction("move_mouse", captureId);
+  async moveMouse(
+    x: number,
+    y: number,
+    captureId?: string,
+  ): Promise<ComputerUseToolResult> {
+    const { target, capture, visibleControl } = await this.prepareAction(
+      "move_mouse",
+      captureId,
+    );
     validatePointInCapture(x, y, capture);
     try {
+      if (!visibleControl) {
+        await this.ensureVisibleControlAllowed("move_mouse", target, "mouse_move");
+        await this.bringTargetToFront(target);
+      }
       await this.helper().mouseMove({
         windowId: target.windowId,
         pid: target.pid,
@@ -935,7 +1067,7 @@ export class ComputerUseTools {
     if (!Array.isArray(path) || path.length < 2) {
       throw new Error("drag requires a path with at least two points.");
     }
-    const { target, capture } = await this.prepareAction("drag", captureId);
+    const { target, capture, visibleControl } = await this.prepareAction("drag", captureId);
     const normalizedPath = path.map((point, index) => {
       const px = requireFiniteCoordinate(`path[${index}].x`, point.x);
       const py = requireFiniteCoordinate(`path[${index}].y`, point.y);
@@ -943,6 +1075,10 @@ export class ComputerUseTools {
       return { x: px, y: py };
     });
     try {
+      if (!visibleControl) {
+        await this.ensureVisibleControlAllowed("drag", target, "mouse_drag");
+        await this.bringTargetToFront(target);
+      }
       await this.helper().mouseDrag({
         windowId: target.windowId,
         pid: target.pid,
@@ -967,11 +1103,15 @@ export class ComputerUseTools {
     scrollY: number,
     captureId?: string,
   ): Promise<ComputerUseToolResult> {
-    const { target, capture } = await this.prepareAction("scroll", captureId);
+    const { target, capture, visibleControl } = await this.prepareAction("scroll", captureId);
     validatePointInCapture(x, y, capture);
     const normalizedScrollX = requireIntegerInRange("scrollX", scrollX, -10_000, 10_000);
     const normalizedScrollY = requireIntegerInRange("scrollY", scrollY, -10_000, 10_000);
     try {
+      if (!visibleControl) {
+        await this.ensureVisibleControlAllowed("scroll", target, "mouse_scroll");
+        await this.bringTargetToFront(target);
+      }
       await this.helper().scrollAtPoint({
         windowId: target.windowId,
         pid: target.pid,
@@ -1005,8 +1145,11 @@ export class ComputerUseTools {
       windowId: target.windowId,
       textLength: text.length,
     });
-    await this.bringTargetToFront(target);
     try {
+      let nextVisibleControl = this.isVisibleControlAllowed(target);
+      if (nextVisibleControl) {
+        await this.bringTargetToFront(target);
+      }
       const focused = await this.helper().focusedElement(target.pid);
       if (focused.exists && focused.canSetValue && !focused.isSecure && focused.elementRef) {
         await this.helper().setValue(focused.elementRef, text);
@@ -1028,6 +1171,15 @@ export class ComputerUseTools {
         ) {
           await this.helper().setValue(focusedTextInput.elementRef, text);
         } else {
+          if (!nextVisibleControl) {
+            await this.ensureVisibleControlAllowed(
+              "type_text",
+              target,
+              "background_text_value_set_failed",
+            );
+            nextVisibleControl = true;
+            await this.bringTargetToFront(target);
+          }
           await this.helper().typeText(text, target.pid, target.windowId);
         }
       }
@@ -1058,8 +1210,9 @@ export class ComputerUseTools {
       windowId: target.windowId,
       keys,
     });
-    await this.bringTargetToFront(target);
     try {
+      await this.ensureVisibleControlAllowed("keypress", target, "keyboard_event");
+      await this.bringTargetToFront(target);
       await this.helper().pressKeys({ ...parseKeypressSpec(target.pid, keys), windowId: target.windowId });
       return await this.captureTarget("keypress");
     } catch (error) {
@@ -1088,13 +1241,12 @@ export class ComputerUseTools {
     if (options?.headless || (process.platform !== "darwin" && process.platform !== "win32")) {
       return [];
     }
-
     return [
       {
         name: "screenshot",
         description:
           "Capture the current controlled window in a native desktop app. Call this first. " +
-          "Passing app and/or windowTitle retargets control to that window. Returns a fresh captureId and PNG image.",
+          "Passing app and/or windowTitle retargets control to that window. Defaults to background window capture; visible control is a fallback only when approved.",
         input_schema: {
           type: "object",
           properties: {

--- a/src/electron/agent/tools/registry.ts
+++ b/src/electron/agent/tools/registry.ts
@@ -2108,7 +2108,8 @@ export class ToolRegistry {
     );
     register(
       "drag",
-      async ({ request }) => this.computerUseTools.drag(request.input.path, request.input.captureId),
+      async ({ request }) =>
+        this.computerUseTools.drag(request.input.path, request.input.captureId),
       serialSchedulerSpec,
     );
     register(
@@ -2125,12 +2126,14 @@ export class ToolRegistry {
     );
     register(
       "type_text",
-      async ({ request }) => this.computerUseTools.typeText(request.input.text),
+      async ({ request }) =>
+        this.computerUseTools.typeText(request.input.text),
       serialSchedulerSpec,
     );
     register(
       "keypress",
-      async ({ request }) => this.computerUseTools.pressKeys(request.input.keys),
+      async ({ request }) =>
+        this.computerUseTools.pressKeys(request.input.keys),
       serialSchedulerSpec,
     );
     register(
@@ -3697,7 +3700,8 @@ ${skillDescriptions}`;
       return await this.computerUseTools.doubleClick(input.x, input.y, input.captureId);
     if (name === "move_mouse")
       return await this.computerUseTools.moveMouse(input.x, input.y, input.captureId);
-    if (name === "drag") return await this.computerUseTools.drag(input.path, input.captureId);
+    if (name === "drag")
+      return await this.computerUseTools.drag(input.path, input.captureId);
     if (name === "scroll")
       return await this.computerUseTools.scroll(
         input.x,
@@ -3706,8 +3710,10 @@ ${skillDescriptions}`;
         input.scrollY,
         input.captureId,
       );
-    if (name === "type_text") return await this.computerUseTools.typeText(input.text);
-    if (name === "keypress") return await this.computerUseTools.pressKeys(input.keys);
+    if (name === "type_text")
+      return await this.computerUseTools.typeText(input.text);
+    if (name === "keypress")
+      return await this.computerUseTools.pressKeys(input.keys);
     if (name === "wait") return await this.computerUseTools.wait(input.ms);
 
     // Batch image processing

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -787,6 +787,10 @@ interface BuiltinToolsSettings {
   toolAutoApprove: Record<string, boolean>;
   runCommandApprovalMode: "per_command" | "single_bundle";
   codexRuntimeMode: "native" | "acpx";
+  computerUseAutomation: {
+    browserAutomationMode: "background" | "visible" | "ask";
+    nativeComputerUseMode: "background_first" | "ask_visible" | "visible";
+  };
   version: string;
 }
 

--- a/src/renderer/components/BuiltinToolsSettings.tsx
+++ b/src/renderer/components/BuiltinToolsSettings.tsx
@@ -39,6 +39,10 @@ interface BuiltinToolsSettingsData {
   toolAutoApprove: Record<string, boolean>;
   runCommandApprovalMode: "per_command" | "single_bundle";
   codexRuntimeMode: "native" | "acpx";
+  computerUseAutomation: {
+    browserAutomationMode: "background" | "visible" | "ask";
+    nativeComputerUseMode: "background_first" | "ask_visible" | "visible";
+  };
   version: string;
 }
 
@@ -159,7 +163,16 @@ export function BuiltinToolsSettings() {
           };
         }
       }
-      setSettings({ ...loadedSettings, categories: mergedCategories });
+      setSettings({
+        ...loadedSettings,
+        categories: mergedCategories,
+        computerUseAutomation: {
+          browserAutomationMode:
+            loadedSettings.computerUseAutomation?.browserAutomationMode || "background",
+          nativeComputerUseMode:
+            loadedSettings.computerUseAutomation?.nativeComputerUseMode || "background_first",
+        },
+      });
       setCategories(loadedCategories);
     } catch (error) {
       console.error("Failed to load built-in tools settings:", error);
@@ -319,6 +332,54 @@ export function BuiltinToolsSettings() {
     }
   };
 
+  const handleBrowserAutomationMode = async (mode: "background" | "visible" | "ask") => {
+    if (!settings) return;
+
+    const newSettings = {
+      ...settings,
+      computerUseAutomation: {
+        ...settings.computerUseAutomation,
+        browserAutomationMode: mode,
+      },
+    };
+
+    setSettings(newSettings);
+
+    try {
+      setSaving(true);
+      await window.electronAPI.saveBuiltinToolsSettings(newSettings);
+    } catch (error) {
+      console.error("Failed to save settings:", error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleNativeComputerUseMode = async (
+    mode: "background_first" | "ask_visible" | "visible",
+  ) => {
+    if (!settings) return;
+
+    const newSettings = {
+      ...settings,
+      computerUseAutomation: {
+        ...settings.computerUseAutomation,
+        nativeComputerUseMode: mode,
+      },
+    };
+
+    setSettings(newSettings);
+
+    try {
+      setSaving(true);
+      await window.electronAPI.saveBuiltinToolsSettings(newSettings);
+    } catch (error) {
+      console.error("Failed to save settings:", error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const handleToolToggle = async (tool: string, enabled: boolean) => {
     if (!settings) return;
 
@@ -327,7 +388,7 @@ export function BuiltinToolsSettings() {
       toolOverrides: {
         ...settings.toolOverrides,
         [tool]: {
-          ...(settings.toolOverrides?.[tool] || {}),
+          ...settings.toolOverrides?.[tool],
           enabled,
         },
       },
@@ -375,6 +436,10 @@ export function BuiltinToolsSettings() {
             category === "shell" ? settings.runCommandApprovalMode : "per_command";
           const runCommandTimeout =
             category === "shell" ? (settings.toolTimeouts?.run_command ?? "") : "";
+          const browserAutomationMode =
+            settings.computerUseAutomation?.browserAutomationMode || "background";
+          const nativeComputerUseMode =
+            settings.computerUseAutomation?.nativeComputerUseMode || "background_first";
 
           return (
             <div
@@ -516,6 +581,57 @@ export function BuiltinToolsSettings() {
                       disabled={!config.enabled}
                       placeholder="30000"
                     />
+                  </div>
+                </div>
+              )}
+
+              {category === "computer_use" && expandedCategory === category && (
+                <div className="builtin-tool-advanced">
+                  <div className="builtin-tool-advanced-row">
+                    <div className="builtin-tool-advanced-text">
+                      <div className="builtin-tool-advanced-label">Browser automation</div>
+                      <div className="builtin-tool-advanced-hint">
+                        Background uses headless browser control unless a task already has a visible
+                        browser session.
+                      </div>
+                    </div>
+                    <select
+                      className="builtin-tool-mode-select"
+                      value={browserAutomationMode}
+                      onChange={(e) =>
+                        handleBrowserAutomationMode(
+                          e.target.value as "background" | "visible" | "ask",
+                        )
+                      }
+                      disabled={!config.enabled}
+                    >
+                      <option value="background">Background (Recommended)</option>
+                      <option value="visible">Visible workbench</option>
+                      <option value="ask">Ask</option>
+                    </select>
+                  </div>
+
+                  <div className="builtin-tool-advanced-row">
+                    <div className="builtin-tool-advanced-text">
+                      <div className="builtin-tool-advanced-label">Native desktop control</div>
+                      <div className="builtin-tool-advanced-hint">
+                        Background first tries Accessibility actions before visible Mac control.
+                      </div>
+                    </div>
+                    <select
+                      className="builtin-tool-mode-select"
+                      value={nativeComputerUseMode}
+                      onChange={(e) =>
+                        handleNativeComputerUseMode(
+                          e.target.value as "background_first" | "ask_visible" | "visible",
+                        )
+                      }
+                      disabled={!config.enabled}
+                    >
+                      <option value="background_first">Background first (Recommended)</option>
+                      <option value="ask_visible">Ask before visible control</option>
+                      <option value="visible">Visible control</option>
+                    </select>
                   </div>
                 </div>
               )}

--- a/src/renderer/components/__tests__/permission-settings-panel.test.ts
+++ b/src/renderer/components/__tests__/permission-settings-panel.test.ts
@@ -66,6 +66,10 @@ describe("PermissionSettingsPanel helpers", () => {
         toolAutoApprove: {},
         runCommandApprovalMode: "per_command",
         codexRuntimeMode: "native",
+        computerUseAutomation: {
+          browserAutomationMode: "background",
+          nativeComputerUseMode: "background_first",
+        },
         version: "1.0.0",
       },
     );
@@ -109,6 +113,10 @@ describe("PermissionSettingsPanel helpers", () => {
         toolAutoApprove: {},
         runCommandApprovalMode: "single_bundle",
         codexRuntimeMode: "native",
+        computerUseAutomation: {
+          browserAutomationMode: "background",
+          nativeComputerUseMode: "background_first",
+        },
         version: "1.0.0",
       },
     );

--- a/src/shared/computer-use-contract.ts
+++ b/src/shared/computer-use-contract.ts
@@ -17,3 +17,19 @@ const COMPUTER_USE_TOOL_NAME_SET = new Set<string>(COMPUTER_USE_TOOL_NAMES);
 export function isComputerUseToolName(toolName: string): toolName is ComputerUseToolName {
   return COMPUTER_USE_TOOL_NAME_SET.has(String(toolName || "").trim());
 }
+
+export type BrowserAutomationMode = "background" | "visible" | "ask";
+export type NativeComputerUseMode = "background_first" | "ask_visible" | "visible";
+
+export interface ComputerUseAutomationSettings {
+  browserAutomationMode: BrowserAutomationMode;
+  nativeComputerUseMode: NativeComputerUseMode;
+}
+
+export function normalizeBrowserAutomationMode(value: unknown): BrowserAutomationMode {
+  return value === "visible" || value === "ask" ? value : "background";
+}
+
+export function normalizeNativeComputerUseMode(value: unknown): NativeComputerUseMode {
+  return value === "visible" || value === "ask_visible" ? value : "background_first";
+}


### PR DESCRIPTION
## Summary
- Default browser navigation to background/headless control unless visible workbench use is requested or approved
- Add configurable computer-use/browser automation modes with approval flows for visible control fallback
- Expand tests to cover visible-workbench selection, approval persistence, and background-first native control behavior

## Testing
- Updated unit tests for tool policy, browser routing, and computer-use fallback behavior
- Not run (not requested)