### PR TITLE
feat(skills): add Atlas Cloud transcription provider

### DIFF
--- a/registry/catalog.json
+++ b/registry/catalog.json
@@ -1422,8 +1422,8 @@
     {
       "id": "openai-whisper-api",
       "name": "Openai-whisper-api",
-      "description": "Transcribe audio via OpenAI Audio Transcriptions API (Whisper).",
-      "version": "1.0.0",
+      "description": "Transcribe audio via OpenAI Whisper or Atlas Cloud speech-to-text APIs.",
+      "version": "1.1.0",
       "author": "CoWork OS",
       "tags": [
         "Tools"

--- a/registry/skills/openai-whisper-api.json
+++ b/registry/skills/openai-whisper-api.json
@@ -1,15 +1,15 @@
 {
   "id": "openai-whisper-api",
   "name": "Openai-whisper-api",
-  "description": "Transcribe audio via OpenAI Audio Transcriptions API (Whisper).",
+  "description": "Transcribe audio via OpenAI Whisper or Atlas Cloud speech-to-text APIs.",
   "icon": "☁️",
   "category": "Tools",
-  "prompt": "# OpenAI Whisper API (curl)\n\nTranscribe an audio file via OpenAI’s `/v1/audio/transcriptions` endpoint.\n\n## Quick start\n\n```bash\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a\n```\n\nDefaults:\n\n- Model: `whisper-1`\n- Output: `<input>.txt`\n\n## Useful flags\n\n```bash\n{baseDir}/scripts/transcribe.sh /path/to/audio.ogg --model whisper-1 --out /tmp/transcript.txt\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --language en\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --prompt \"Speaker names: Peter, Daniel\"\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --json --out /tmp/transcript.json\n```\n\n## API key\n\nSet `OPENAI_API_KEY`, or configure it in `~/.CoWork-OSS/CoWork-OSS.json`:\n\n```json5\n{\n  skills: {\n    \"openai-whisper-api\": {\n      apiKey: \"OPENAI_KEY_HERE\",\n    },\n  },\n}\n```",
+  "prompt": "# Audio Transcription APIs (curl)\n\nTranscribe a local audio file through OpenAI Whisper (default) or Atlas Cloud speech-to-text.\n\n## Quick start\n\n```bash\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --provider atlas\n```\n\nDefaults:\n\n- Provider: `openai`\n- OpenAI model: `whisper-1`\n- Atlas Cloud model: `xai/stt-v1`\n- Output: `<input>.txt`\n\n## Useful flags\n\n```bash\n{baseDir}/scripts/transcribe.sh /path/to/audio.ogg --model whisper-1 --out /tmp/transcript.txt\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --provider atlas --language en\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --provider atlas --prompt \"Peter\"\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --json --out /tmp/transcript.json\n```\n\nFor Atlas Cloud, `--prompt` is sent as one transcription key term and must be at most 50 characters. Atlas submissions are sent once, then polled with bounded GET requests until completion.\n\n## API keys\n\nSet `OPENAI_API_KEY` or `ATLASCLOUD_API_KEY`. You can also configure provider-specific keys in `~/.CoWork-OSS/CoWork-OSS.json`:\n\n```json5\n{\n  skills: {\n    \"openai-whisper-api\": {\n      apiKey: \"OPENAI_KEY_HERE\",\n      atlasApiKey: \"ATLAS_KEY_HERE\",\n    },\n  },\n}\n```",
   "parameters": [],
   "enabled": true,
   "metadata": {
     "routing": {
-      "useWhen": "Use when the user asks to transcribe audio via OpenAI Audio Transcriptions API Whisper.",
+      "useWhen": "Use when the user asks to transcribe audio through OpenAI Whisper or Atlas Cloud speech-to-text.",
       "dontUseWhen": "Do not use when the request is asking for planning documents, high-level strategy, or non-executable discussion; use the relevant planning or design workflow instead.",
       "outputs": "Outcome from Openai-whisper-api: task-specific result plus concrete action notes.",
       "successCriteria": "Returns concrete actions and decisions matching the requested task, with no fabricated tool-side behavior.",
@@ -17,7 +17,7 @@
         "positive": [
           "Use the openai-whisper-api skill for this request.",
           "Help me with openai-whisper-api.",
-          "Use when the user asks to transcribe audio via OpenAI Audio Transcriptions API Whisper.",
+          "Use when the user asks to transcribe audio through OpenAI Whisper or Atlas Cloud speech-to-text.",
           "Openai-whisper-api: provide an actionable result."
         ],
         "negative": [

--- a/registry/skills/openai-whisper-api.json
+++ b/registry/skills/openai-whisper-api.json
@@ -30,6 +30,7 @@
     },
     "authoring": {
       "complexity": "low"
-    }
+    },
+    "version": "1.1.0"
   }
 }

--- a/resources/skills/openai-whisper-api.json
+++ b/resources/skills/openai-whisper-api.json
@@ -1,15 +1,15 @@
 {
   "id": "openai-whisper-api",
   "name": "Openai-whisper-api",
-  "description": "Transcribe audio via OpenAI Audio Transcriptions API (Whisper).",
+  "description": "Transcribe audio via OpenAI Whisper or Atlas Cloud speech-to-text APIs.",
   "icon": "☁️",
   "category": "Tools",
-  "prompt": "# OpenAI Whisper API (curl)\n\nTranscribe an audio file via OpenAI’s `/v1/audio/transcriptions` endpoint.\n\n## Quick start\n\n```bash\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a\n```\n\nDefaults:\n\n- Model: `whisper-1`\n- Output: `<input>.txt`\n\n## Useful flags\n\n```bash\n{baseDir}/scripts/transcribe.sh /path/to/audio.ogg --model whisper-1 --out /tmp/transcript.txt\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --language en\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --prompt \"Speaker names: Peter, Daniel\"\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --json --out /tmp/transcript.json\n```\n\n## API key\n\nSet `OPENAI_API_KEY`, or configure it in `~/.CoWork-OSS/CoWork-OSS.json`:\n\n```json5\n{\n  skills: {\n    \"openai-whisper-api\": {\n      apiKey: \"OPENAI_KEY_HERE\",\n    },\n  },\n}\n```",
+  "prompt": "# Audio Transcription APIs (curl)\n\nTranscribe a local audio file through OpenAI Whisper (default) or Atlas Cloud speech-to-text.\n\n## Quick start\n\n```bash\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --provider atlas\n```\n\nDefaults:\n\n- Provider: `openai`\n- OpenAI model: `whisper-1`\n- Atlas Cloud model: `xai/stt-v1`\n- Output: `<input>.txt`\n\n## Useful flags\n\n```bash\n{baseDir}/scripts/transcribe.sh /path/to/audio.ogg --model whisper-1 --out /tmp/transcript.txt\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --provider atlas --language en\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --provider atlas --prompt \"Peter\"\n{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --json --out /tmp/transcript.json\n```\n\nFor Atlas Cloud, `--prompt` is sent as one transcription key term and must be at most 50 characters. Atlas submissions are sent once, then polled with bounded GET requests until completion.\n\n## API keys\n\nSet `OPENAI_API_KEY` or `ATLASCLOUD_API_KEY`. You can also configure provider-specific keys in `~/.CoWork-OSS/CoWork-OSS.json`:\n\n```json5\n{\n  skills: {\n    \"openai-whisper-api\": {\n      apiKey: \"OPENAI_KEY_HERE\",\n      atlasApiKey: \"ATLAS_KEY_HERE\",\n    },\n  },\n}\n```",
   "parameters": [],
   "enabled": true,
   "metadata": {
     "routing": {
-      "useWhen": "Use when the user asks to transcribe audio via OpenAI Audio Transcriptions API Whisper.",
+      "useWhen": "Use when the user asks to transcribe audio through OpenAI Whisper or Atlas Cloud speech-to-text.",
       "dontUseWhen": "Do not use when the request is asking for planning documents, high-level strategy, or non-executable discussion; use the relevant planning or design workflow instead.",
       "outputs": "Outcome from Openai-whisper-api: task-specific result plus concrete action notes.",
       "successCriteria": "Returns concrete actions and decisions matching the requested task, with no fabricated tool-side behavior.",
@@ -17,7 +17,7 @@
         "positive": [
           "Use the openai-whisper-api skill for this request.",
           "Help me with openai-whisper-api.",
-          "Use when the user asks to transcribe audio via OpenAI Audio Transcriptions API Whisper.",
+          "Use when the user asks to transcribe audio through OpenAI Whisper or Atlas Cloud speech-to-text.",
           "Openai-whisper-api: provide an actionable result."
         ],
         "negative": [

--- a/resources/skills/openai-whisper-api.json
+++ b/resources/skills/openai-whisper-api.json
@@ -30,6 +30,7 @@
     },
     "authoring": {
       "complexity": "low"
-    }
+    },
+    "version": "1.1.0"
   }
 }

--- a/resources/skills/openai-whisper-api/SKILL.md
+++ b/resources/skills/openai-whisper-api/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openai-whisper-api
-description: "Transcribe audio via OpenAI Audio Transcriptions API (Whisper)."
-version: "1.0.0"
+description: "Transcribe audio via OpenAI Whisper or Atlas Cloud speech-to-text APIs."
+version: "1.1.0"
 metadata:
   author: CoWork OS Contributors <info@coworkosapp.com>
 ---
@@ -10,11 +10,11 @@ metadata:
 
 ## Purpose
 
-Transcribe audio via OpenAI Audio Transcriptions API (Whisper).
+Transcribe audio via OpenAI Whisper or Atlas Cloud speech-to-text APIs.
 
 ## Routing
 
-- Use when: Use when the user asks to transcribe audio via OpenAI Audio Transcriptions API Whisper.
+- Use when: Use when the user asks to transcribe audio through OpenAI Whisper or Atlas Cloud speech-to-text.
 - Do not use when: Do not use when the request is asking for planning documents, high-level strategy, or non-executable discussion; use the relevant planning or design workflow instead.
 - Outputs: Outcome from Openai-whisper-api: task-specific result plus concrete action notes.
 - Success criteria: Returns concrete actions and decisions matching the requested task, with no fabricated tool-side behavior.
@@ -25,7 +25,7 @@ Transcribe audio via OpenAI Audio Transcriptions API (Whisper).
 
 - Use the openai-whisper-api skill for this request.
 - Help me with openai-whisper-api.
-- Use when the user asks to transcribe audio via OpenAI Audio Transcriptions API Whisper.
+- Use when the user asks to transcribe audio through OpenAI Whisper or Atlas Cloud speech-to-text.
 - Openai-whisper-api: provide an actionable result.
 
 ### Negative
@@ -37,5 +37,5 @@ Transcribe audio via OpenAI Audio Transcriptions API (Whisper).
 
 ## Runtime Prompt
 
-- Current runtime prompt length: 796 characters.
+- Current runtime prompt length: 1245 characters.
 - Runtime prompt is defined directly in `../openai-whisper-api.json`. 

--- a/resources/skills/openai-whisper-api/scripts/transcribe.sh
+++ b/resources/skills/openai-whisper-api/scripts/transcribe.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: transcribe.sh <audio-file> [--model whisper-1] [--out FILE] [--language LANG] [--prompt TEXT] [--json]
+Usage: transcribe.sh <audio-file> [--provider openai|atlas] [--model MODEL] [--out FILE] [--language LANG] [--prompt TEXT] [--json]
 USAGE
 }
 
@@ -13,7 +13,8 @@ if [[ $# -lt 1 ]]; then
 fi
 
 INPUT=""
-MODEL="whisper-1"
+PROVIDER="openai"
+MODEL=""
 OUT=""
 LANG=""
 PROMPT=""
@@ -21,6 +22,10 @@ AS_JSON=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --provider)
+      PROVIDER="${2:-}"
+      shift 2
+      ;;
     --model)
       MODEL="${2:-}"
       shift 2
@@ -74,6 +79,23 @@ if [[ ! -f "$INPUT" ]]; then
   exit 1
 fi
 
+case "$PROVIDER" in
+  openai)
+    MODEL="${MODEL:-whisper-1}"
+    ;;
+  atlas)
+    MODEL="${MODEL:-xai/stt-v1}"
+    if [[ "$MODEL" != "xai/stt-v1" ]]; then
+      echo "Unsupported Atlas Cloud model: $MODEL (expected xai/stt-v1)." >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Unsupported provider: $PROVIDER (expected openai or atlas)." >&2
+    exit 1
+    ;;
+esac
+
 if [[ -z "$OUT" ]]; then
   if [[ "$AS_JSON" -eq 1 ]]; then
     OUT="${INPUT%.*}.json"
