### PR TITLE
fix: use Browser Use Cloud V4 by default

### DIFF
--- a/src/electron/agent/browser/__tests__/browser-use-cloud-client.test.ts
+++ b/src/electron/agent/browser/__tests__/browser-use-cloud-client.test.ts
@@ -52,21 +52,35 @@ describe("BrowserUseCloudClient", () => {
     );
   });
 
-  it("stops browser sessions through the v3 patch action", async () => {
+  it("uses the Browser Use V4 API by default", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "browser-session-1" }), { status: 201 }),
+    );
+    const client = new BrowserUseCloudClient("test-key", { fetchImpl: fetchImpl as Any });
+
+    await client.createBrowserSession({ proxyCountryCode: "us" });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.browser-use.com/api/v4/browsers",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("stops browser sessions through the V4 patch action", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ id: "browser-session-1", status: "stopped" }), {
         status: 200,
       }),
     );
     const client = new BrowserUseCloudClient("test-key", {
-      baseUrl: "https://api.test/api/v3",
+      baseUrl: "https://api.test/api/v4",
       fetchImpl: fetchImpl as Any,
     });
 
     await client.stopBrowserSession("browser-session-1");
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      "https://api.test/api/v3/browsers/browser-session-1",
+      "https://api.test/api/v4/browsers/browser-session-1",
       expect.objectContaining({
         method: "PATCH",
         body: JSON.stringify({ action: "stop" }),

--- a/src/electron/agent/browser/browser-use-cloud-client.ts
+++ b/src/electron/agent/browser/browser-use-cloud-client.ts
@@ -85,7 +85,7 @@ export class BrowserUseCloudClient {
 
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const fetchImpl = this.options.fetchImpl || fetch;
-    const baseUrl = (this.options.baseUrl || "https://api.browser-use.com/api/v3").replace(/\/$/, "");
+    const baseUrl = (this.options.baseUrl || "https://api.browser-use.com/api/v4").replace(/\/$/, "");
     const response = await fetchImpl(`${baseUrl}${path}`, {
       ...init,
       headers: {


### PR DESCRIPTION
## What

Switch the built-in Browser Use Cloud client's default base URL from `/api/v3` to `/api/v4`.

## Why

V4 is the current Browser Use API. CoWork OS already sends a create/stop contract supported by V4, so this keeps the integration on the current route without changing its behavior.

## Validation

- 8 BrowserUseCloudClient tests
- 26 BrowserTools tests
- TypeScript type-check
- Targeted oxlint: 0 errors
- V4 OpenAPI contract checked for create and stop

No credentials or live Browser Use sessions were used.