@@ -82,49 +104,168 @@ if [[ -z "$OUT" ]]; then
   fi
 fi
 
-API_KEY="${OPENAI_API_KEY:-}"
-if [[ -z "$API_KEY" && -f "$HOME/.CoWork-OSS/CoWork-OSS.json" ]] && command -v node >/dev/null 2>&1; then
-  API_KEY="$(node -e 'const fs=require("fs");try{const j=JSON.parse(fs.readFileSync(process.env.HOME+"/.CoWork-OSS/CoWork-OSS.json","utf8"));const k=(j.skills&&j.skills["openai-whisper-api"]&&j.skills["openai-whisper-api"].apiKey)||(j.skills&&j.skills.entries&&j.skills.entries["openai-whisper-api"]&&j.skills.entries["openai-whisper-api"].apiKey)||"";process.stdout.write(k)}catch{process.stdout.write("")}' )"
-fi
-
-if [[ -z "$API_KEY" ]]; then
-  echo "OPENAI_API_KEY is required (or set skills.openai-whisper-api.apiKey in ~/.CoWork-OSS/CoWork-OSS.json)." >&2
-  exit 1
-fi
-
 if ! command -v curl >/dev/null 2>&1; then
   echo "curl is required." >&2
   exit 1
 fi
 
+read_config_key() {
+  local key="$1"
+  if [[ ! -f "$HOME/.CoWork-OSS/CoWork-OSS.json" ]] || ! command -v node >/dev/null 2>&1; then
+    return
+  fi
+  CONFIG_KEY="$key" node -e 'const fs=require("fs");try{const j=JSON.parse(fs.readFileSync(process.env.HOME+"/.CoWork-OSS/CoWork-OSS.json","utf8"));const s=j.skills&&j.skills["openai-whisper-api"];const e=j.skills&&j.skills.entries&&j.skills.entries["openai-whisper-api"];const k=(s&&s[process.env.CONFIG_KEY])||(e&&e[process.env.CONFIG_KEY])||"";process.stdout.write(k)}catch{process.stdout.write("")}'
+}
+
 tmp_resp="$(mktemp)"
-trap 'rm -f "$tmp_resp"' EXIT
+tmp_req="$(mktemp)"
+trap 'rm -f "$tmp_resp" "$tmp_req"' EXIT
 
-curl_args=(
-  -sS
-  -X POST "https://api.openai.com/v1/audio/transcriptions"
-  -H "Authorization: Bearer ${API_KEY}"
-  -F "file=@${INPUT}"
-  -F "model=${MODEL}"
-)
+if [[ "$PROVIDER" == "openai" ]]; then
+  API_KEY="${OPENAI_API_KEY:-}"
+  if [[ -z "$API_KEY" ]]; then
+    API_KEY="$(read_config_key apiKey)"
+  fi
 
-if [[ -n "$LANG" ]]; then
-  curl_args+=( -F "language=${LANG}" )
-fi
-if [[ -n "$PROMPT" ]]; then
-  curl_args+=( -F "prompt=${PROMPT}" )
-fi
-if [[ "$AS_JSON" -eq 1 ]]; then
-  curl_args+=( -F "response_format=json" )
+  if [[ -z "$API_KEY" ]]; then
+    echo "OPENAI_API_KEY is required (or set skills.openai-whisper-api.apiKey in ~/.CoWork-OSS/CoWork-OSS.json)." >&2
+    exit 1
+  fi
+
+  curl_args=(
+    -sS
+    -X POST "https://api.openai.com/v1/audio/transcriptions"
+    -H "Authorization: Bearer ${API_KEY}"
+    -F "file=@${INPUT}"
+    -F "model=${MODEL}"
+  )
+
+  if [[ -n "$LANG" ]]; then
+    curl_args+=( -F "language=${LANG}" )
+  fi
+  if [[ -n "$PROMPT" ]]; then
+    curl_args+=( -F "prompt=${PROMPT}" )
+  fi
+  if [[ "$AS_JSON" -eq 1 ]]; then
+    curl_args+=( -F "response_format=json" )
+  else
+    curl_args+=( -F "response_format=text" )
+  fi
+
+  http_code="$(curl "${curl_args[@]}" -o "$tmp_resp" -w '%{http_code}')"
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    echo "OpenAI API request failed (HTTP $http_code):" >&2
+    cat "$tmp_resp" >&2
+    exit 1
+  fi
 else
-  curl_args+=( -F "response_format=text" )
-fi
+  if ! command -v node >/dev/null 2>&1; then
+    echo "node is required for Atlas Cloud transcription." >&2
+    exit 1
+  fi
 
-http_code="$(curl "${curl_args[@]}" -o "$tmp_resp" -w '%{http_code}')"
-if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
-  echo "OpenAI API request failed (HTTP $http_code):" >&2
-  cat "$tmp_resp" >&2
-  exit 1
+  API_KEY="${ATLASCLOUD_API_KEY:-}"
+  if [[ -z "$API_KEY" ]]; then
+    API_KEY="$(read_config_key atlasApiKey)"
+  fi
+  if [[ -z "$API_KEY" ]]; then
+    echo "ATLASCLOUD_API_KEY is required (or set skills.openai-whisper-api.atlasApiKey in ~/.CoWork-OSS/CoWork-OSS.json)." >&2
+    exit 1
+  fi
+
+  node - "$INPUT" "$MODEL" "$LANG" "$PROMPT" "$tmp_req" <<'NODE'
+const fs = require("fs");
+const [input, model, language, prompt, output] = process.argv.slice(2);
+if (prompt.length > 50) {
+  console.error("Atlas Cloud key term from --prompt must be 50 characters or fewer.");
+  process.exit(1);
+}
+const payload = {
+  model,
+  audio: fs.readFileSync(input).toString("base64"),
+  audio_format: "auto",
+};
+if (language) payload.language = language;
+if (prompt) payload.keyterm = [prompt];
+fs.writeFileSync(output, JSON.stringify(payload));
+NODE
+
+  atlas_base="${ATLASCLOUD_API_BASE_URL:-https://api.atlascloud.ai/api/v1}"
+  http_code="$(curl -sS -X POST "${atlas_base}/model/generateAudio" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    --data-binary "@${tmp_req}" \
+    -o "$tmp_resp" -w '%{http_code}')"
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    echo "Atlas Cloud API request failed (HTTP $http_code):" >&2
+    cat "$tmp_resp" >&2
+    exit 1
+  fi
+
+  read_atlas_field() {
+    local field="$1"
+    ATLAS_FIELD="$field" node - "$tmp_resp" <<'NODE'
+const fs = require("fs");
+const body = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const data = body.data || body;
+const value = data[process.env.ATLAS_FIELD];
+process.stdout.write(value == null ? "" : String(value));
+NODE
+  }
+
+  request_id="$(read_atlas_field id)"
+  status="$(read_atlas_field status)"
+  if [[ -z "$request_id" ]]; then
+    echo "Atlas Cloud response did not include a prediction ID:" >&2
+    cat "$tmp_resp" >&2
+    exit 1
+  fi
+
+  delay=1
+  for ((attempt=1; attempt<=60; attempt++)); do
+    if [[ "$status" == "completed" ]]; then
+      break
+    fi
+    if [[ "$status" == "failed" || "$status" == "timeout" ]]; then
+      echo "Atlas Cloud prediction ${status}:" >&2
+      cat "$tmp_resp" >&2
+      exit 1
+    fi
+    sleep "$delay"
+    http_code="$(curl -sS "${atlas_base}/model/prediction/${request_id}" \
+      -H "Authorization: Bearer ${API_KEY}" \
+      -o "$tmp_resp" -w '%{http_code}')"
+    if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
+      status="$(read_atlas_field status)"
+      delay=1
+    elif [[ "$http_code" -eq 429 || "$http_code" -ge 500 ]]; then
+      delay=$((delay < 8 ? delay * 2 : 8))
+    else
+      echo "Atlas Cloud prediction request failed (HTTP $http_code):" >&2
+      cat "$tmp_resp" >&2
+      exit 1
+    fi
+  done
+
+  if [[ "$status" != "completed" ]]; then
+    echo "Atlas Cloud prediction did not complete after 60 checks." >&2
+    exit 1
+  fi
+
+  if [[ "$AS_JSON" -eq 0 ]]; then
+    node - "$tmp_resp" "$tmp_req" <<'NODE'
+const fs = require("fs");
+const body = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const data = body.data || body;
+const text = data.stt_result?.text || data.outputs?.[0];
+if (typeof text !== "string" || !text) {
+  console.error("Atlas Cloud response did not include transcript text.");
+  process.exit(1);
+}
+fs.writeFileSync(process.argv[3], `${text}\n`);
+NODE
+    cp "$tmp_req" "$tmp_resp"
+  fi
 fi
 
 cp "$tmp_resp" "$OUT"

--- a/resources/skills/openai-whisper-api/scripts/transcribe.sh
+++ b/resources/skills/openai-whisper-api/scripts/transcribe.sh
@@ -223,7 +223,7 @@ NODE
 
   delay=1
   for ((attempt=1; attempt<=60; attempt++)); do
-    if [[ "$status" == "completed" ]]; then
+    if [[ "$status" == "completed" || "$status" == "succeeded" ]]; then
       break
     fi
     if [[ "$status" == "failed" || "$status" == "timeout" ]]; then
@@ -247,7 +247,7 @@ NODE
     fi
   done
 
-  if [[ "$status" != "completed" ]]; then
+  if [[ "$status" != "completed" && "$status" != "succeeded" ]]; then
     echo "Atlas Cloud prediction did not complete after 60 checks." >&2
     exit 1
   fi

--- a/tests/skills/openai-whisper-api.test.ts
+++ b/tests/skills/openai-whisper-api.test.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("openai-whisper-api skill", () => {
+  it("accepts Atlas succeeded predictions as completed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "cowork-whisper-api-"));
+    const binDir = join(tempDir, "bin");
+    const inputPath = join(tempDir, "input.wav");
+    const outputPath = join(tempDir, "output.txt");
+    const statePath = join(tempDir, "poll-state");
+    const curlPath = join(binDir, "curl");
+    const sleepPath = join(binDir, "sleep");
+
+    try {
+      writeFileSync(inputPath, "fake audio");
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(
+        curlPath,
+        `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -X|-H|--data-binary) shift 2 ;;
+    -sS) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+if [[ "$url" == *generateAudio* ]]; then
+  printf '%s' '{"data":{"id":"pred-1","status":"processing"}}' > "$output"
+else
+  if [[ -e "$FAKE_STATE" ]]; then
+    printf '%s' '{"data":{"id":"pred-1","status":"failed"}}' > "$output"
+  else
+    touch "$FAKE_STATE"
+    printf '%s' '{"data":{"id":"pred-1","status":"succeeded","stt_result":{"text":"hello"}}}' > "$output"
+  fi
+fi
+printf '200'
+`,
+        "utf8",
+      );
+      writeFileSync(sleepPath, "#!/usr/bin/env bash\nexit 0\n", "utf8");
+      chmodSync(curlPath, 0o755);
+      chmodSync(sleepPath, 0o755);
+
+      execFileSync(
+        "bash",
+        [
+          resolve("resources/skills/openai-whisper-api/scripts/transcribe.sh"),
+          inputPath,
+          "--provider",
+          "atlas",
+          "--out",
+          outputPath,
+        ],
+        {
+          env: {
+            ...process.env,
+            ATLASCLOUD_API_KEY: "test-key",
+            ATLASCLOUD_API_BASE_URL: "http://atlas.test/api/v1",
+            FAKE_STATE: statePath,
+            PATH: `${binDir}:${process.env.PATH || ""}`,
+          },
+          encoding: "utf8",
+        },
+      );
+
+      expect(readFileSync(outputPath, "utf8")).toBe("hello\n");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Description

Add Atlas Cloud as an optional speech-to-text provider for the bundled `openai-whisper-api` skill while preserving OpenAI as the default.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Security improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Reliability Regression Policy

- [ ] This PR fixes a production failure/incident.
- [ ] If checked above, I added or updated at least one eval case file under `scripts/qa/eval-cases/`.
- Eval case file path(s): N/A

## Category

- [ ] Security / Guardrails
- [ ] Messaging Channels (WhatsApp, Telegram, Discord, Slack, Teams, Google Chat, iMessage, Signal, Matrix, etc.)
- [ ] LLM Providers
- [x] Agent Capabilities / Tools
- [ ] Cloud Storage (Google Workspace, OneDrive, Dropbox, Box, SharePoint, Notion)
- [ ] UI / UX
- [ ] MCP Integration
- [ ] Remote Access (Tailscale, SSH, WebSocket API)
- [ ] Database / IPC
- [ ] Other

## Changes Made

- Add `--provider openai|atlas`, keeping `openai` and `whisper-1` as the defaults.
- Submit local audio to Atlas Cloud `xai/stt-v1` once, then use bounded GET polling and support text or JSON output.
- Document `ATLASCLOUD_API_KEY`, provider-specific configuration, model constraints, and key-term behavior in both synchronized skill manifests.

## Security Considerations

- [ ] This change has NO security implications
- [x] This change has been reviewed for security implications (describe below)

API keys remain sourced from environment variables or the existing local skill configuration. Temporary request and response files are removed on exit, and no credentials are written to output files.

## Screenshots

N/A

## Testing

- [x] Tested locally on macOS
- [ ] Tested with at least one LLM provider (Anthropic/Bedrock/Gemini/OpenRouter/OpenAI/Ollama)
- [ ] Tested messaging channel integration (if applicable)
- [ ] Tested MCP functionality (if applicable)
- [ ] Verified no console errors
- [ ] Security tests pass (if applicable)

Commands and results:

- `bash -n resources/skills/openai-whisper-api/scripts/transcribe.sh`
- Focused mock-curl regression: OpenAI default path, Atlas single POST plus GET polling, text/JSON output, invalid model, and overlong key term all passed.
- `npm run skills:check`: 0 routing/content/audit errors, 0 warnings, 100% positive and negative routing cases.
- One live Atlas Cloud submission was attempted without retry and reached the API, but returned HTTP 402 `insufficient balance`; no prediction was created and no live GET polling occurred.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I updated `docs/architecture.md` if this PR changes capabilities, defaults, or architecture
- [x] My changes generate no new warnings
- [x] I have considered security implications of my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This changes only the bundled transcription skill. It does not change application-wide provider architecture or the existing OpenAI default behavior.
